### PR TITLE
Clear initialization on ModPrsL deassertion, add test for that

### DIFF
--- a/hdl/boards/sidecar/qsfp_x32/BUILD
+++ b/hdl/boards/sidecar/qsfp_x32/BUILD
@@ -171,6 +171,7 @@ bluesim_tests('QsfpModuleControllerTests',
         'mkI2CReadTest',
         'mkI2CWriteTest',
         'mkInitializationTest',
+        'mkUninitializationAfterRemovalTest',
     ],
     deps = [
         'cobalt//hdl:Strobe',

--- a/hdl/boards/sidecar/qsfp_x32/QSFPModule/qsfp_modules_top.rdl
+++ b/hdl/boards/sidecar/qsfp_x32/QSFPModule/qsfp_modules_top.rdl
@@ -109,8 +109,20 @@ addrmap qsfp_modules_top {
         field {
             desc = "'1' if the bus is busy.";
         } BUSY[4:4] = 0;
+
+        enum error_types {
+            NoError = 4'h0 {desc = "All good!";};
+            NoModule = 4'h1 {desc = "No module found (ModPrsL = 1)";};
+            NoPower = 4'h2 {desc = "Power not enabled";};
+            PowerFault = 4'h3 {desc = "Power good timed out or lost";};
+            NotInitialized = 4'h4 {desc = "Module has not been out of reset for duration of t_init";};
+            I2cAddressNack = 4'h5 {desc = "Module nack'd the address";};
+            I2cByteNack = 4'h6 {desc = "Module nack'd a byte";};
+        };
+
         field {
-            desc = "0x0 = NoError, 0x01 = NoModule, 0x02 = NoPower, 0x03 = PowerFault, 0x04 = I2cAddressnack, 0x05 = I2cByteNack";
+            desc = "Port I2C error status";
+            encode = error_types;
         } ERROR[3:0] = 0;
     };
 

--- a/hdl/boards/sidecar/qsfp_x32/QSFPModule/test/QsfpModuleControllerTests.gtkw
+++ b/hdl/boards/sidecar/qsfp_x32/QSFPModule/test/QsfpModuleControllerTests.gtkw
@@ -1,45 +1,48 @@
 [*]
 [*] GTKWave Analyzer v3.3.100 (w)1999-2019 BSI
-[*] Fri Dec 02 20:10:23 2022
+[*] Thu Apr 20 14:17:41 2023
 [*]
-[dumpfile] "\\wsl$\Ubuntu-20.04\home\aaron\Oxide\git\quartz\build\vcd\QsfpModuleControllerTests_mkI2CReadTest.vcd"
-[dumpfile_mtime] "Fri Dec 02 20:05:11 2022"
-[dumpfile_size] 13652393
+[dumpfile] "\\wsl$\Ubuntu-20.04\home\aaron\Oxide\git\quartz\build\vcd\QsfpModuleControllerTests_mkUninitializationAfterRemovalTest.vcd"
+[dumpfile_mtime] "Thu Apr 20 14:13:56 2023"
+[dumpfile_size] 863645
 [savefile] "\\wsl$\Ubuntu-20.04\home\aaron\Oxide\git\quartz\hdl\boards\sidecar\qsfp_x32\QSFPModule\test\QsfpModuleControllerTests.gtkw"
-[timestart] 0
+[timestart] 118326
 [size] 2551 1360
 [pos] -1 -1
-*-18.518816 1177000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+*-5.925377 118720 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
 [treeopen] main.
 [treeopen] main.top.
 [sst_width] 446
 [signals_width] 526
 [sst_expanded] 1
-[sst_vpaned_height] 424
+[sst_vpaned_height] 414
 @200
 -DUT - QsfpModuleController
 -Pins
 @28
-main.top.bench_controller_present_
 main.top.bench_controller_lpmode_
-main.top.bench_controller_reset__
-main.top.bench_controller_hot_swap_enabled_r
+main.top.bench_controller_resetl_
+main.top.bench_controller_modprsl_
+main.top.bench_controller_intl_
 @200
 -
 @28
-main.top.bench_controller_hot_swap_good_r
 main.top.bench_controller_hot_swap_enabled_r
+main.top.bench_hsc_pg_r
 @200
 -
 -State
 @28
+main.top.bench_controller_i2c_attempt
+main.top.bench_controller_module_initialized_r
+@c00025
 main.top.bench_controller_error[2:0]
-@22
-main.top.bench_controller_sequence_state[3:0]
 @28
-main.top.bench_controller_fault
-main.top.bench_controller_target_power_state[2:0]
-main.top.bench_controller_current_power_state[2:0]
+(0)main.top.bench_controller_error[2:0]
+(1)main.top.bench_controller_error[2:0]
+(2)main.top.bench_controller_error[2:0]
+@1401205
+-group_end
 @200
 -
 -


### PR DESCRIPTION
Additional context here: https://github.com/oxidecomputer/hubris/issues/1299#issuecomment-1517001941

I also moved the `PortError` enum out of the BSV module and into the RDL. This will help keep our FPGA source, docs, and Rust all in sync.