### PR TITLE
QSFP: Add QSFP module I2C status registers

### DIFF
--- a/hdl/I2C/I2CCore.bsv
+++ b/hdl/I2C/I2CCore.bsv
@@ -72,7 +72,8 @@ interface I2CCore;
     interface Put#(Command) send_command;
     interface PutS#(Bit#(8)) send_data;
     interface Get#(Bit#(8)) received_data;
-    method Maybe#(Error) error();
+    method Maybe#(Error) error;
+    method Bool busy;
 endinterface
 
 module mkI2CCore#(Integer core_clk_freq, Integer i2c_scl_freq) (I2CCore);
@@ -230,6 +231,7 @@ module mkI2CCore#(Integer core_clk_freq, Integer i2c_scl_freq) (I2CCore);
     interface Get received_data = toGet(rx_data_q);
 
     method error = error_r;
+    method busy = state_r != Idle;
 endmodule
 
 endpackage: I2CCore

--- a/hdl/boards/sidecar/qsfp_x32/QSFPModule/QsfpModuleController.bsv
+++ b/hdl/boards/sidecar/qsfp_x32/QSFPModule/QsfpModuleController.bsv
@@ -86,6 +86,8 @@ interface QsfpModuleController;
     method Bit#(1) pg_timeout;
     method Bit#(1) present;
     method Bit#(1) irq;
+    method Maybe#(I2CCore::Error) i2c_error;
+    method Bit#(1) i2c_busy;
 endinterface
 
 module mkQsfpModuleController #(Parameters parameters) (QsfpModuleController);
@@ -246,6 +248,9 @@ module mkQsfpModuleController #(Parameters parameters) (QsfpModuleController);
     method pg_timeout   = pack(hot_swap.good_timeout);
     method present      = present_;
     method irq          = irq_;
+
+    method i2c_busy     = pack(i2c_core.busy);
+    method i2c_error    = i2c_core.error;
 
 endmodule
 

--- a/hdl/boards/sidecar/qsfp_x32/QSFPModule/qsfp_modules_top.rdl
+++ b/hdl/boards/sidecar/qsfp_x32/QSFPModule/qsfp_modules_top.rdl
@@ -94,6 +94,168 @@ addrmap qsfp_modules_top {
         } START[0:0] = 0;
     } I2C_CTRL;
 
+    reg {
+        default sw = r;
+        name = "Ports 8 -> 15 I2C core status. '1' is busy.";
+        field {} PORT15[7:7] = 0;
+        field {} PORT14[6:6] = 0;
+        field {} PORT13[5:5] = 0;
+        field {} PORT12[4:4] = 0;
+        field {} PORT11[3:3] = 0;
+        field {} PORT10[2:2] = 0;
+        field {} PORT9[1:1] = 0;
+        field {} PORT8[0:0] = 0;
+    } I2C_BUSY_H;
+
+    reg {
+        default sw = r;
+        name = "Ports 0 -> 7 I2C core status. '1' is busy.";
+        field {} PORT7[7:7] = 0;
+        field {} PORT6[6:6] = 0;
+        field {} PORT5[5:5] = 0;
+        field {} PORT4[4:4] = 0;
+        field {} PORT3[3:3] = 0;
+        field {} PORT2[2:2] = 0;
+        field {} PORT1[1:1] = 0;
+        field {} PORT0[0:0] = 0;
+    } I2C_BUSY_L;
+
+    reg {
+        name = "Ports 15/14 I2C core error status";
+        default sw = r;
+        field {
+            desc = "'1' if there was an error on the most recent transaction.";
+        } PORT15_ERROR[7:7] = 0;
+        field {
+            desc = "Valid if ERROR is set. 3'b000 for AddressNack, 3'b001 for ByteNack.";
+        } PORT15_ERROR_TYPE[6:4] = 0;
+        field {
+            desc = "'1' if there was an error on the most recent transaction.";
+        } PORT14_ERROR[3:3] = 0;
+        field {
+            desc = "Valid if ERROR is set. 3'b000 for AddressNack, 3'b001 for ByteNack.";
+        } PORT14_ERROR_TYPE[2:0] = 0;
+    } I2C_ERROR0;
+
+    reg {
+        name = "Ports 13/12 I2C core error status";
+        default sw = r;
+        field {
+            desc = "'1' if there was an error on the most recent transaction.";
+        } PORT13_ERROR[7:7] = 0;
+        field {
+            desc = "Valid if ERROR is set. 3'b000 for AddressNack, 3'b001 for ByteNack.";
+        } PORT13_ERROR_TYPE[6:4] = 0;
+        field {
+            desc = "'1' if there was an error on the most recent transaction.";
+        } PORT12_ERROR[3:3] = 0;
+        field {
+            desc = "Valid if ERROR is set. 3'b000 for AddressNack, 3'b001 for ByteNack.";
+        } PORT12_ERROR_TYPE[2:0] = 0;
+    } I2C_ERROR1;
+
+    reg {
+        name = "Ports 11/10 I2C core error status";
+        default sw = r;
+        field {
+            desc = "'1' if there was an error on the most recent transaction.";
+        } PORT11_ERROR[7:7] = 0;
+        field {
+            desc = "Valid if ERROR is set. 3'b000 for AddressNack, 3'b001 for ByteNack.";
+        } PORT11_ERROR_TYPE[6:4] = 0;
+        field {
+            desc = "'1' if there was an error on the most recent transaction.";
+        } PORT10_ERROR[3:3] = 0;
+        field {
+            desc = "Valid if ERROR is set. 3'b000 for AddressNack, 3'b001 for ByteNack.";
+        } PORT10_ERROR_TYPE[2:0] = 0;
+    } I2C_ERROR2;
+
+    reg {
+        name = "Ports 9/8 I2C core error status";
+        default sw = r;
+        field {
+            desc = "'1' if there was an error on the most recent transaction.";
+        } PORT9_ERROR[7:7] = 0;
+        field {
+            desc = "Valid if ERROR is set. 3'b000 for AddressNack, 3'b001 for ByteNack.";
+        } PORT9_ERROR_TYPE[6:4] = 0;
+        field {
+            desc = "'1' if there was an error on the most recent transaction.";
+        } PORT8_ERROR[3:3] = 0;
+        field {
+            desc = "Valid if ERROR is set. 3'b000 for AddressNack, 3'b001 for ByteNack.";
+        } PORT8_ERROR_TYPE[2:0] = 0;
+    } I2C_ERROR3;
+
+    reg {
+        name = "Ports 7/6 I2C core error status";
+        default sw = r;
+        field {
+            desc = "'1' if there was an error on the most recent transaction.";
+        } PORT7_ERROR[7:7] = 0;
+        field {
+            desc = "Valid if ERROR is set. 3'b000 for AddressNack, 3'b001 for ByteNack.";
+        } PORT7_ERROR_TYPE[6:4] = 0;
+        field {
+            desc = "'1' if there was an error on the most recent transaction.";
+        } PORT6_ERROR[3:3] = 0;
+        field {
+            desc = "Valid if ERROR is set. 3'b000 for AddressNack, 3'b001 for ByteNack.";
+        } PORT6_ERROR_TYPE[2:0] = 0;
+    } I2C_ERROR4;
+
+    reg {
+        name = "Ports 5/4 I2C core error status";
+        default sw = r;
+        field {
+            desc = "'1' if there was an error on the most recent transaction.";
+        } PORT5_ERROR[7:7] = 0;
+        field {
+            desc = "Valid if ERROR is set. 3'b000 for AddressNack, 3'b001 for ByteNack.";
+        } PORT5_ERROR_TYPE[6:4] = 0;
+        field {
+            desc = "'1' if there was an error on the most recent transaction.";
+        } PORT4_ERROR[3:3] = 0;
+        field {
+            desc = "Valid if ERROR is set. 3'b000 for AddressNack, 3'b001 for ByteNack.";
+        } PORT4_ERROR_TYPE[2:0] = 0;
+    } I2C_ERROR5;
+
+    reg {
+        name = "Ports 3/2 I2C core error status";
+        default sw = r;
+        field {
+            desc = "'1' if there was an error on the most recent transaction.";
+        } PORT3_ERROR[7:7] = 0;
+        field {
+            desc = "Valid if ERROR is set. 3'b000 for AddressNack, 3'b001 for ByteNack.";
+        } PORT3_ERROR_TYPE[6:4] = 0;
+        field {
+            desc = "'1' if there was an error on the most recent transaction.";
+        } PORT2_ERROR[3:3] = 0;
+        field {
+            desc = "Valid if ERROR is set. 3'b000 for AddressNack, 3'b001 for ByteNack.";
+        } PORT2_ERROR_TYPE[2:0] = 0;
+    } I2C_ERROR6;
+
+    reg {
+        name = "Ports 1/0 I2C core error status";
+        default sw = r;
+        field {
+            desc = "'1' if there was an error on the most recent transaction.";
+        } PORT1_ERROR[7:7] = 0;
+        field {
+            desc = "Valid if ERROR is set. 3'b000 for AddressNack, 3'b001 for ByteNack.";
+        } PORT1_ERROR_TYPE[6:4] = 0;
+        field {
+            desc = "'1' if there was an error on the most recent transaction.";
+        } PORT0_ERROR[3:3] = 0;
+        field {
+            desc = "Valid if ERROR is set. 3'b000 for AddressNack, 3'b001 for ByteNack.";
+        } PORT0_ERROR_TYPE[2:0] = 0;
+    } I2C_ERROR7;
+
     //
     // QSFP Module Control
     //
@@ -176,6 +338,7 @@ addrmap qsfp_modules_top {
 
     reg {
         name = "Ports 8 -> 15 HSC power good";
+        default sw = r;
         field {} PORT15[7:7] = 0;
         field {} PORT14[6:6] = 0;
         field {} PORT13[5:5] = 0;
@@ -188,6 +351,7 @@ addrmap qsfp_modules_top {
 
     reg {
         name = "Ports 0 -> 7 HSC power good";
+        default sw = r;
         field {} PORT7[7:7] = 0;
         field {} PORT6[6:6] = 0;
         field {} PORT5[5:5] = 0;
@@ -200,6 +364,7 @@ addrmap qsfp_modules_top {
 
     reg {
         name = "Ports 8 -> 15 HSC power good timeout";
+        default sw = r;
         field {} PORT15[7:7] = 0;
         field {} PORT14[6:6] = 0;
         field {} PORT13[5:5] = 0;
@@ -212,6 +377,7 @@ addrmap qsfp_modules_top {
 
     reg {
         name = "Ports 0 -> 7 HSC power good timeout";
+        default sw = r;
         field {} PORT7[7:7] = 0;
         field {} PORT6[6:6] = 0;
         field {} PORT5[5:5] = 0;
@@ -224,6 +390,7 @@ addrmap qsfp_modules_top {
 
     reg {
         name = "Ports 8 -> 15 ModPrsL signal for the module (logic inverted at the pin)";
+        default sw = r;
         field {} PORT15[7:7] = 0;
         field {} PORT14[6:6] = 0;
         field {} PORT13[5:5] = 0;
@@ -236,6 +403,7 @@ addrmap qsfp_modules_top {
 
     reg {
         name = "Ports 0 -> 7 ModPrsL signal for the module (logic inverted at the pin)";
+        default sw = r;
         field {} PORT7[7:7] = 0;
         field {} PORT6[6:6] = 0;
         field {} PORT5[5:5] = 0;
@@ -248,6 +416,7 @@ addrmap qsfp_modules_top {
 
     reg {
         name = "Ports 8 -> 15 IntL/RxLOS signal for the module (logic inverted at the pin)";
+        default sw = r;
         field {} PORT15[7:7] = 0;
         field {} PORT14[6:6] = 0;
         field {} PORT13[5:5] = 0;
@@ -260,6 +429,7 @@ addrmap qsfp_modules_top {
 
     reg {
         name = "Ports 0 -> 7 IntL/RxLOS signal for the module (logic inverted at the pin)";
+        default sw = r;
         field {} PORT7[7:7] = 0;
         field {} PORT6[6:6] = 0;
         field {} PORT5[5:5] = 0;

--- a/hdl/boards/sidecar/qsfp_x32/QsfpX32ControllerSpiServer.bsv
+++ b/hdl/boards/sidecar/qsfp_x32/QsfpX32ControllerSpiServer.bsv
@@ -149,6 +149,26 @@ module mkSpiServer #(VSC8562::Registers vsc8562,
             ret_byte = pack(qsfp_top.i2c_bcast_h);
         end else if (spi_request.address == fromInteger(qsfpI2cBcastLOffset)) begin
             ret_byte = pack(qsfp_top.i2c_bcast_l);
+        end else if (spi_request.address == fromInteger(qsfpI2cBusyHOffset)) begin
+            ret_byte = pack(qsfp_top.i2c_busy_h);
+        end else if (spi_request.address == fromInteger(qsfpI2cBusyLOffset)) begin
+            ret_byte = pack(qsfp_top.i2c_busy_l);
+        end else if (spi_request.address == fromInteger(qsfpI2cError0Offset)) begin
+            ret_byte = pack(qsfp_top.i2c_error0);
+        end else if (spi_request.address == fromInteger(qsfpI2cError1Offset)) begin
+            ret_byte = pack(qsfp_top.i2c_error1);
+        end else if (spi_request.address == fromInteger(qsfpI2cError2Offset)) begin
+            ret_byte = pack(qsfp_top.i2c_error2);
+        end else if (spi_request.address == fromInteger(qsfpI2cError3Offset)) begin
+            ret_byte = pack(qsfp_top.i2c_error3);
+        end else if (spi_request.address == fromInteger(qsfpI2cError4Offset)) begin
+            ret_byte = pack(qsfp_top.i2c_error4);
+        end else if (spi_request.address == fromInteger(qsfpI2cError5Offset)) begin
+            ret_byte = pack(qsfp_top.i2c_error5);
+        end else if (spi_request.address == fromInteger(qsfpI2cError6Offset)) begin
+            ret_byte = pack(qsfp_top.i2c_error6);
+        end else if (spi_request.address == fromInteger(qsfpI2cError7Offset)) begin
+            ret_byte = pack(qsfp_top.i2c_error7);
         end else if (spi_request.address == fromInteger(qsfpI2cCtrlOffset)) begin
             ret_byte = pack(qsfp_top.i2c_ctrl);
         end else if (spi_request.address == fromInteger(qsfpCtrlEnHOffset)) begin


### PR DESCRIPTION
This commit does the following:
- adds a `busy` signal to `I2CCore` which is asserted when the core is not in `Idle`
- wires that `busy` signal through to a register for each port
- wires the `error` signal through to a register for each port. The error bit and type will persist until the next transaction on that port.