### PR TITLE
Use Ninja in CI to build bitstreams in parallel

### DIFF
--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -100,4 +100,4 @@ pushd build
 banner FPGA Builds
 
 # Get all bit files and build them
-./cobble list | grep .bit | while read line; do ./cobble build -v "$line"; done
+./cobble build -v "//.*#bitstream"


### PR DESCRIPTION
Buildomat currently builds all bitstreams one at the time by explicitly asking Ninja for one target at the time. This change uses Cobble to compute the set of all bitstream targets and then ask for all of them from Ninja, allowing Ninja to schedule their builds in parallel (by default two threads per core). On the Ignition branch, where building the mainboard controller bitstream takes about 50 minutes and it's building two of these one at the time, the total time for the CI job is reduced by well over 50% from ~115 minutes to about 55 minutes.

We are running these CI jobs on m4.2xlarge VMs with 8 cores and 32GB of RAM. This will let us do more in parallel, save us money and we'll get our CI results quicker.