### PR TITLE
Reset PHY4 together with MGMT

### DIFF
--- a/hdl/boards/sidecar/mainboard/SidecarMainboardControllerTop.bsv
+++ b/hdl/boards/sidecar/mainboard/SidecarMainboardControllerTop.bsv
@@ -124,6 +124,8 @@ interface SidecarMainboardControllerTop;
     // Thermal Alert
     (* prefix = "" *) method Action mgmt_to_fpga_temp_therm_l(Bool mgmt_to_fpga_temp_therm_l);
 
+    method Bool fpga_to_phy4_reset_l();
+
     //
     // Fans
     //
@@ -375,6 +377,8 @@ module mkSidecarMainboardControllerTop (SidecarMainboardControllerTop);
     method ldo_to_fpga_v2p5_mgmt_pg = sync(vsc7448_v2p5_pg);
 
     method mgmt_to_fpga_temp_therm_l = sync_inverted(vsc7448_thermal_alert);
+
+    method Bool fpga_to_phy4_reset_l = !vsc7448_reset;
 
     // Fan pins
     method fpga_to_fan0_hsc_en = fan0_en;

--- a/hdl/boards/sidecar/mainboard/sidecar_mainboard_controller_rev_b.lpf
+++ b/hdl/boards/sidecar/mainboard/sidecar_mainboard_controller_rev_b.lpf
@@ -47,6 +47,8 @@ LOCATE COMP "ldo_to_fpga_v2p5_mgmt_pg" SITE "D14";
 IOBUF PORT "ldo_to_fpga_v2p5_mgmt_pg" PULLMODE=NONE IO_TYPE=LVCMOS18;
 LOCATE COMP "mgmt_to_fpga_temp_therm_l" SITE "E6";
 IOBUF PORT "mgmt_to_fpga_temp_therm_l" PULLMODE=NONE IO_TYPE=LVCMOS33;
+LOCATE COMP "fpga_to_phy4_reset_l" SITE "J4";
+IOBUF PORT "fpga_to_phy4_reset_l" PULLMODE=NONE IO_TYPE=LVCMOS25;
 
 // Fans
 LOCATE COMP "fpga_to_fan1_led_l" SITE "A8";


### PR DESCRIPTION
MGMT and PHY4 are conceptually in the same control domain. On Rev B reset control moved to the mainboard controller and rather than making these separate reset domains they are tied together. We may or may not want this long term, but we can evaluate at a later point.