### PR TITLE
Add IRQ block and IRQ simulation for gimlet sequencer

### DIFF
--- a/hdl/boards/gimlet/sequencer/BUILD
+++ b/hdl/boards/gimlet/sequencer/BUILD
@@ -1,9 +1,15 @@
 # -*- python -*- vim:syntax=python:
 
+bluespec_library('IrqBlock',
+    sources = [
+        'IrqBlock.bsv',
+    ])
+
 bluespec_library('RegCommon',
     sources = [
         'RegCommon.bsv',
     ])
+
 
 bluespec_library('GimletSeqFpgaRegs',
     sources = [
@@ -17,6 +23,7 @@ bluespec_library('GimletRegs',
         'GimletRegs.bsv',
     ],
     deps = [
+        ':IrqBlock',
         ':RegCommon',
         ':GimletSeqFpgaRegs',
         ':NicBlock',

--- a/hdl/boards/gimlet/sequencer/GimletSeqFpgaRegs.bsv
+++ b/hdl/boards/gimlet/sequencer/GimletSeqFpgaRegs.bsv
@@ -50,6 +50,29 @@ typedef struct {
     Bit#(1)            fantimeout;  // bit 0
 } Ifr deriving (Bits, Eq, FShow);
 
+instance Bitwise#(Ifr);
+    function Ifr \& (Ifr i1, Ifr i2) =
+        unpack(pack(i1) & pack(i2));
+    function Ifr \| (Ifr i1, Ifr i2) =
+        unpack(pack(i1) | pack(i2));
+    function Ifr \^ (Ifr i1, Ifr i2) =
+        unpack(pack(i1) ^ pack(i2));
+    function Ifr \~^ (Ifr i1, Ifr i2) =
+        unpack(pack(i1) ~^ pack(i2));
+    function Ifr \^~ (Ifr i1, Ifr i2) =
+        unpack(pack(i1) ^~ pack(i2));
+    function Ifr invert (Ifr i) =
+        unpack(invert(pack(i)));
+    function Ifr \<< (Ifr i, t x) =
+        error("Left shift operation is not supported with type Ifr");
+    function Ifr \>> (Ifr i, t x) =
+        error("Right shift operation is not supported with type Ifr");
+    function Bit#(1) msb (Ifr i) =
+        error("msb operation is not supported with type Ifr");
+    function Bit#(1) lsb (Ifr i) =
+        error("lsb operation is not supported with type Ifr");
+endinstance
+
 Integer ifrOffset = 5;
 
 // Register IER definitions

--- a/hdl/boards/gimlet/sequencer/IrqBlock.bsv
+++ b/hdl/boards/gimlet/sequencer/IrqBlock.bsv
@@ -1,0 +1,64 @@
+package IrqBlock;
+// Bring in enable vector
+// Bring is cause_raw vector
+// Bring in debug vector
+// Bring in clear vector
+// Out cause_sticky
+// Out irq bit.
+// Functionality:
+// Cause_raw monitored for rising edges.
+// Cause_raw_redges bitwise or'd with debug strobe is stored in cause_sticky
+// cause clear clears bits, but if a rising edge is happening the same cycle we let it through so interrupts aren't missed.
+// cause_sticky bitwise and with enable and or-reduced to become irq out (registered)
+
+interface IRQBlock#(type irq_type);
+    (* always_enabled *)
+    method Action enables(irq_type value);
+    (* always_enabled *)
+    method Action cause_raw(irq_type value);
+    (* always_enabled *)
+    method Action clear(irq_type value);
+    (* always_enabled *)
+    method Action debug(irq_type value);
+    method irq_type cause_reg;
+    method Bit#(1) irq_pin;
+endinterface
+
+module mkIRQBlock (IRQBlock#(type_t))
+    provisos(
+        Bits#(type_t, s), 
+        Bitwise#(type_t)
+    );
+    Reg#(type_t) cause_raw_last <- mkReg(unpack(0));
+    Reg#(type_t) cause <- mkReg(unpack(0));
+    Reg#(Bit#(1))irq <- mkReg(0);
+    // Combo stuff
+    Wire#(type_t) cur_cause_raw <- mkDWire(unpack(0));
+    Wire#(type_t) cur_enables <- mkDWire(unpack(0));
+    Wire#(type_t) cur_dbg <- mkDWire(unpack(0));
+    Wire#(type_t) cur_clear <- mkDWire(unpack(0));
+
+    rule do_irq_management;
+        let rising_raw_causes = cur_cause_raw & (~cause_raw_last);  // Get rising edges on causes
+        let final_rising = rising_raw_causes | cur_dbg;  // Allow software to cause a rising edge regardless of input pin state
+        // Don't allow a clear this cycle to clear any interrupts that would be triggered
+        // this cycle (so we don't accidentally drop an interrupt) by masking off any bits that will be triggered
+        // this cycle from the clear mask
+        let clear_mask = cur_clear & (~final_rising);
+        // keep any sticky bits, set any new bis and clear any cleared bits.
+        let new_cause =  (cause | final_rising) & (~clear_mask);
+        cause <= new_cause;
+        cause_raw_last <= cause;
+        irq <= reduceOr(pack(new_cause & cur_enables));
+    endrule
+    
+    method enables = cur_enables._write;
+    method cause_raw = cur_cause_raw._write;
+    method clear = cur_clear._write;
+    method debug = cur_dbg._write;
+    method irq_pin = irq._read;
+    method cause_reg = cause._read;
+
+
+endmodule
+endpackage


### PR DESCRIPTION
IRQ block was written generically to take a type that can be packed/unpacked and will do the "correct" thing.

A couple of notes:
- Current design has no actual interrupt sources `irq_cause_raw` in GimletRegs.bsv is a place-holder.
- We can use the spi bit-set commands to force interrupts (or sticky cause bits) until something comes back around and bitclears them. The cause register doesn't do anything with a standard write... we could change that if we wanted...
- I need to add the Bitwise stuff to the register generator rather than manually like I did here long-term but I wanted to get this banged out this week and I have planned work for the rdl stuff coming which will integrate this also.

If you want to see this in sim, `./cobble build -v latest/hdl/boards/gimlet/sequencer/gimlet_test && latest/hdl/boards/gimlet/sequencer/gimlet_test -V test.vcd` for fun and profit, (irq stuff is at the end)!