### PR TITLE
Remove spurious ieee warnings from simulator output

### DIFF
--- a/tools/vunit_gen/templates/run_py.jinja2
+++ b/tools/vunit_gen/templates/run_py.jinja2
@@ -50,7 +50,6 @@ vu.add_json4vhdl()
 vu.add_osvvm()
 vu.add_random()
 vu.add_verification_components()
-
 # Create libraries
 {% for library in libraries %}
 {{library.name}} = vu.add_library("{{library.name}}")
@@ -67,5 +66,7 @@ vu.add_verification_components()
 {% endfor %}
 {% endif %}
 
+# Disable annoying ieee warnings across VUnit-supported simulators
+vu.set_sim_option("disable_ieee_warnings", True)
 # Run vunit function
 vu.main()


### PR DESCRIPTION
This removes a lot of noise during simulation when stuff that is 'U' is compared by logic. Until reset, these are extremely annoying and add little value.

This hooks into VUnit's simulator interface so should work for any simulator VUnit supports