### PR TITLE
Adds MDIO module

### DIFF
--- a/BUILD.conf
+++ b/BUILD.conf
@@ -62,6 +62,7 @@ environment('sidecar_mainboard_emulator_ecp5_evn', base='cobalt//ecp5_evn', cont
 })
 
 seed('//hdl')
+seed('//hdl/MDIO')
 seed('//hdl/ignition/target/test')
 seed('//hdl/boards/gimlet/ignition_target')
 seed('//hdl/boards/gimlet/sequencer')

--- a/hdl/MDIO/BUILD
+++ b/hdl/MDIO/BUILD
@@ -5,7 +5,7 @@ bluespec_library('MDIO',
         'MDIO.bsv'
     ],
     deps = [
-        '//hdl:Common',
+        '//hdl:CommonInterfaces',
         'cobalt//hdl:Strobe',
     ])
 
@@ -14,7 +14,7 @@ bluespec_library('MDIOPeripheralModel',
         'test/MDIOPeripheralModel.bsv',
     ],
     deps = [
-        '//hdl:Common',
+        '//hdl:CommonInterfaces',
         ':MDIO',
     ])
 
@@ -27,7 +27,7 @@ bluesim_tests('MDIOTests',
         'mkMDIOIgnoreWrongPhyAddrTest',
     ],
     deps = [
-        '//hdl:Common',
+        '//hdl:CommonInterfaces',
         ':MDIO',
         ':MDIOPeripheralModel',
     ])

--- a/hdl/MDIO/MDIO.bsv
+++ b/hdl/MDIO/MDIO.bsv
@@ -17,7 +17,7 @@ import Vector::*;
 
 import Strobe::*;
 
-import Common::*;
+import CommonInterfaces::*;
 
 // Parameters used to configure various things within the block
 // system_frequency_hz      - main clock domain for the design

--- a/hdl/MDIO/test/MDIOPeripheralModel.bsv
+++ b/hdl/MDIO/test/MDIOPeripheralModel.bsv
@@ -14,7 +14,7 @@ import FIFO::*;
 import GetPut::*;
 import Vector::*;
 
-import Common::*;
+import CommonInterfaces::*;
 import MDIO::*;
 
 // The model will emit these ModelEvents over the course of a transaction so a

--- a/hdl/MDIO/test/MDIOTests.bsv
+++ b/hdl/MDIO/test/MDIOTests.bsv
@@ -13,7 +13,7 @@ import GetPut::*;
 import FIFO::*;
 import StmtFSM::*;
 
-import Common::*;
+import CommonInterfaces::*;
 
 import MDIO::*;
 import MDIOPeripheralModel::*;


### PR DESCRIPTION
This is my MDIO implementation. It utilized on the QSFP FPGA to communicate with the VSC8562. With the simulation coverage here and the miles we've put on actual FPGA <-> VSC8562 communication, I think this is fairly solid.

This code is dependent on `Common.bsv`, which I am attempting to add via https://github.com/oxidecomputer/quartz/pull/17.