### PR TITLE
QSFP: Add rev B build target

### DIFF
--- a/BUILD.conf
+++ b/BUILD.conf
@@ -29,7 +29,7 @@ environment('sidecar', base = 'cobalt//ecp5', contents = {
 })
 environment('qsfp', base = 'cobalt//ecp5', contents = {
     'nextpnr_ecp5_flags': [
-        '--um-45k',
+        '--45k',
         '--package CABGA554',
         '--freq 50',
     ],

--- a/hdl/boards/sidecar/qsfp_x32/BUILD
+++ b/hdl/boards/sidecar/qsfp_x32/BUILD
@@ -135,7 +135,21 @@ yosys_design('qsfp_x32_top',
         'cobalt//vnd/bluespec:Verilog.v',
     ])
 
-nextpnr_ecp5_bitstream('qsfp_x32',
+# Rev A uses a LFE45UM device and requires a different device ID. This target
+# can be removed once rev A boards have been phased out.
+nextpnr_ecp5_bitstream('qsfp_x32_rev_a',
+    env = 'qsfp_x32',
+    design = ':qsfp_x32_top#qsfp_x32_top.json',
+    deps = [
+        ':qsfp_x32_top',
+    ],
+    local = {
+        'nextpnr_ecp5_flags': [
+            '--um-45k',
+        ]
+    })
+
+nextpnr_ecp5_bitstream('qsfp_x32_rev_b',
     env = 'qsfp_x32',
     design = ':qsfp_x32_top#qsfp_x32_top.json',
     deps = [


### PR DESCRIPTION
Rev B QSFP x32 boards are assembled using LFE5U-45 devices rather than LFE5UM-45 devices. This diff makes the non-M device default and adds a rev A build target for the time being.