### PR TITLE
Ignition: Disable power fault monitor/MAPO for Gimlet

### DIFF
--- a/hdl/boards/gimlet/ignition_target/IgnitionTargetGimlet.bsv
+++ b/hdl/boards/gimlet/ignition_target/IgnitionTargetGimlet.bsv
@@ -18,6 +18,7 @@ import IgnitionTargetWrapper::*;
 module mkGimletRevBTargetWithResetButton (IgnitionTargetTop);
     Parameters parameters = default_app_with_reset_button;
     parameters.invert_leds = True;
+    parameters.system_power_fault_monitor_enable = False;
 
     (* hide *) IgnitionTargetTopWithDebug _top <-
         mkIgnitionTargetIOAndResetWrapper(parameters);

--- a/hdl/boards/sidecar/ignition_target/IgnitionTargetSidecar.bsv
+++ b/hdl/boards/sidecar/ignition_target/IgnitionTargetSidecar.bsv
@@ -34,7 +34,7 @@ module mkSidecarRevATargetWithPowerButton (IgnitionTargetTop);
 endmodule
 
 //
-// Rev B
+// Rev B, C
 //
 
 (* default_clock_osc = "clk_50mhz", default_reset = "design_reset_l" *)

--- a/hdl/ignition/IgnitionTarget.bsv
+++ b/hdl/ignition/IgnitionTarget.bsv
@@ -311,9 +311,12 @@ module mkTarget #(Parameters parameters) (Target);
         //
         let system_power_next = system_power_r;
 
-        // Turn system power off if a power fault occurs (MAPO).
-        if (system_power_on &&
+        // Turn system power off if a power fault occurs (MAPO). Disabling this
+        // in the `parameters` structure will cause the compiler to optimize
+        // this out.
+        if (parameters.system_power_fault_monitor_enable &&
                 system_power_fault_monitor_enabled &&
+                system_power_on &&
                 system_power_fault) begin
             // Signal the Controller that an abort happened as a result of a
             // fault. This flag is only set here.


### PR DESCRIPTION
This diff disables the MAPO logic in Ignition Target for Gimlet. It seems it was never enabled for Sidecar and the PSC so it's left as is.