### PR TITLE
Adds Common.bsv package to share code between designs

### DIFF
--- a/hdl/BUILD
+++ b/hdl/BUILD
@@ -1,8 +1,13 @@
 # -*- python -*- vim:syntax=python:
 
-bluespec_library('Common',
+bluespec_library('CommonInterfaces',
     sources = [
-        'Common.bsv',
+        'CommonInterfaces.bsv',
+    ])
+
+bluespec_library('CommonFunctions',
+    sources = [
+        'CommonFunctions.bsv',
     ])
 
 bluespec_library('FanModule',

--- a/hdl/CommonFunctions.bsv
+++ b/hdl/CommonFunctions.bsv
@@ -4,20 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package Common;
+package CommonFunctions;
 
-import Connectable::*;
-import TriState::*;
-
-// Interface to bundle signals that will connect to a TriState at the Top level
-// of the FPGA design. This could get put into some sort of Oxide common package
-interface Tristate;
-    method Bit#(1) out;
-    method Bit#(1) out_en;
-    method Action in(Bit#(1) val);
-endinterface
-
-// TODO: Copied from the Tofino2Sequencer.bsv, should move to a common spot
 // Helpers used to map values/internal registers onto the register interface.
 function ReadOnly#(t) valueToReadOnly(t val);
     return (
@@ -34,4 +22,4 @@ function ReadOnly#(v) castToReadOnly(t val)
         endinterface);
 endfunction
 
-endpackage: Common
+endpackage: CommonFunctions

--- a/hdl/CommonInterfaces.bsv
+++ b/hdl/CommonInterfaces.bsv
@@ -1,0 +1,17 @@
+// Copyright 2022 Oxide Computer Company
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package CommonInterfaces;
+
+// Interface to bundle signals that will connect to a TriState at the Top level
+// of the FPGA design.
+interface Tristate;
+    method Bit#(1) out;
+    method Bit#(1) out_en;
+    method Action in(Bit#(1) val);
+endinterface
+
+endpackage: CommonInterfaces


### PR DESCRIPTION
A pattern that has emerged is to put common code that is either 1) not generic enough for Cobalt, or 2) is early stage and not refined enough for Cobalt yet into the `quartz/hdl` folder so it can at least be shared between our various board designs. To date we've put various modules here, but this PR creates a `Common.bsv` package that is meant to be a dumping ground for non-module type of things, such as interfaces, functions, or types that are generally useful.