### PR TITLE
QSFP: Use IO pull-up to make up for missing external PU

### DIFF
--- a/hdl/boards/sidecar/qsfp_x32/qsfp_x32.lpf
+++ b/hdl/boards/sidecar/qsfp_x32/qsfp_x32.lpf
@@ -23,7 +23,7 @@ IOBUF PORT "spi_main_to_fpga_mosi" PULLMODE=NONE IO_TYPE=LVCMOS33;
 LOCATE COMP "pmbus_v3p3_qsfp_to_fpga_alert" SITE "B3";
 IOBUF PORT "pmbus_v3p3_qsfp_to_fpga_alert" PULLMODE=NONE IO_TYPE=LVCMOS33;
 LOCATE COMP "vr_v3p3_qsfp_to_fpga_pg" SITE "C1";
-IOBUF PORT "vr_v3p3_qsfp_to_fpga_pg" PULLMODE=NONE IO_TYPE=LVCMOS33;
+IOBUF PORT "vr_v3p3_qsfp_to_fpga_pg" PULLMODE=UP OPENDRAIN=ON IO_TYPE=LVCMOS33;
 LOCATE COMP "fpga_to_vr_v3p3_qsfp_en" SITE "C2";
 IOBUF PORT "fpga_to_vr_v3p3_qsfp_en" PULLMODE=NONE IO_TYPE=LVCMOS33;
 


### PR DESCRIPTION
The QSFP0/1 power rails are missing a pull-up on their PG signals. This visually manifests itself with D404/D405 not turning on, but it also prevents us from reading the PG state of these rails. Enabling the PU on the IO pin correct for the missing external PUs.