### PR TITLE
QSFP: Fix VSC8562 power-down sequence bug

### DIFF
--- a/hdl/boards/sidecar/qsfp_x32/QsfpX32ControllerSpiServer.bsv
+++ b/hdl/boards/sidecar/qsfp_x32/QsfpX32ControllerSpiServer.bsv
@@ -141,6 +141,8 @@ module mkSpiServer #(VSC8562::Registers vsc8562,
             ret_byte = pack(vsc8562.phy_smi_reg_addr);
         end else if (spi_request.address == fromInteger(vsc8562PhySmiCtrlOffset)) begin
             ret_byte = pack(vsc8562.phy_smi_ctrl);
+        end else if (spi_request.address == fromInteger(vsc8562PhyRailStatesOffset)) begin
+            ret_byte = pack(vsc8562.phy_rail_states);
         end else if (spi_request.address == fromInteger(qsfpI2cBusAddrOffset)) begin
             ret_byte = pack(qsfp_top.i2c_bus_addr);
         end else if (spi_request.address == fromInteger(qsfpI2cRegAddrOffset)) begin

--- a/hdl/boards/sidecar/qsfp_x32/VSC8562/test/VSC8562Tests.bsv
+++ b/hdl/boards/sidecar/qsfp_x32/VSC8562/test/VSC8562Tests.bsv
@@ -108,6 +108,12 @@ function Stmt power_up_sequence(Bench bench);
         await(bench.registers.phy_status.ready == 1);
         assert_not_set(bench.registers.phy_status.pg_timed_out,
             "PG timeout should not have ocurred during a successful power up");
+        assert_eq(unpack(bench.registers.phy_rail_states.v1p0_state),
+            Enabled,
+            "V1P0 rail should be Enabled at the end of the power up sequence.");
+        assert_eq(unpack(bench.registers.phy_rail_states.v2p5_state),
+            Enabled,
+            "V2P5 rail should be Enabled at the end of the power up sequence.");
     endseq);
 endfunction
 
@@ -187,6 +193,12 @@ module mkPowerDownTest (Empty);
             "Reset should not be released until the PHY is enabled");
         bench.v1p0_pg(False);
         bench.v2p5_pg(False);
+        assert_eq(unpack(bench.registers.phy_rail_states.v1p0_state),
+            Disabled,
+            "V1P0 rail should be Disabled at the end of the power down sequence.");
+        assert_eq(unpack(bench.registers.phy_rail_states.v2p5_state),
+            Disabled,
+            "V2P5 rail should be Disabled at the end of the power down sequence.");
         delay(5);
     endseq);
 endmodule

--- a/hdl/boards/sidecar/qsfp_x32/VSC8562/test/VSC8562Tests.gtkw
+++ b/hdl/boards/sidecar/qsfp_x32/VSC8562/test/VSC8562Tests.gtkw
@@ -1,15 +1,15 @@
 [*]
 [*] GTKWave Analyzer v3.3.100 (w)1999-2019 BSI
-[*] Wed Feb 01 20:00:14 2023
+[*] Wed Jun 14 13:21:17 2023
 [*]
-[dumpfile] "\\wsl$\Ubuntu-20.04\home\aaron\Oxide\git\quartz\build\vcd\VSC8562Tests_mkSmiTest.vcd"
-[dumpfile_mtime] "Wed Feb 01 00:25:44 2023"
-[dumpfile_size] 286073
+[dumpfile] "\\wsl$\Ubuntu-20.04\home\aaron\Oxide\git\quartz\build\vcd\VSC8562Tests_mkPowerDownTest.vcd"
+[dumpfile_mtime] "Tue Jun 13 20:38:22 2023"
+[dumpfile_size] 222530
 [savefile] "\\wsl$\Ubuntu-20.04\home\aaron\Oxide\git\quartz\hdl\boards\sidecar\qsfp_x32\VSC8562\test\VSC8562Tests.gtkw"
-[timestart] 73704
-[size] 2551 1360
+[timestart] 62742
+[size] 2194 1163
 [pos] -1 -1
-*-6.113186 74280 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+*-7.196409 63120 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
 [treeopen] main.
 [treeopen] main.top.
 [sst_width] 446
@@ -40,11 +40,6 @@ main.top.bench_dut_phy_ready
 main.top.bench_dut_coma_mode
 main.top.bench_dut_smi_ctrl[7:0]
 main.top.bench_dut_smi_busy
-@22
-main.top.bench_dut_smi_wdata_h[7:0]
-main.top.bench_dut_smi_wdata_l[7:0]
-main.top.bench_dut_smi_rdata_h[7:0]
-main.top.bench_dut_smi_rdata_l[7:0]
 @200
 -SMI (MDIO)
 @22
@@ -60,6 +55,10 @@ main.top.bench_dut_v1p0_clear_w
 main.top.bench_dut_v1p0_enabled_r
 main.top.bench_dut_v1p0_fault
 main.top.bench_dut_v1p0_good
+main.top.bench_dut_v1p0_timeout_q
+main.top.bench_dut_v1p0_vrhot
+@25
+main.top.bench_dut_v1p0_state_r[2:0]
 @200
 -
 -V2P5 Supply
@@ -68,6 +67,10 @@ main.top.bench_dut_v2p5_clear_w
 main.top.bench_dut_v2p5_enabled_r
 main.top.bench_dut_v2p5_fault
 main.top.bench_dut_v2p5_good
+main.top.bench_dut_v2p5_timeout_q
+main.top.bench_dut_v2p5_vrhot
+@24
+main.top.bench_dut_v2p5_state_r[2:0]
 @200
 -
 -MDIO Model

--- a/hdl/boards/sidecar/qsfp_x32/VSC8562/vsc8562.rdl
+++ b/hdl/boards/sidecar/qsfp_x32/VSC8562/vsc8562.rdl
@@ -29,7 +29,7 @@ addrmap vsc8562 {
         } READY[6:6] = 0;
 
         field {
-            desc = "Value inverted to drive  FPGA1_TO_PHY_RESET_L.";
+            desc = "Value of FPGA1_TO_PHY_RESET_L";
         } RESET[5:5] = 0;
 
         field {
@@ -57,11 +57,19 @@ addrmap vsc8562 {
         name = "Control bits related to VSC8562  (valid on FPGA1 only)";
 
         field {
+            desc = "Software control for the FPGA1_TO_PHY_RESET_L net. Only effective after PHY initialization.";
+        } RESET[4:4] = 0;
+
+        field {
+            desc = "Software control for the FPGA1_TO_PHY_REFCLK_EN net. Only effective after PHY initialization.";
+        } REFCLK_EN[3:3] = 1;
+
+        field {
             desc = "Setting this bit to 1 will clear the timed out state of the V1P0 and V2P5 rail controllers, allowing PHY power sequencing to be attempted again.";
         } CLEAR_POWER_FAULT[2:2] = 0;
 
         field {
-            desc = "Software control for the COMA_MODE pin.";
+            desc = "Software control for the FPGA1_TO_PHY_COMA_MODE net. Only effective after PHY initialization.";
         } COMA_MODE[1:1] = 1;
 
         field {
@@ -146,4 +154,17 @@ addrmap vsc8562 {
             desc = "Read = 0, Write = 1";
         } RW[0:0] = 0;
     } PHY_SMI_CTRL;
+
+    reg {
+        name = "PHY PowerRail state (internal to FPGA)";
+        default sw = r;
+
+        field {
+            desc = "0x0 = Disabled, 0x1 = RampingUp, 0x2 = TimedOut, 0x3 = Aborted, 0x4 = Enabled";
+        } V2P5_STATE[6:4] = 0;
+
+        field {
+            desc = "0x0 = Disabled, 0x1 = RampingUp, 0x2 = TimedOut, 0x3 = Aborted, 0x4 = Enabled";
+        } V1P0_STATE[2:0] = 0;
+    } PHY_RAIL_STATES;
 };

--- a/hdl/boards/sidecar/qsfp_x32/qsfp_x32_controller.rdl
+++ b/hdl/boards/sidecar/qsfp_x32/qsfp_x32_controller.rdl
@@ -126,11 +126,11 @@ addrmap qsfp_x32_controller {
     // VSC8562
     //
 
-    vsc8562 VSC8562;
+    vsc8562 VSC8562 @0x0100;
 
     //
     // QSFP Modules
     //
 
-    qsfp_modules_top QSFP;
+    qsfp_modules_top QSFP @0x1000;
 };


### PR DESCRIPTION
We have a small module called `PowerRail.bsv` that provides a small state machine and error reporting for power rails. There is a small bug in the VSC8562 power-down sequence where I was not "disabling" the V2P5 `PowerRail`. In practice this works because the V1P0 Power Good acts as the enable to the V2P5 rail on the board, but it does lead to the internal `PowerRail` state being confused as it had not been told that the rail would be disabled, leading it to enter the `Aborted` state (Power Good was lost, but the rail was still enabled). Improving the simulation to test for this catches the issue:
```
aaron@Aaron-Lenovo:~/Oxide/git/quartz/build$ ./cobble bluesim_test //hdl/boards/sidecar/qsfp_x32:VSC8562Tests_mkPowerDownTest --vcd-always
1 query result(s)
[3/3] BLUESIM env/1031c685e6256807a2cc3bab0adbd3d9d867a24d/hdl/boards/sidecar/qsfp_x32/mkPowerDownTest.ba
                        //hdl/boards/sidecar/qsfp_x32:VSC8562Tests
  FAIL   (0:00:00.171)   .. mkPowerDownTest
 expected: Disabled
 actual: Aborted
 Dynamic assertion failed: "../hdl/boards/sidecar/qsfp_x32/VSC8562/test/VSC8562Tests.bsv", line 201, column 13
 V2P5 rail should be Disabled at the end of the power down sequence.
 ```

Disabling the V2P5 `PowerRail` as part of the sequence (see line 219 of `VSC8562.bsv` below) fixes this behavior.

Additionally, I added a `PHY_RAIL_STATES` register to the SPI interface which exposes the value of both `PowerRail::State` values.