### PR TITLE
AMD reset and pwrok monitoring

### DIFF
--- a/hdl/boards/gimlet/sequencer/A0Block.bsv
+++ b/hdl/boards/gimlet/sequencer/A0Block.bsv
@@ -739,6 +739,8 @@ interface SP3Model;
     interface SP3 pins;
     method Action thermtrip(Bool value);
     method Action disabled(Bool value);
+    method Action pwrok_override(Bool value);
+    method Action rst_override(Bool value);
 endinterface
 
 typedef enum {
@@ -867,6 +869,20 @@ module mkSP3Model(SP3Model);
     endinterface
     method thermtrip = thermtrip_._write;
     method disabled = disabled_._write;
+    method Action pwrok_override (Bool value);
+        if (value) begin
+            sp3_to_seq_pwrok_v3p3 <= 1;
+        end else begin
+            sp3_to_seq_pwrok_v3p3 <= 0;
+        end
+    endmethod
+    method Action rst_override (Bool value);
+        if (value) begin
+            sp3_to_seq_reset_v3p3_l <= 0;
+        end else begin
+            sp3_to_seq_reset_v3p3_l <= 1;
+        end
+    endmethod
 endmodule
 
 module mkA0PowerUpTest(Empty);

--- a/hdl/boards/gimlet/sequencer/BUILD
+++ b/hdl/boards/gimlet/sequencer/BUILD
@@ -129,6 +129,8 @@ bluesim_tests('TopTests',
     modules = [
         'mkGimletTopTest',
         'mkGimletThermtripTopTest',
+        'mkGimletAMDResetTripTest',
+        'mkGimletAMDPWROKTripTest',
     ],
     deps = [
         ':GimletSeqTop',

--- a/hdl/boards/gimlet/sequencer/GimletRegs.bsv
+++ b/hdl/boards/gimlet/sequencer/GimletRegs.bsv
@@ -134,7 +134,7 @@ module mkGimletRegs(GimletRegIF);
             amd_rstn_cnts <= amd_rstn_cnts + 1;
         end
         // Register writes take precedence and reset the counter.
-        if (amd_rstn_write) begin
+        if (amd_pwrokn_write) begin
             amd_pwrokn_cnts <= 0;
          // Saturating counter
         end else if (amd_pwrokn_fedge && amd_pwrokn_cnts < 255) begin
@@ -211,6 +211,8 @@ module mkGimletRegs(GimletRegIF);
             fromInteger(outStatusNic2Offset) : readdata <= tagged Valid (pack(nic2_out_status));
             //fromInteger(clkgenOutStatusOffset) : readdata <= tagged Valid (pack(clkgen_out_status));
             fromInteger(dbgCtrlOffset) : readdata <= tagged Valid (pack(dbgCtrl_reg));
+            fromInteger(amdRstnCntsOffset) : readdata <= tagged Valid (pack(amd_rstn_cnts));
+            fromInteger(amdPwroknCntsOffset) : readdata <= tagged Valid (pack(amd_pwrokn_cnts));
             default : readdata <= tagged Valid ('hff);
         endcase
     endrule
@@ -249,12 +251,12 @@ module mkGimletRegs(GimletRegIF);
         end
 
         // Deal with register writes making clear signals
-        // if (do_write && address == fromInteger()) begin
-        //     amd_rstn_write.send();
-        // end
-        // if (do_write && address == fromInteger()) begin
-        //     amd_pwrokn_write.send();
-        // end
+        if (do_write && address == fromInteger(amdRstnCntsOffset)) begin
+            amd_rstn_write.send();
+        end
+        if (do_write && address == fromInteger(amdPwroknCntsOffset)) begin
+            amd_pwrokn_write.send();
+        end
     endrule
 
     interface Server decoder_if;

--- a/hdl/boards/gimlet/sequencer/gimlet_seq_fpga_regs.rdl
+++ b/hdl/boards/gimlet/sequencer/gimlet_seq_fpga_regs.rdl
@@ -717,16 +717,18 @@ addrmap gimlet_seq_fpga {
     AMD_DBG_OUT->name = "Readbacks of FPGA outputs to AMD";
 
     reg amd_reset_fedge_counter {
-        default sw = rw;
+        default sw=rw;
+        default onwrite=wclr;
         field {
             desc = "Falling edge counter of AMD's reset output while in A0/A0HP. Saturates at 255. Any write clears";
         } RESET_CNTS[7:0] = 0;
-    };
+    } AMD_RSTN_CNTS;
 
     reg amd_pwrok_fedge_counter {
-        default sw = rw;
+        default sw=rw;
+        default onwrite=wclr;
         field {
             desc = "Falling edge counter of AMD's PowerOK output while in A0/A0HP. Saturates at 255.  Any write clears";
         } RESET_CNTS[7:0] = 0;
-    };
+    }AMD_PWROKN_CNTS;
 };


### PR DESCRIPTION
Added new registers for counting falling edges of AMD's reset output and AMD's Power OK output. Falling edges are only counted when we're in the "DONE" state of A0.  SP software can reset the counters by any write to them.