### PR TITLE
Add Tofino debug port

### DIFF
--- a/hdl/boards/sidecar/mainboard/BUILD
+++ b/hdl/boards/sidecar/mainboard/BUILD
@@ -20,6 +20,16 @@ bluespec_library('SidecarMainboardControllerReg',
         'cobalt//hdl:RegCommon',
     ])
 
+bluespec_library('TofinoDebugPort',
+    sources = [
+        'TofinoDebugPort.bsv',
+    ],
+    deps = [
+        ':SidecarMainboardControllerReg',
+        '//hdl:CommonFunctions',
+        '//hdl/I2C:I2CCore',
+    ])
+
 bluespec_library('Tofino2Sequencer',
     sources = [
         'Tofino2Sequencer.bsv',
@@ -44,8 +54,9 @@ bluespec_library('SidecarMainboardController',
         'SidecarMainboardMiscSequencers.bsv',
     ],
     deps = [
-        ':Tofino2Sequencer',
         ':PCIeEndpointController',
+        ':Tofino2Sequencer',
+        ':TofinoDebugPort',
         '//hdl:FanModule',
         '//hdl:PowerRail',
         'cobalt//hdl:GitVersion',
@@ -62,7 +73,14 @@ bluespec_library('SidecarMainboardControllerTop',
         ':SidecarMainboardController',
         '//hdl:IOSync',
         'cobalt//hdl:SyncBits',
-    ])
+    ],
+    using = {
+        # The folling script is needed to fix the inout syntax used in the generated Verilog.
+        # For additonal context, see https://github.com/B-Lang-org/bsc/issues/327#issuecomment-786182555
+        'bsc_flags': [
+            '-verilog-filter', ROOT + '/vnd/cobalt/vnd/bluespec/basicinout.pl',
+        ]
+    })
 
 bluespec_verilog('mkSidecarMainboardControllerTop',
     top = 'SidecarMainboardControllerTop.bsv',

--- a/hdl/boards/sidecar/mainboard/TofinoDebugPort.bsv
+++ b/hdl/boards/sidecar/mainboard/TofinoDebugPort.bsv
@@ -1,0 +1,328 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package TofinoDebugPort;
+
+// Tofino 2 has an I2C debug port which can be used in conjunction with PCIe to
+// read/modify its internal state. This module provides some glue between an I2C
+// controller and SPI register map to allow this port to be used.
+
+export ReadVolatileReg(..);
+export TofinoDebugPortState(..);
+export Registers(..);
+export Pins(..);
+export TofinoDebugPort(..);
+export mkTofinoDebugPort;
+
+// Some additional exports for convenience/tests.
+export RequestOpcode(..);
+export state_send_buffer_empty;
+export state_send_buffer_full;
+export state_receive_buffer_empty;
+export state_receive_buffer_full;
+export state_request_in_progress;
+export state_error_valid;
+export state_idle;
+export state_ready_to_start_request;
+
+import BRAMFIFO::*;
+import ConfigReg::*;
+import Connectable::*;
+import FIFOF::*;
+import GetPut::*;
+import StmtFSM::*;
+
+import CommonFunctions::*;
+import I2CCore::*;
+import SidecarMainboardControllerReg::*;
+
+
+interface ReadVolatileReg #(type t);
+    method ActionValue#(t) _read();
+    method Action _write(t val);
+endinterface
+
+(* always_enabled *)
+interface Registers;
+    interface Reg#(TofinoDebugPortState) state;
+    interface ReadVolatileReg#(Bit#(8)) buffer;
+endinterface
+
+interface TofinoDebugPort;
+    interface Pins pins;
+    interface Registers registers;
+endinterface
+
+// An enum type representing the possible operations performed through the debug
+// port. These match what is found in
+// pkgsrc/bf-platforms/platforms/accton-bf/include/bf_pltfm_slave_i2c.h.
+typedef enum {
+    LocalWrite = 0,
+    LocalRead = 1,
+    ImmediateWrite = 2,
+    ImmediateRead = 3,
+    DirectWrite = 4,
+    DirectRead = 5,
+    IndirectWrite = 6,
+    IndirectRead = 7
+} RequestOpcode deriving (Eq, Bits, FShow);
+
+function Bool is_read_request(RequestOpcode opcode);
+    return case (opcode)
+        LocalRead,
+        ImmediateRead,
+        DirectRead,
+        IndirectRead: True;
+        default: False;
+    endcase;
+endfunction
+
+function Integer request_length(RequestOpcode opcode);
+    return case (opcode)
+        LocalWrite: 1;
+        LocalRead: 0;
+        // ImmediateRead/Write do not seem to be implemented in any of the
+        // Tofino platforms. These are not prohibited or filtered but will most
+        // likely cause incorrect behavior so the driver should not issue them.
+        ImmediateWrite: 0;
+        ImmediateRead: 0;
+        DirectWrite: 8;
+        DirectRead: 4;
+        IndirectWrite: 21;  // 40 bit address, 16 bytes of data.
+        IndirectRead: 5;    // 40 bit address
+    endcase;
+endfunction
+
+function Integer response_length(RequestOpcode opcode);
+    return case (opcode)
+        LocalRead: 1;
+        DirectRead: 4;
+        IndirectRead: 16;
+        default: 0;
+    endcase;
+endfunction
+
+typedef struct {
+    Bool write;
+    UInt#(3) bytes_remaining;
+} Request deriving (Bits, Eq, FShow);
+
+module mkTofinoDebugPort #(
+        Integer system_frequency_hz,
+        Integer i2c_frequency_hz,
+        Bit#(7) tofino_i2c_address)
+            (TofinoDebugPort);
+    I2CCore i2c <- mkI2CCore(system_frequency_hz, i2c_frequency_hz);
+    ConfigReg#(Maybe#(Error)) error <- mkConfigReg(tagged Invalid);
+
+    // Buffer and connections to the module interface.
+    FIFOF#(Bit#(8)) send_buffer <- mkSizedBRAMFIFOF(256);
+    FIFOF#(Bit#(8)) receive_buffer <- mkSizedBRAMFIFOF(256);
+
+    // Connect the FIFOs to the register interface. The use of a DWire between
+    // the receive FIFO and register interface will return a 0 if the FIFO is
+    // empty. Likewise a Wire between the register interface and the send FIFO
+    // will cause bytes to be dropped rather than block either serial interface
+    // if the FIFO is full.
+    //
+    // It is be the responsibility of a driver using this peripheral to keep
+    // track of these FIFOs and know how much data is expected to be received
+    // based on requests issued. Fortunately the Tofino register interface
+    // operates on 1, 4, or 16 bytes depending on the opcode, so this should be
+    // no problem.
+    Wire#(Bit#(8)) send_byte <- mkWire();
+    Wire#(Bit#(8)) byte_from_receive_buffer <- mkDWire('h00);
+    Wire#(Bit#(8)) byte_to_receive_buffer <- mkWire();
+
+    PulseWire deq_send_buffer <- mkPulseWire();
+    PulseWire deq_receive_buffer <- mkPulseWire();
+
+    mkConnection(send_byte, send_buffer.enq);
+    mkConnection(send_buffer.first, i2c.send_data.offer);
+    mkConnection(receive_buffer.first, byte_from_receive_buffer._write);
+    mkConnection(byte_to_receive_buffer, receive_buffer.enq);
+
+    (* fire_when_enabled *)
+    rule do_deq_send_buffer (deq_send_buffer || i2c.send_data.accepted);
+        send_buffer.deq();
+
+        if (i2c.send_data.accepted)
+            $display("%t ", $time, fshow(send_buffer.first));
+    endrule
+
+    (* fire_when_enabled *)
+    rule do_deq_receive_buffer (deq_receive_buffer);
+        receive_buffer.deq;
+    endrule
+
+    // Request state.
+    ConfigReg#(Bool) request_in_progress <- mkConfigReg(False);
+    Reg#(RequestOpcode) opcode <- mkRegU();
+    Reg#(UInt#(5)) bytes_remaining <- mkRegU();
+
+    PulseWire start_request <- mkPulseWire();
+    PulseWire clear_error <- mkPulseWire();
+
+    FSM request_seq <- mkFSMWithPred(seq
+        // Issue a Write, sending the opcode and any request data.
+        action
+            let opcode_byte = send_buffer.first;
+            let opcode_ = RequestOpcode'(unpack(opcode_byte[7:5]));
+            let request_length_ = fromInteger(request_length(opcode_));
+
+            opcode <= opcode_;
+            bytes_remaining <= request_length_;
+
+            i2c.send_command.put(
+                I2CCore::Command {
+                    op: Write,
+                    i2c_addr: tofino_i2c_address,
+                    reg_addr: send_buffer.first,
+                    num_bytes: request_length_});
+
+            deq_send_buffer.send();
+
+            $display(
+                "%t I2C Write, ", $time,
+                ((opcode_ == LocalRead || opcode_ == LocalWrite) ?
+                    $format(fshow(opcode_), " %2d", opcode_byte[4:0]) :
+                    $format(fshow(opcode_))),
+                ", length %3d", request_length_);
+        endaction
+
+        // Move request data from the send FIFO to I2C controller. It is
+        // tempting to directly use the `first`, `enq` and `deg` methods on
+        // FIFOs here, but doing so would cause this action to block if there is
+        // no request data to send (in the case of LocalRead) and the send FIFO
+        // is empty.
+        //
+        // So instead those methods are called from separate rules (which will
+        // appropriately block if the send FIFO is empty) to make sure this
+        // sequence can keep making progress.
+        while (bytes_remaining != 0) action
+            if (i2c.send_data.accepted)
+                bytes_remaining <= bytes_remaining - 1;
+        endaction
+
+        // In the case of a read request, turn the bus around and issue a Read
+        // to get the response.
+        if (is_read_request(opcode)) seq
+            action
+                let response_length_ = fromInteger(response_length(opcode));
+
+                bytes_remaining <= response_length_;
+                i2c.send_command.put(
+                    I2CCore::Command {
+                        op: Read,
+                        i2c_addr: tofino_i2c_address,
+                        reg_addr: ?,
+                        num_bytes: response_length_});
+
+                $display("%t I2C Read, length %3d", $time, response_length_);
+            endaction
+
+            // Read from the I2C controller and enqueue in the receive FIFO. In
+            // the case of a read request at least one byte is expected to be
+            // received so it is safe to call `receive_buffer.get` from within
+            // this action.
+            //
+            // `receive_buffer.enq` may block however if the FIFO is full, so
+            // write to a Wire instead allowing the byte to be dropped rather
+            // than stall this action and cause the I2C controller to get out of
+            // sync. It is the responsibility of the driver to make the receive
+            // buffer has sufficient space to complete the request buffer and
+            // not drop data (which it should know given that this can be
+            // determined using the request opcodes).
+            while (bytes_remaining != 0) action
+                let b <- i2c.received_data.get;
+
+                byte_to_receive_buffer <= b;
+                bytes_remaining <= bytes_remaining - 1;
+
+                $display("%t ", $time, fshow(b));
+            endaction
+        endseq
+    endseq, request_in_progress);
+
+    (* fire_when_enabled *)
+    rule do_update_state;
+        // Clear/latch errors from the I2C controller.
+        if (clear_error)
+            error <= tagged Invalid;
+        else if (!isValid(error))
+            error <= i2c.error;
+
+        // Manage the in progress request status.
+        if (isValid(i2c.error)) begin
+            request_seq.abort();
+            request_in_progress <= False;
+        end
+        // If there is data in the send buffer, start a new request if requested
+        // by the driver or continue with the next request. This implictly
+        // completes the last request once the send buffer is empty.
+        else if ((!request_in_progress && start_request) ||
+                    (request_in_progress && request_seq.done)) begin
+            request_in_progress <= send_buffer.notEmpty;
+        end
+    endrule
+
+    // A FSM `start` may block, so try this in its own rule. This will greedily
+    // try to start the next request whenever it is allowed to.
+    rule do_start_request (request_in_progress && !isValid(error));
+        request_seq.start();
+    endrule
+
+    interface Pins pins = i2c.pins;
+
+    interface Registers registers;
+        interface Reg state;
+            method _read =
+                TofinoDebugPortState {
+                    send_buffer_empty: ~pack(send_buffer.notEmpty),
+                    send_buffer_full: ~pack(send_buffer.notFull),
+                    receive_buffer_empty: ~pack(receive_buffer.notEmpty),
+                    receive_buffer_full: ~pack(receive_buffer.notFull),
+                    request_in_progress: pack(request_in_progress),
+                    error_valid: pack(isValid(error)),
+                    error_details: pack(fromMaybe(defaultValue, error))};
+
+            method Action _write(TofinoDebugPortState state_);
+                if (state_.send_buffer_empty == 1)
+                    send_buffer.clear();
+
+                if (state_.receive_buffer_empty == 1)
+                    receive_buffer.clear();
+
+                if (state_.request_in_progress == 1)
+                    start_request.send();
+
+                if (state_.error_valid == 1)
+                    clear_error.send();
+            endmethod
+        endinterface
+
+        interface ReadVolatileReg buffer;
+            method ActionValue#(Bit#(8)) _read();
+                deq_receive_buffer.send();
+                return byte_from_receive_buffer;
+            endmethod
+
+            method _write = send_byte._write;
+        endinterface
+    endinterface
+endmodule
+
+TofinoDebugPortState state_send_buffer_empty = unpack('b0000001);
+TofinoDebugPortState state_send_buffer_full = unpack('b0000010);
+TofinoDebugPortState state_receive_buffer_empty = unpack('b0000100);
+TofinoDebugPortState state_receive_buffer_full = unpack('b0001000);
+TofinoDebugPortState state_request_in_progress = unpack('b0010000);
+TofinoDebugPortState state_error_valid = unpack('b0100000);
+
+TofinoDebugPortState state_idle =
+    state_send_buffer_empty |
+    state_receive_buffer_empty;
+TofinoDebugPortState state_ready_to_start_request = state_receive_buffer_empty;
+
+endpackage

--- a/hdl/boards/sidecar/mainboard/emulator/SidecarMainboardEmulator.bsv
+++ b/hdl/boards/sidecar/mainboard/emulator/SidecarMainboardEmulator.bsv
@@ -1,12 +1,16 @@
 package SidecarMainboardEmulator;
 
+import BuildVector::*;
 import Clocks::*;
 import Connectable::*;
+import TriState::*;
+import Vector::*;
 
 import ECP5::*;
 import SPI::*;
 import Strobe::*;
 
+import I2CCommon::*;
 import IOSync::*;
 import PowerRail::*;
 import SidecarMainboardController::*;
@@ -84,6 +88,7 @@ module mkSidecarMainboardEmulatorOnEcp5EvnWrapper (SidecarMainboardEmulator);
     SpiServer spi_server <-
         mkSpiServer(
             controller.registers.tofino,
+            controller.registers.tofino_debug_port,
             controller.registers.pcie);
 
     Reg#(Bit#(1)) csn <- mkInputSyncFor(spi_phy.pins.csn);

--- a/hdl/boards/sidecar/mainboard/sidecar_mainboard_controller.rdl
+++ b/hdl/boards/sidecar/mainboard/sidecar_mainboard_controller.rdl
@@ -364,4 +364,42 @@ addrmap sidecar_mainboard_controller {
             desc = "Host PCIe Reset";
         } HOST_RESET[1] = 0;
     } PCIE_HOTPLUG_STATUS;
+
+    reg {
+        name = "Tofino Debug Port Data";
+        default sw = rw;
+        default hw = rw;
+
+        field {
+            desc = "Send/receive buffer read/write port";
+        } DATA [7:0] = 0;
+    } TOFINO_DEBUG_PORT_BUFFER @ 0x200;
+
+    reg {
+        name = "Tofino Debug Port Status";
+        default sw = r;
+        default hw = w;
+
+        field {
+            desc = "Send buffer empty";
+        } SEND_BUFFER_EMPTY[1] = 0;
+        field {
+            desc = "Send buffer full";
+        } SEND_BUFFER_FULL[1] = 0;
+        field {
+            desc = "Receive buffer empty";
+        } RECEIVE_BUFFER_EMPTY[1] = 0;
+        field {
+            desc = "Receive buffer full";
+        } RECEIVE_BUFFER_FULL[1] = 0;
+        field {
+            desc = "Flag indicating the port is busy processing requests";
+        } REQUEST_IN_PROGRESS[1] = 0;
+        field {
+            desc = "Flag indicating an I2C error occured";
+        } ERROR_VALID[1] = 0;
+        field {
+            desc = "Field indicating the type of I2C error occured";
+        } ERROR_DETAILS[1] = 0;
+    } TOFINO_DEBUG_PORT_STATE;
 };

--- a/hdl/boards/sidecar/mainboard/sidecar_mainboard_controller_rev_a.lpf
+++ b/hdl/boards/sidecar/mainboard/sidecar_mainboard_controller_rev_a.lpf
@@ -160,16 +160,17 @@ IOBUF PORT "fpga_to_vr_tf_vdda1p8_en" PULLMODE=NONE IO_TYPE=LVCMOS33;
 LOCATE COMP "vr_tf_v1p8_to_fpga_vdda1p8_pg" SITE "C16";
 IOBUF PORT "vr_tf_v1p8_to_fpga_vdda1p8_pg" PULLMODE=NONE IO_TYPE=LVCMOS18;
 
+// Debug port
+LOCATE COMP "i2c_fpga_to_tf_scl" SITE "A15";
+LOCATE COMP "i2c_fpga_to_tf_sda" SITE "C19";
+LOCATE COMP "i2c_fpga_to_tf_sda_o_r" SITE "A14";
+IOBUF PORT "i2c_fpga_to_tf_scl" PULLMODE=NONE OPENDRAIN=ON IO_TYPE=LVCMOS18;
+IOBUF PORT "i2c_fpga_to_tf_sda" PULLMODE=NONE OPENDRAIN=ON IO_TYPE=LVCMOS18;
+IOBUF PORT "i2c_fpga_to_tf_sda_o_r" PULLMODE=NONE IO_TYPE=LVCMOS18;
 
 // misc
 LOCATE COMP "tf_pg_led" SITE "A13";
 IOBUF PORT "tf_pg_led" PULLMODE=NONE IO_TYPE=LVCMOS33;
-LOCATE COMP "i2c_fpga_to_tf_sda_o_r" SITE "A14";
-IOBUF PORT "i2c_fpga_to_tf_sda_o_r" PULLMODE=NONE OPENDRAIN=ON IO_TYPE=LVCMOS33;
-LOCATE COMP "i2c_fpga_to_tf_sda" SITE "A15";
-IOBUF PORT "i2c_fpga_to_tf_sda" PULLMODE=NONE OPENDRAIN=ON IO_TYPE=LVCMOS33;
-LOCATE COMP "i2c_fpga_to_tf_scl" SITE "C19";
-IOBUF PORT "i2c_fpga_to_tf_scl" PULLMODE=NONE OPENDRAIN=ON IO_TYPE=LVCMOS18;
 LOCATE COMP "tf_to_fpga_irq[3]" SITE "B17";
 IOBUF PORT "tf_to_fpga_irq[3]" PULLMODE=NONE IO_TYPE=LVCMOS18;
 LOCATE COMP "fpga_to_tf_test_core_tap_l" SITE "B21";

--- a/hdl/boards/sidecar/mainboard/sidecar_mainboard_controller_rev_b.lpf
+++ b/hdl/boards/sidecar/mainboard/sidecar_mainboard_controller_rev_b.lpf
@@ -162,16 +162,17 @@ IOBUF PORT "fpga_to_vr_tf_vdda1p8_en" PULLMODE=NONE IO_TYPE=LVCMOS33;
 LOCATE COMP "vr_tf_v1p8_to_fpga_vdda1p8_pg" SITE "C16";
 IOBUF PORT "vr_tf_v1p8_to_fpga_vdda1p8_pg" PULLMODE=NONE IO_TYPE=LVCMOS18;
 
+// Debug port
+LOCATE COMP "i2c_fpga_to_tf_scl" SITE "A15";
+LOCATE COMP "i2c_fpga_to_tf_sda" SITE "C19";
+LOCATE COMP "i2c_fpga_to_tf_sda_o_r" SITE "A14";
+IOBUF PORT "i2c_fpga_to_tf_scl" PULLMODE=NONE OPENDRAIN=ON IO_TYPE=LVCMOS18;
+IOBUF PORT "i2c_fpga_to_tf_sda" PULLMODE=NONE OPENDRAIN=ON IO_TYPE=LVCMOS18;
+IOBUF PORT "i2c_fpga_to_tf_sda_o_r" PULLMODE=NONE IO_TYPE=LVCMOS18;
 
 // misc
 LOCATE COMP "tf_pg_led" SITE "A13";
 IOBUF PORT "tf_pg_led" PULLMODE=NONE IO_TYPE=LVCMOS33;
-LOCATE COMP "i2c_fpga_to_tf_sda_o_r" SITE "A14";
-IOBUF PORT "i2c_fpga_to_tf_sda_o_r" PULLMODE=NONE OPENDRAIN=ON IO_TYPE=LVCMOS33;
-LOCATE COMP "i2c_fpga_to_tf_sda" SITE "A15";
-IOBUF PORT "i2c_fpga_to_tf_sda" PULLMODE=NONE OPENDRAIN=ON IO_TYPE=LVCMOS33;
-LOCATE COMP "i2c_fpga_to_tf_scl" SITE "C19";
-IOBUF PORT "i2c_fpga_to_tf_scl" PULLMODE=NONE OPENDRAIN=ON IO_TYPE=LVCMOS18;
 LOCATE COMP "tf_to_fpga_irq[3]" SITE "B17";
 IOBUF PORT "tf_to_fpga_irq[3]" PULLMODE=NONE IO_TYPE=LVCMOS18;
 LOCATE COMP "fpga_to_tf_test_core_tap_l" SITE "B21";

--- a/hdl/boards/sidecar/mainboard/test/BUILD
+++ b/hdl/boards/sidecar/mainboard/test/BUILD
@@ -14,6 +14,23 @@ bluesim_tests('PCIeEndpointControllerTests',
         'cobalt//hdl:TestUtils',
     ])
 
+bluesim_tests('TofinoDebugPortTests',
+    suite = 'TofinoDebugPortTests.bsv',
+    env = 'cobalt//bluesim_default',
+    modules = [
+        'mkClearSendBufferTest',
+        'mkAbortRequestOnAddressNackTest',
+        'mkLocalReadTest',
+        'mkLocalWriteTest',
+        'mkDirectReadTest',
+        'mkDirectWriteTest',
+    ],
+    deps = [
+        '//hdl/boards/sidecar/mainboard:TofinoDebugPort',
+        '//hdl/I2C:I2CPeripheralModel',
+        'cobalt//hdl:TestUtils',
+    ])
+
 bluesim_tests('Tofino2SequencerTests',
     suite = 'Tofino2SequencerTests.bsv',
     env = 'cobalt//bluesim_default',

--- a/hdl/boards/sidecar/mainboard/test/TofinoDebugPortTests.bsv
+++ b/hdl/boards/sidecar/mainboard/test/TofinoDebugPortTests.bsv
@@ -1,0 +1,289 @@
+package TofinoDebugPortTests;
+
+import Connectable::*;
+import GetPut::*;
+import StmtFSM::*;
+import Vector::*;
+
+import TestUtils::*;
+
+import I2CPeripheralModel::*;
+import TofinoDebugPort::*;
+
+
+Bit#(7) tofino_address = 7'b1011_011;
+Bit#(7) incorrect_address = 7'b0;
+
+function Bit#(8) local_read(Bit#(5) i) = {pack(LocalRead), i};
+function Bit#(8) local_write(Bit#(5) i) = {pack(LocalWrite), i};
+
+(* synthesize *)
+module mkClearSendBufferTest (Empty);
+    TofinoDebugPort debug_port <- mkTofinoDebugPort(10000, 100, tofino_address);
+    I2CPeripheralModel tofino <- mkI2CPeripheralModel(tofino_address);
+
+    mkConnection(debug_port.pins, tofino);
+
+    let state = asIfc(debug_port.registers.state);
+    let buffer = asIfc(debug_port.registers.buffer);
+
+    mkAutoFSM(seq
+        assert_set(state.send_buffer_empty, "expected send buffer empty");
+
+        buffer <= 1;
+        assert_not_set(state.send_buffer_empty, "expected send buffer not empty");
+
+        state <= state_send_buffer_empty;
+        assert_set(state.send_buffer_empty, "expected send buffer empty");
+    endseq);
+endmodule
+
+(* synthesize *)
+module mkAbortRequestOnAddressNackTest (Empty);
+    TofinoDebugPort debug_port <- mkTofinoDebugPort(10000, 100, tofino_address);
+    I2CPeripheralModel tofino <- mkI2CPeripheralModel(incorrect_address);
+
+    mkConnection(debug_port.pins, tofino);
+
+    let state = asIfc(debug_port.registers.state);
+    let buffer = asIfc(debug_port.registers.buffer);
+
+    mkAutoFSM(seq
+        assert_eq(state, state_idle, "expect debug port idle");
+
+        // Submit a request.
+        buffer <= local_read(1);
+        assert_eq(state,
+            state_ready_to_start_request,
+            "expected port ready to start request");
+
+        // Start the request and wait for the busy bit to clear.
+        state <= state_request_in_progress;
+        await(state.request_in_progress == 0);
+
+        assert_set(state.error_valid, "expected error");
+        assert_eq(state.error_details, 0, "expected address NACK error");
+
+        // Clear the error and retry.
+        state <= state_error_valid;
+        assert_not_set(state.error_valid, "expected error cleared");
+    endseq);
+endmodule
+
+(* synthesize *)
+module mkLocalWriteTest (Empty);
+    TofinoDebugPort debug_port <- mkTofinoDebugPort(10000, 100, tofino_address);
+    I2CPeripheralModel tofino <- mkI2CPeripheralModel(tofino_address);
+
+    mkConnection(debug_port.pins, tofino);
+
+    let state = asIfc(debug_port.registers.state);
+    let buffer = asIfc(debug_port.registers.buffer);
+
+    mkAutoFSM(seq
+        buffer <= local_write(1);
+        buffer <= 'haa;
+        assert_not_set(state.send_buffer_empty, "expected send buffer not empty");
+        assert_set(state.receive_buffer_empty, "expected receive buffer empty");
+
+        // Issue the request.
+        par
+            seq
+                state <= state_request_in_progress;
+                assert_set(state.request_in_progress, "expected request in progress");
+                await(state.request_in_progress == 0);
+            endseq
+
+            seq
+                assert_get_eq(tofino.receive, tagged ReceivedStart, "expected START");
+                assert_get_eq(tofino.receive, tagged AddressMatch, "expected address");
+                assert_get_eq(
+                    tofino.receive,
+                    tagged ReceivedData local_write(1),
+                    "expected LocalWrite of register 1");
+                assert_get_eq(
+                    tofino.receive,
+                    tagged ReceivedData 'haa,
+                    "expected data byte");
+                assert_get_eq(tofino.receive, tagged ReceivedStop, "expected STOP");
+            endseq
+        endpar
+
+        assert_set(state.receive_buffer_empty, "expected receive buffer still empty");
+    endseq);
+endmodule
+
+(* synthesize *)
+module mkLocalReadTest (Empty);
+    TofinoDebugPort debug_port <- mkTofinoDebugPort(10000, 100, tofino_address);
+    I2CPeripheralModel tofino <- mkI2CPeripheralModel(tofino_address);
+
+    mkConnection(debug_port.pins, tofino);
+
+    let state = asIfc(debug_port.registers.state);
+    let buffer = asIfc(debug_port.registers.buffer);
+
+    mkAutoFSM(seq
+        buffer <= local_read(1);
+        assert_not_set(state.send_buffer_empty, "expected send buffer not empty");
+        assert_set(state.receive_buffer_empty, "expected receive buffer empty");
+
+        // Issue the request.
+        par
+            seq
+                state <= state_request_in_progress;
+                assert_set(state.request_in_progress, "expected request in progress");
+                await(state.request_in_progress == 0);
+            endseq
+
+            seq
+                assert_get_eq(tofino.receive, tagged ReceivedStart, "expected START");
+                assert_get_eq(tofino.receive, tagged AddressMatch, "expected address");
+                assert_get_eq(
+                    tofino.receive,
+                    tagged ReceivedData local_read(1),
+                    "expected LocalRead of register 1");
+                assert_get_eq(tofino.receive,tagged ReceivedStop, "expected STOP");
+
+                assert_get_eq(tofino.receive, tagged ReceivedStart, "expected START");
+                assert_get_eq(tofino.receive, tagged AddressMatch, "expected address");
+
+                // The peripheral doesn't handle outside data just yet, so
+                // ignore the response for now.
+                assert_get_any(tofino.receive);
+                assert_get_eq(tofino.receive, tagged ReceivedNack, "expected NACK");
+                assert_get_eq(tofino.receive, tagged ReceivedStop, "expected STOP");
+            endseq
+        endpar
+
+        assert_not_set(state.receive_buffer_empty, "expected receive buffer not empty");
+        assert_av_not_eq(buffer, 'h00, "expected register value");
+    endseq);
+
+    mkTestWatchdog(20000);
+endmodule
+
+(* synthesize *)
+module mkDirectWriteTest (Empty);
+    TofinoDebugPort debug_port <- mkTofinoDebugPort(10000, 100, tofino_address);
+    I2CPeripheralModel tofino <- mkI2CPeripheralModel(tofino_address);
+
+    mkConnection(debug_port.pins, tofino);
+
+    let state = asIfc(debug_port.registers.state);
+    let buffer = asIfc(debug_port.registers.buffer);
+    let opcode_byte = Bit#(8)'({pack(DirectWrite), 5'b0});
+
+    Vector#(4, Bit#(8)) address = unpack('h01020304);
+    Vector#(4, Bit#(8)) value = unpack('h04030201);
+
+    mkAutoFSM(seq
+        buffer <= opcode_byte;
+        buffer <= address[0];
+        buffer <= address[1];
+        buffer <= address[2];
+        buffer <= address[3];
+        buffer <= value[0];
+        buffer <= value[1];
+        buffer <= value[2];
+        buffer <= value[3];
+
+        assert_not_set(state.send_buffer_empty, "expected send buffer not empty");
+        assert_set(state.receive_buffer_empty, "expected receive buffer empty");
+
+        // Issue the request.
+        par
+            seq
+                state <= state_request_in_progress;
+                assert_set(state.request_in_progress, "expected request in progress");
+                await(state.request_in_progress == 0);
+            endseq
+
+            seq
+                assert_get_eq(tofino.receive, tagged ReceivedStart, "expected START");
+                assert_get_eq(tofino.receive, tagged AddressMatch, "expected address");
+                assert_get_eq(tofino.receive, tagged ReceivedData opcode_byte, "expected Opcode");
+                assert_get_eq(tofino.receive, tagged ReceivedData 'h04, "expected address byte 0");
+                assert_get_eq(tofino.receive, tagged ReceivedData 'h03, "expected address byte 1");
+                assert_get_eq(tofino.receive, tagged ReceivedData 'h02, "expected address byte 2");
+                assert_get_eq(tofino.receive, tagged ReceivedData 'h01, "expected address byte 3");
+                assert_get_eq(tofino.receive, tagged ReceivedData 'h01, "expected value byte 0");
+                assert_get_eq(tofino.receive, tagged ReceivedData 'h02, "expected value byte 1");
+                assert_get_eq(tofino.receive, tagged ReceivedData 'h03, "expected value byte 2");
+                assert_get_eq(tofino.receive, tagged ReceivedData 'h04, "expected value byte 3");
+                assert_get_eq(tofino.receive, tagged ReceivedStop, "expected STOP");
+            endseq
+        endpar
+
+        assert_set(state.receive_buffer_empty, "expected receive buffer still empty");
+    endseq);
+
+    mkTestWatchdog(20000);
+endmodule
+
+(* synthesize *)
+module mkDirectReadTest (Empty);
+    TofinoDebugPort debug_port <- mkTofinoDebugPort(10000, 100, tofino_address);
+    I2CPeripheralModel tofino <- mkI2CPeripheralModel(tofino_address);
+
+    mkConnection(debug_port.pins, tofino);
+
+    let state = asIfc(debug_port.registers.state);
+    let buffer = asIfc(debug_port.registers.buffer);
+    let opcode_byte = Bit#(8)'({pack(DirectRead), 5'b0});
+
+    Vector#(4, Bit#(8)) address = unpack('h01020304);
+
+    mkAutoFSM(seq
+        buffer <= opcode_byte;
+        buffer <= address[3];
+        buffer <= address[2];
+        buffer <= address[1];
+        buffer <= address[0];
+
+        assert_not_set(state.send_buffer_empty, "expected send buffer not empty");
+        assert_set(state.receive_buffer_empty, "expected receive buffer empty");
+
+        // Issue the request.
+        par
+            seq
+                state <= state_request_in_progress;
+                assert_set(state.request_in_progress, "expected request in progress");
+                await(state.request_in_progress == 0);
+            endseq
+
+            seq
+                assert_get_eq(tofino.receive, tagged ReceivedStart, "expected START");
+                assert_get_eq(tofino.receive, tagged AddressMatch, "expected address");
+                assert_get_eq(tofino.receive, tagged ReceivedData opcode_byte, "expected Opcode");
+                assert_get_eq(tofino.receive, tagged ReceivedData 'h01, "expected address byte 0");
+                assert_get_eq(tofino.receive, tagged ReceivedData 'h02, "expected address byte 1");
+                assert_get_eq(tofino.receive, tagged ReceivedData 'h03, "expected address byte 2");
+                assert_get_eq(tofino.receive, tagged ReceivedData 'h04, "expected address byte 3");
+                assert_get_eq(tofino.receive,tagged ReceivedStop, "expected STOP");
+
+                assert_get_eq(tofino.receive, tagged ReceivedStart, "expected START");
+                assert_get_eq(tofino.receive, tagged AddressMatch, "expected address");
+                // Receive the first 3 value bytes.
+                repeat(4) seq
+                    assert_get_any(tofino.receive);
+                    assert_get_eq(tofino.receive, tagged ReceivedAck, "expected Ack");
+                endseq
+                // Receive the last value byte.
+                assert_get_any(tofino.receive);
+                assert_get_eq(tofino.receive, tagged ReceivedNack, "expected Nack");
+                assert_get_eq(tofino.receive, tagged ReceivedStop, "expected STOP");
+            endseq
+        endpar
+
+        assert_not_set(state.receive_buffer_empty, "expected receive buffer not empty");
+        $display("%t Buffer Read, 4", $time);
+        repeat(4) action
+            assert_av_not_eq_display(buffer, 'h00, "expected value byte");
+        endaction
+    endseq);
+
+    mkTestWatchdog(20000);
+endmodule
+
+endpackage


### PR DESCRIPTION
Tofino has an I2C peripheral interface which can be used during early stages of boot. This diff provides a request/response wrapper and some glue to allow Hubris software to interact with this peripheral interface and use it to program the attached SPI EEPROM holding the PCIe SerDes parameters.