### PR TITLE
Add nic pwren readback for c and newer gimlets

### DIFF
--- a/hdl/projects/gimlet/sequencer/A0Block.bsv
+++ b/hdl/projects/gimlet/sequencer/A0Block.bsv
@@ -102,6 +102,7 @@ import PowerRail::*;
 
     interface FpgaSP3;
         // From SP3
+        method Action sp3_to_sp_nic_pwren_l(Bit#(1) value);
         method Action sp3_to_seq_pwrgd_out(Bit#(1) value);
         method Action sp3_to_seq_slp_s3_l(Bit#(1) value);
         method Action sp3_to_seq_slp_s5_l(Bit#(1) value);
@@ -117,6 +118,7 @@ import PowerRail::*;
 
     interface SP3;
         // From SP3
+        method Bit#(1) sp3_to_sp_nic_pwren_l();
         method Bit#(1) sp3_to_seq_pwrgd_out();
         method Bit#(1) sp3_to_seq_slp_s3_l();
         method Bit#(1) sp3_to_seq_slp_s5_l();
@@ -132,6 +134,7 @@ import PowerRail::*;
 
     instance Connectable#(FpgaSP3, SP3);
         module mkConnection#(FpgaSP3 source, SP3 sink) (Empty);
+            mkConnection(source.sp3_to_sp_nic_pwren_l, sink.sp3_to_sp_nic_pwren_l);
             mkConnection(source.sp3_to_seq_pwrgd_out, sink.sp3_to_seq_pwrgd_out);
             mkConnection(source.sp3_to_seq_slp_s3_l, sink.sp3_to_seq_slp_s3_l);
             mkConnection(source.sp3_to_seq_slp_s5_l, sink.sp3_to_seq_slp_s5_l);
@@ -255,6 +258,7 @@ module mkA0BlockSeq#(Integer one_ms_counts)(A0BlockTop);
     Reg#(Bit#(1)) pwr_cont2_sp3_nvrhot <- mkDWire(1);
     Wire#(Bit#(1)) sp3_to_seq_thermtrip_l <- mkDWire(1);
     Wire#(Bit#(1)) sp3_to_seq_fsr_req_l <- mkDWire(1);
+    Wire#(Bit#(1)) sp3_to_sp_nic_pwren_l <- mkDWire(1);
 
     // Edge registers
     Reg#(Bit#(1)) sp3_to_seq_pwrok_last <- mkReg(0);
@@ -596,6 +600,7 @@ module mkA0BlockSeq#(Integer one_ms_counts)(A0BlockTop);
             slp_s3: ~sp3_to_seq_slp_s3_l 
         };
         amd_status <= AmdStatus {
+            nic_pwren: ~sp3_to_sp_nic_pwren_l,
             pwrgd_out: sp3_to_seq_pwrgd_out,
             fsr_req: ~sp3_to_seq_fsr_req_l,
             thermtrip: ~sp3_to_seq_thermtrip_l
@@ -611,6 +616,7 @@ module mkA0BlockSeq#(Integer one_ms_counts)(A0BlockTop);
     interface A0Pins pins;
         interface FpgaSP3 sp3;
             // From SP3
+            method sp3_to_sp_nic_pwren_l = sp3_to_sp_nic_pwren_l._write;
             method sp3_to_seq_pwrgd_out = sp3_to_seq_pwrgd_out._write;
             method sp3_to_seq_slp_s3_l = sp3_to_seq_slp_s3_l._write;
             method sp3_to_seq_slp_s5_l = sp3_to_seq_slp_s5_l._write;
@@ -834,6 +840,8 @@ module mkSP3Model(SP3Model);
     Reg#(Bit#(1)) sp3_to_seq_reset_v3p3_l <- mkReg(0);
     Reg#(Bit#(1)) sp3_to_seq_thermtrip_l <- mkReg(1);
     Reg#(Bit#(1)) sp3_to_seq_fsr_req_l <- mkReg(1);
+    Reg#(Bit#(1)) sp3_to_sp_nic_pwren_l <- mkReg(1);
+    
     // To SP3
     Wire#(Bit#(1)) seq_to_sp3_sys_rst_l <- mkDWire(1);
     Wire#(Bit#(1)) seq_to_sp3_pwr_btn_l <- mkDWire(1);
@@ -931,6 +939,7 @@ module mkSP3Model(SP3Model);
         method sp3_to_seq_reset_v3p3_l = sp3_to_seq_reset_v3p3_l._read;
         method sp3_to_seq_thermtrip_l = sp3_to_seq_thermtrip_l._read;
         method sp3_to_seq_fsr_req_l = sp3_to_seq_fsr_req_l._read;
+        method sp3_to_sp_nic_pwren_l = sp3_to_sp_nic_pwren_l._read;
         // To SP3
         method seq_to_sp3_sys_rst_l = seq_to_sp3_sys_rst_l._write;
         method seq_to_sp3_pwr_btn_l = seq_to_sp3_pwr_btn_l._write;

--- a/hdl/projects/gimlet/sequencer/GimletTopIOSync.bsv
+++ b/hdl/projects/gimlet/sequencer/GimletTopIOSync.bsv
@@ -40,6 +40,8 @@ interface InPins;
     (* prefix = "" *)
     method Action pwr_cont_nic_pg0((* port="pwr_cont_nic_pg0" *) Bit#(1) value);
     (* prefix = "" *)
+    method Action sp3_to_sp_nic_pwren_l((* port="sp3_to_sp_nic_pwren_l" *) Bit#(1) value);
+    (* prefix = "" *)
     method Action nic_to_seq_v1p5d_pg((* port="nic_to_seq_v1p5d_pg" *) Bit#(1) value);
     (* prefix = "" *)
     method Action nic_to_seq_v1p5a_pg((* port="nic_to_seq_v1p5a_pg" *) Bit#(1) value);
@@ -153,6 +155,7 @@ interface InPinsReversed;
     method Bit#(1) seq_rev_id2();
     method Bit#(1) pwr_cont_nic_pg1();
     method Bit#(1) pwr_cont_nic_pg0();
+    method Bit#(1) sp3_to_sp_nic_pwren_l();
     method Bit#(1) nic_to_seq_v1p5d_pg();
     method Bit#(1) nic_to_seq_v1p5a_pg();
     method Bit#(1) nic_to_seq_v1p2_pg();
@@ -317,6 +320,7 @@ module mkGimletSeqTop (SeqPins);
 
     // A0 input connections
     // from sp3
+    mkConnection(sync.syncd.sp3_to_sp_nic_pwren_l, inner.a0_pins.sp3.sp3_to_sp_nic_pwren_l);
     mkConnection(sync.syncd.sp3_to_seq_pwrgd_out, inner.a0_pins.sp3.sp3_to_seq_pwrgd_out);
     mkConnection(sync.syncd.sp3_to_seq_slp_s3_l, inner.a0_pins.sp3.sp3_to_seq_slp_s3_l);
     mkConnection(sync.syncd.sp3_to_seq_slp_s5_l, inner.a0_pins.sp3.sp3_to_seq_slp_s5_l);
@@ -395,6 +399,7 @@ module mkGimletSeqTop (SeqPins);
         method seq_rev_id2 = sync.pins.seq_rev_id2;
         method pwr_cont_nic_pg1 = sync.pins.pwr_cont_nic_pg1;
         method pwr_cont_nic_pg0 = sync.pins.pwr_cont_nic_pg0;
+        method sp3_to_sp_nic_pwren_l = sync.pins.sp3_to_sp_nic_pwren_l;
         method nic_to_seq_v1p5d_pg = sync.pins.nic_to_seq_v1p5d_pg;
         method nic_to_seq_v1p5a_pg = sync.pins.nic_to_seq_v1p5a_pg;
         method nic_to_seq_v1p2_pg = sync.pins.nic_to_seq_v1p2_pg;
@@ -513,6 +518,7 @@ module mkInputSync(InputSync);
     SyncBitIfc#(Bit#(1)) seq_rev_id2 <- mkSyncBit1(clk_sys, rst_sys, clk_sys);
     SyncBitIfc#(Bit#(1)) pwr_cont_nic_pg1 <- mkSyncBit1(clk_sys, rst_sys, clk_sys);
     SyncBitIfc#(Bit#(1)) pwr_cont_nic_pg0 <- mkSyncBit1(clk_sys, rst_sys, clk_sys);
+    SyncBitIfc#(Bit#(1)) sp3_to_sp_nic_pwren_l <- mkSyncBit1(clk_sys, rst_sys, clk_sys);
     SyncBitIfc#(Bit#(1)) nic_to_seq_v1p5d_pg <- mkSyncBit1(clk_sys, rst_sys, clk_sys);
     SyncBitIfc#(Bit#(1)) nic_to_seq_v1p5a_pg <- mkSyncBit1(clk_sys, rst_sys, clk_sys);
     SyncBitIfc#(Bit#(1)) nic_to_seq_v1p2_pg <- mkSyncBit1(clk_sys, rst_sys, clk_sys);
@@ -573,6 +579,7 @@ module mkInputSync(InputSync);
         method seq_rev_id2 = seq_rev_id2.send;
         method pwr_cont_nic_pg1 = pwr_cont_nic_pg1.send;
         method pwr_cont_nic_pg0 = pwr_cont_nic_pg0.send;
+        method sp3_to_sp_nic_pwren_l = sp3_to_sp_nic_pwren_l.send;
         method nic_to_seq_v1p5d_pg = nic_to_seq_v1p5d_pg.send;
         method nic_to_seq_v1p5a_pg = nic_to_seq_v1p5a_pg.send;
         method nic_to_seq_v1p2_pg = nic_to_seq_v1p2_pg.send;
@@ -633,6 +640,7 @@ module mkInputSync(InputSync);
         method seq_rev_id2 = seq_rev_id2.read;
         method pwr_cont_nic_pg1 = pwr_cont_nic_pg1.read;
         method pwr_cont_nic_pg0 = pwr_cont_nic_pg0.read;
+        method sp3_to_sp_nic_pwren_l = sp3_to_sp_nic_pwren_l.read;
         method nic_to_seq_v1p5d_pg = nic_to_seq_v1p5d_pg.read;
         method nic_to_seq_v1p5a_pg = nic_to_seq_v1p5a_pg.read;
         method nic_to_seq_v1p2_pg = nic_to_seq_v1p2_pg.read;

--- a/hdl/projects/gimlet/sequencer/gimlet_seq_fpga_regs.rdl
+++ b/hdl/projects/gimlet/sequencer/gimlet_seq_fpga_regs.rdl
@@ -517,6 +517,14 @@ addrmap gimlet_seq_fpga {
     reg {
         name = "General AMD readbacks";
         field {
+            desc = "NIC_PWREN (inversion of net SP3_TO_SP_NIC_PWREN_L), available on C and newer Gimlets.
+                   When Asserted high in this register, the net is active low, and NIC power is expected to
+                   be commanded on by Hubris (see NIC_CTRL register).  This is a readback-only view, no 
+                   autonomous FPGA action occurs on the status of this pin, Hubris also monitors and takes
+                   action.  Only valid in A0 and higher power states but is a simple pass-through in the
+                   FPGA, no gating logic";
+        } NIC_PWREN[1] = 0;
+        field {
             desc = "inverted CPU's thermtrip_L, 500ms to shut down power planes into S5 state. De-assertion of PWROK resets THERMTRIP_L";
         } THERMTRIP[1] = 0;
         field {

--- a/hdl/projects/gimlet/sequencer/gimlet_sequencer.pcf
+++ b/hdl/projects/gimlet/sequencer/gimlet_sequencer.pcf
@@ -21,6 +21,7 @@ set_io --warn-no-port nic_to_seq_ext_rst_l C13
 set_io --warn-no-port pwr_cont_nic_en1 C16
 set_io --warn-no-port seq_to_nic_v1p5d_en D1
 set_io --warn-no-port seq_to_clk_nmr_l D2
+set_io --warn-no-port sp3_to_sp_nic_pwren_l D4
 #set_io --warn-no-port nic_to_seq_v1p1_pg D14
 set_io --warn-no-port fanhp_to_seq_fault_l D15
 set_io --warn-no-port fanhp_to_seq_pwrgd D16


### PR DESCRIPTION
This wires a new pin to from FPGA pin D4 to the AMD_STATUS register for increased observability on the `sp3_to_sp_nic_pwren_l`.

Fixes #129 .