### PR TITLE
Fix Nic1 Output status to actually report enable status

### DIFF
--- a/hdl/boards/gimlet/sequencer/GimletRegs.bsv
+++ b/hdl/boards/gimlet/sequencer/GimletRegs.bsv
@@ -50,7 +50,6 @@ module mkGimletRegs(GimletRegIF);
     ConfigReg#(PwrCtrl) power_control <- mkReg(defaultValue);
     ConfigReg#(NicCtrl) nic_control <- mkReg(defaultValue);
     //  NIC domain signals
-    ConfigReg#(NicOutput1Type) nic1_out_status <- mkRegU(); // RO register for outputs
     
     ConfigReg#(NicOutput1Type) dbg_nic1_out       <- mkReg(unpack(0));
     ConfigReg#(NicOutput2Type) dbg_nic2_out       <- mkReg(unpack(0));
@@ -99,7 +98,6 @@ module mkGimletRegs(GimletRegIF);
     Wire#(Bit#(16)) address <- mkDWire(0);
     Wire#(RegOps) operation <- mkDWire(NOOP);
     // RWire#(NicStatus) cur_nic_pins <- mkRWire();
-    RWire#(NicOutput1Type) cur_nic1_out_status <- mkRWire();
     RWire#(EarlyPower) cur_early_outputs <- mkRWire();
     RWire#(EarlyRbks) cur_early_inputs <- mkRWire();
 
@@ -121,6 +119,7 @@ module mkGimletRegs(GimletRegIF);
     Wire#(Bool) thermtrip <- mkDWire(False);
     Wire#(Bool) fanfault <- mkDWire(False);
     Wire#(NicOutput2Type) nic2_out_status <- mkDWire(unpack(0));
+    Wire#(NicOutput1Type) nic1_out_status <- mkDWire(unpack(0));
     Wire#(NicCtrl) nic_ctrl_next <- mkDWire(defaultValue);
 
     IRQBlock#(IrqType) irq_block <- mkIRQBlock();
@@ -329,6 +328,7 @@ module mkGimletRegs(GimletRegIF);
         endmethod
         method pgs = nic_status._write;
         method nic_outs = nic2_out_status._write;
+        method nic_ens = nic1_out_status._write;
         method mapo = nic_mapo._write;
     endinterface
 

--- a/hdl/boards/gimlet/sequencer/NicBlock.bsv
+++ b/hdl/boards/gimlet/sequencer/NicBlock.bsv
@@ -25,6 +25,7 @@ import PowerRail::*;
         method Bool ok();
         method NicStateType state();
         method NicStatus pgs;
+        method NicOutput1Type nic_ens;
         method NicOutput2Type nic_outs;
         method Bool mapo();
         // method A1OutStatus output_readbacks();
@@ -40,6 +41,7 @@ import PowerRail::*;
         method Action ok(Bool value);
         method Action state(NicStateType value);
         method Action pgs (NicStatus value);
+        method Action nic_ens (NicOutput1Type value);
         method Action nic_outs (NicOutput2Type value);
         method Action mapo(Bool value);
     endinterface
@@ -288,6 +290,17 @@ import PowerRail::*;
             method cld_rst_override = cld_rst_override._write;
             method perst_override = perst_override._write;
             method perst_solo = perst_solo._write;
+            method NicOutput1Type nic_ens;
+                return NicOutput1Type {
+                    nic_v0p9_a0_en: pack(v0p9_a0hp.enabled),
+                    nic_v1p2_eth_en: pack(v1p2.enabled),
+                    nic_v1p5a_en: pack(v1p5a.enabled),
+                    nic_v1p5d_en: pack(v1p5d.enabled),
+                    nic_v1p2_en: pack(v1p2.enabled),
+                    nic_v1p1_en: pack(v1p1.enabled),
+                    nic_v3p3_en: pack(ldo_v3p3.enabled)
+                };
+            endmethod
             method NicOutput2Type nic_outs;
                 return NicOutput2Type {
                    sp3_perst: ~sp3_to_seq_nic_perst_l,

--- a/hdl/boards/gimlet/sequencer/gimlet_seq_fpga_regs.rdl
+++ b/hdl/boards/gimlet/sequencer/gimlet_seq_fpga_regs.rdl
@@ -596,14 +596,11 @@ addrmap gimlet_seq_fpga {
 
     reg nic_output1_type {
         field {
+            desc = "Enable (U565), V0P96_NIC_VDD_A0HP rail (SEQ_TO_NIC_V0P9_A0HP_EN net)";
+        } NIC_V0P9_A0_EN[1] = 0;
+        field {
             desc = "Turns on V1P2_NIC_ENET_A0HP, no readback (SEQ_TO_NIC_V1P2_ENET_EN net)";
         } NIC_V1P2_ETH_EN[1] = 0;
-        field {
-            desc = "EN0 for ISL68224 (U357), V0P96_NIC_VDD_A0HP rail (PWR_CONT_NIC_EN0 net)";
-        } NIC_CONT_EN0[1] = 0;
-        field {
-            desc = "EN1 for ISL68224 (U357), V1P8_NIC_A0HP rail (PWR_CONT_NIC_EN1 ent)  ";
-        } NIC_CONT_EN1[1] = 0;
         field {
             desc = "En for V1P5_NIC_AVDD_A0HP rail (SEQ_TO_NIC_V1P5A_EN net)";
         } NIC_V1P5A_EN[1] = 0;
@@ -618,7 +615,7 @@ addrmap gimlet_seq_fpga {
         } NIC_V1P1_EN[1] = 0;
         field {
             desc = "Enables V3PV_NIC_A0HP rail (SEQ_TO_NIC_LDO_V3P3_EN net)";
-        } NIC_V3P3[1] = 0;
+        } NIC_V3P3_EN[1] = 0;
     };
 
     reg nic_output2_type {


### PR DESCRIPTION
This renames the pins and nets to match the revB+ schematics and actually wires the status up to the register instead of just showing 0's.

Fixes #35 