### PR TITLE
Refactor sequencer state machine to *actually* work

### DIFF
--- a/hdl/boards/gimlet/sequencer/BUILD
+++ b/hdl/boards/gimlet/sequencer/BUILD
@@ -116,7 +116,9 @@ bluesim_tests('A0Tests',
         'mkA0PowerUpTest',
         'mkA0FakeSP3Test',
         'mkA0MAPOTest',
-        'mkA0ThermtripTest'
+        'mkA0ThermtripTest',
+        'mkA0DebugBrokenTest',
+        'mkA0PowerErrorsTest'
     ],
     deps = [
         ':A0Block'
@@ -126,8 +128,8 @@ bluesim_tests('TopTests',
     env = 'cobalt//bluesim_default',
     suite = "GimletSeqTop.bsv",
     modules = [
-        'mkGimletTestTop',
-        'mkGimletThermtripTop',
+        'mkGimletTopTest',
+        'mkGimletThermtripTopTest',
     ],
     deps = [
         ':GimletSeqTop',

--- a/hdl/boards/gimlet/sequencer/GimletSeqTop.bsv
+++ b/hdl/boards/gimlet/sequencer/GimletSeqTop.bsv
@@ -316,7 +316,7 @@ module mkBench(Bench);
 endmodule
 
 (* synthesize *)
-module mkGimletTestTop(Empty);
+module mkGimletTopTest(Empty);
     
     Bench bench <- mkBench();
 
@@ -358,7 +358,7 @@ module mkGimletTestTop(Empty);
 endmodule
 
 (* synthesize *)
-module mkGimletThermtripTop(Empty);
+module mkGimletThermtripTopTest(Empty);
     
     Bench bench <- mkBench();
 


### PR DESCRIPTION
This is intended to resolve #57.

#57 had a number of logic bugs of my own making. That said, while these are maybe better looking, I have mostly concluded that the FSMWithPred is an anti-pattern that should be avoided if  you aren't doing simple straight line sequencing. Previously I had 3 different FSMWithPred blocks in order to accomplish a normal power up, a normal power down, and a fault power down.  These 3 machines needed predicates that could not be true at the same time so that they could drive the same signals which makes sense physically.  But doing these predicates in a sane way appears to be nearly impossible, especially if the predicates, or the logic that sets the predicates is also relient on the current state.
At best, these provide a loose approximation of a monolothic state machine and this approximation means that you have to synthesize your own states anyway, and have less control than you would with a "real" state machine. As I was writing this comment, I thought it was possibly too harsh, and even though my re-write was passing tests, I even went back with a new idea and re-tooled the original implementation trying to save FSMWithPred to no avail now fighting the scheduler because the next-state logic for the predicate *registers* was reliant on the state *register*.  There's no reason why the predicate's next state can't depend on the current state- I'm done with FSMWithPred.

This has been re-written in a more hdl-like style with the whole state machine in a single rule living in a case statement.  This works in this pattern because the state machine isn't interacting with outside interfaces that provide implicit conditions.  There are still ugly things here, like having to set flags during the transition from one state to another "early" such that the bit toggles with the state change, but at least this can be reasoned about completely. This could be done more cleanly if bsv addressed https://github.com/B-Lang-org/bsc/issues/471 or if they allowed shadowing of writes such that you could either override the actions in the rule at the bottom for error handling, or use default values to be overwritten at the top. Alas without introducing wires and doubling the number of things to keep track of, it is not to be.  

I'll save the remaining ranting  for a different time.

