### PR TITLE
Small adjustments to low-speed module signals

### DIFF
--- a/hdl/ip/bsv/Debouncer.bsv
+++ b/hdl/ip/bsv/Debouncer.bsv
@@ -109,6 +109,22 @@ instance Connectable#(PulseWire, Debouncer#(assert_duration,
     endmodule
 endinstance
 
+// Implementing connecting a Wire#(Bool) to a Debouncer as a convenience.
+instance Connectable#(Wire#(Bool), Debouncer#(assert_duration,
+                                            deassert_duration,
+                                            one_bit_type));
+    module mkConnection#(Wire#(Bool) w,
+                        Debouncer#(assert_duration,
+                                    deassert_duration,
+                                    one_bit_type) debouncer)
+                        (Empty);
+        (* fire_when_enabled *)
+        rule do_send (w);
+            debouncer.send();
+        endrule
+    endmodule
+endinstance
+
 // mkDebouncerTest
 //
 // This is a basic test suite which validates that the output does not follow

--- a/hdl/projects/sidecar/qsfp_x32/BUILD
+++ b/hdl/projects/sidecar/qsfp_x32/BUILD
@@ -56,6 +56,7 @@ bluespec_library('QsfpModuleController',
         '//hdl/ip/bsv:PowerRail',
         '//hdl/ip/bsv/I2C:I2CCore',
         '//hdl/ip/bsv:Bidirection',
+        '//hdl/ip/bsv:Debouncer',
     ])
 
 
@@ -153,6 +154,9 @@ bluesim_tests('QsfpModuleControllerTests',
     env = '//bluesim_default',
     suite = 'QSFPModule/test/QsfpModuleControllerTests.bsv',
     modules = [
+        'mkIntLTest',
+        'mkModPrsLTest',
+        'mkNoLPModeWhenModuleIsUnpoweredTest',
         'mkNoModuleTest',
         'mkNoPowerTest',
         'mkRemovePowerEnableTest',

--- a/hdl/projects/sidecar/qsfp_x32/QSFPModule/test/QsfpModuleControllerTests.bsv
+++ b/hdl/projects/sidecar/qsfp_x32/QSFPModule/test/QsfpModuleControllerTests.bsv
@@ -47,12 +47,6 @@ function Action check_peripheral_event(I2CPeripheralModel peripheral,
 // The Bench is what is accessed in the unit tests themselves. All interaction
 // with the DUT is done through this interface.
 interface Bench;
-    // QSFP module low speed pins
-    method Bit#(1) lpmode;
-    method Bit#(1) resetl;
-    method Action intl(Bit#(1) v);
-    method Action modprsl(Bit#(1) v);
-
     // The SPI register interface for the controller
     interface Registers registers;
 
@@ -62,15 +56,37 @@ interface Bench;
     // A way to expose if the I2C read/write is finished
     method Bool i2c_busy();
 
-    // Control of the hot swap power good pin
-    method Action power_en(Bit#(1) v);
-    method Action hsc_pg(Bit#(1) v);
+    // Control of the hot swap power enable pin
+    method Action set_power_en(Bit#(1) v);
+    // Readback of the enable pin
     method Bool hsc_en;
+    // Control of the hot swap power good pin
+    method Action set_hsc_pg(Bit#(1) v);
+    // Readback of the enable pin
+    method Bool hsc_pg;
+
     method Bool hsc_pg_timeout;
     method Bool hsc_pg_lost;
 
-    // Control of ModResetL
+    // Control of ModResetL for the bench
     method Action set_resetl(Bit#(1) v);
+    // Readback of ModResetL pin
+    method Bit#(1) resetl;
+
+    // Control of LPMode/TxDis for the bench
+    method Action set_lpmode(Bit#(1) v);
+    // Readback of LPMode pin
+    method Bit#(1) lpmode;
+
+    // Control of IntL for the bench
+    method Action set_intl(Bit#(1) v);
+    // Readback of IntL pin
+    method Bit#(1) intl;
+
+    // Control of ModPrsL for the bench
+    method Action set_modprsl(Bit#(1) v);
+    // Readback of ModPrsL pin
+    method Bit#(1) modprsl;
 
     // Expose if the module has been initialized or not
     method Bool module_initialized;
@@ -89,13 +105,15 @@ module mkBench (Bench);
 
     // Some registers for setting outputs
     Reg#(Bit#(1)) resetl_r   <- mkReg(0); // 0 as it is pulled down on board
+    Reg#(Bit#(1)) lpmode_r <- mkReg(0);
     mkConnection(controller.resetl, resetl_r);
+    mkConnection(controller.lpmode, lpmode_r);
 
     // Hot swap
     Reg#(Bit#(1)) power_en_r  <- mkReg(1);
     Reg#(Bool) hsc_pg_r     <- mkReg(False);
     mkConnection(controller.power_en, power_en_r);
-    mkConnection(controller.pins.hsc.pg, hsc_pg_r);
+    mkConnection(controller.pins.power_good, hsc_pg_r);
 
     Strobe#(16) tick_1khz   <-
         mkLimitStrobe(1, qsfp_test_params.system_frequency_hz / 1000, 0);
@@ -196,26 +214,37 @@ module mkBench (Bench);
         end
     endmethod
 
-    method lpmode = controller.pins.lpmode;
+    method intl = pack(controller.intl);
+    method modprsl = pack(controller.modprsl);
     method resetl = controller.pins.resetl;
-    method Action intl(Bit#(1) v);
+    method lpmode = controller.pins.lpmode;
+
+    method Action set_intl(Bit#(1) v);
         intl_r <= v;
     endmethod
-    method Action modprsl(Bit#(1) v);
+
+    method Action set_modprsl(Bit#(1) v);
         modprsl_r <= v;
     endmethod
 
-    method Action power_en(Bit#(1) v);
-        power_en_r <= v;
-    endmethod
-    method Action hsc_pg(Bit#(1) v);
-        hsc_pg_r <= unpack(v);
-    endmethod
     method Action set_resetl(Bit#(1) v);
         resetl_r    <= v;
     endmethod
 
-    method hsc_en = controller.pins.hsc.en;
+    method Action set_lpmode(Bit#(1) v);
+        lpmode_r    <= v;
+    endmethod
+
+    method Action set_power_en(Bit#(1) v);
+        power_en_r <= v;
+    endmethod
+
+    method Action set_hsc_pg(Bit#(1) v);
+        hsc_pg_r <= unpack(v);
+    endmethod
+
+    method hsc_en = controller.pins.power_en;
+    method hsc_pg = controller.pg;
     method hsc_pg_timeout = controller.pg_timeout;
     method hsc_pg_lost = controller.pg_lost;
 
@@ -227,12 +256,16 @@ function Stmt insert_and_power_module(Bench bench);
         // insert a module, which tells the controller to enable power
         assert_false(bench.hsc_en(),
             "Hot swap should not be enabled when module is not present");
-        bench.modprsl(0);
+        bench.set_modprsl(0);
+        // modprsl is debounced, so wait for it to transition
+        await(bench.modprsl == 0);
         delay(5);
         assert_true(bench.hsc_en(),
             "Hot swap should be enabled when module is present");
         // after some delay, give the controller power good
-        bench.hsc_pg(1);
+        bench.set_hsc_pg(1);
+        // power good is debounced, so wait for it to transition
+        await(bench.hsc_pg);
         delay(5);
     endseq);
 endfunction
@@ -270,7 +303,7 @@ module mkNoModuleTest (Empty);
                 reg_addr: 8'h00,
                 num_bytes: 1
             });
-        delay(2);
+        delay(5);
         assert_eq(unpack(bench.registers.port_status.error[2:0]),
             NoModule,
             "NoModule error should be present when attempting to communicate with a device which is not present.");
@@ -288,7 +321,7 @@ module mkNoPowerTest (Empty);
 
     mkAutoFSM(seq
         delay(5);
-        bench.modprsl(0);
+        bench.set_modprsl(0);
         await(bench.hsc_en());
         bench.command(Command {
                 op: Read,
@@ -296,7 +329,7 @@ module mkNoPowerTest (Empty);
                 reg_addr: 8'h00,
                 num_bytes: 1
             });
-        delay(2);
+        delay(5);
         assert_eq(unpack(bench.registers.port_status.error[2:0]),
             NoPower,
             "NoPower error should be present when attempting to communicate before the hot swap is stable.");
@@ -322,13 +355,16 @@ module mkRemovePowerEnableTest (Empty);
                 reg_addr: 8'h00,
                 num_bytes: 1
             });
-        delay(2);
+        delay(5);
         assert_eq(unpack(bench.registers.port_status.error[2:0]),
             NoError,
             "NoPower should be present when attempting to communicate when the hot swap is stable.");
-        bench.power_en(0);
+        bench.set_power_en(0);
         delay(2);
-        bench.hsc_pg(0);
+        bench.set_hsc_pg(0);
+        // power good is debounced and thus won't transition immediately
+        await(!bench.hsc_pg);
+        delay(3);
         assert_eq(bench.hsc_en(), False, "Expect hot swap to no longer be enabled.");
         delay(5);
     endseq);
@@ -343,7 +379,7 @@ module mkPowerGoodTimeoutTest (Empty);
 
     mkAutoFSM(seq
         delay(5);
-        bench.modprsl(0);
+        bench.set_modprsl(0);
         await(bench.hsc_pg_timeout());
         bench.command(Command {
                 op: Read,
@@ -351,7 +387,7 @@ module mkPowerGoodTimeoutTest (Empty);
                 reg_addr: 8'h00,
                 num_bytes: 1
             });
-        delay(2);
+        delay(5);
         assert_eq(unpack(bench.registers.port_status.error[2:0]),
             PowerFault,
             "PowerFault error should be present when attempting to communicate after the hot swap has timed out");
@@ -369,14 +405,16 @@ module mkPowerGoodLostTest (Empty);
     mkAutoFSM(seq
         delay(5);
         add_and_initialize_module(bench);
-        bench.hsc_pg(0);
+        bench.set_hsc_pg(0);
+        // power good is debounced and thus won't transition immediately
+        await(!bench.hsc_pg);
         bench.command(Command {
                 op: Read,
                 i2c_addr: i2c_test_params.peripheral_addr,
                 reg_addr: 8'h00,
                 num_bytes: 1
             });
-        delay(2);
+        delay(5);
         assert_eq(unpack(bench.registers.port_status.error[2:0]),
             PowerFault,
             "PowerFault error should be present when attempting to communicate after the hot swap has aborted");
@@ -452,6 +490,7 @@ module mkInitializationTest (Empty);
         bench.set_resetl(1);
         bench.command(read_cmd);
         await(!bench.i2c_busy());
+        delay(3);
         assert_eq(unpack(bench.registers.port_status.error[2:0]),
             NotInitialized,
             "NotInitialized error should be present when attempting to communicate before t_init has elapsed.");
@@ -459,6 +498,7 @@ module mkInitializationTest (Empty);
         deassert_reset_and_await_init(bench);
         bench.command(read_cmd);
         await(!bench.i2c_busy());
+        delay(3);
         assert_eq(unpack(bench.registers.port_status.error[2:0]),
             NoError,
             "NoError should be present when attempting to communicate after t_init has elapsed.");
@@ -466,6 +506,7 @@ module mkInitializationTest (Empty);
         bench.set_resetl(0);
         bench.command(read_cmd);
         await(!bench.i2c_busy());
+        delay(3);
         assert_eq(unpack(bench.registers.port_status.error[2:0]),
             NotInitialized,
             "NotInitialized error should be present when resetl is asserted.");
@@ -496,14 +537,79 @@ module mkUninitializationAfterRemovalTest (Empty);
             NoError,
             "NoError should be present when attempting to communicate after t_init has elapsed.");
 
-        bench.modprsl(1);
-        bench.modprsl(0);
+        bench.set_modprsl(1);
+        // ModPrsL is debounced and thus won't transition immediately
+        await(bench.modprsl == 1);
+        bench.set_modprsl(0);
+        await(bench.modprsl == 0);
         delay(3); // wait a few cycles for power to re-enable
         bench.command(read_cmd);
+
         await(!bench.i2c_busy());
-                assert_eq(unpack(bench.registers.port_status.error[2:0]),
+        delay(3);
+        assert_eq(unpack(bench.registers.port_status.error[2:0]),
             NotInitialized,
             "NotInitialized error should be present when a module has been reseated but not initialized.");
+    endseq);
+endmodule
+
+// mkNoLPModeWhenModuleIsUnpoweredTest
+//
+// This test checks that hardware gating of the LPMode signal is working to
+// override SW setting LPMode when a module has not been powered. Details on
+// why we do this: https://github.com/oxidecomputer/hardware-qsfp-x32/issues/47
+module mkNoLPModeWhenModuleIsUnpoweredTest (Empty);
+    Bench bench <- mkBench();
+
+    mkAutoFSM(seq
+        bench.set_lpmode(0);
+        delay(3);
+        assert_not_set(bench.lpmode, "LpMode should be deasserted when set to 0.");
+
+        bench.set_lpmode(1); // SW attempts to assert LPMode
+        delay(3);
+        assert_not_set(bench.lpmode, "LpMode should be deasserted when a module is not present and powered.");
+
+        bench.set_modprsl(0); // insert a module
+        await(bench.modprsl == 0); // wait out debounce
+        delay(3);
+        assert_set(bench.hsc_en, "HSC power should be enabled now that a module is present.");
+        bench.set_hsc_pg(1);
+        assert_not_set(bench.hsc_pg, "HSC PG should not be debounced yet.");
+        assert_not_set(bench.lpmode, "LpMode should be deasserted when a module is not present and powered.");
+
+        await(bench.hsc_pg); // wait out debounce
+        assert_set(bench.lpmode, "LpMode should be asserted now that 3.3V is up.");
+    endseq);
+endmodule
+
+// mkIntLTest
+//
+// This test ensures that the IntL input pin is properly reflected on the
+// interface.
+module mkIntLTest (Empty);
+    Bench bench <- mkBench();
+
+    mkAutoFSM(seq
+        assert_set(bench.intl, "IntL's default state should be pulled up.");
+        bench.set_intl(0);
+        await(bench.intl == 0);
+        assert_not_set(bench.intl, "IntL should be low after debounce");
+    endseq);
+endmodule
+
+// mkModPrsLTest
+//
+// This test ensures that the ModPrsL input pin is properly reflected on the
+// interface.
+module mkModPrsLTest (Empty);
+    Bench bench <- mkBench();
+
+    mkAutoFSM(seq
+        assert_set(bench.modprsl, "ModPrsL's default state should be pulled up.");
+        bench.set_modprsl(0);
+        await(bench.modprsl == 0);
+        assert_not_set(bench.modprsl, "ModPrsL should be low after debounce");
     endseq);
 endmodule
 

--- a/hdl/projects/sidecar/qsfp_x32/QsfpX32ControllerTop.bsv
+++ b/hdl/projects/sidecar/qsfp_x32/QsfpX32ControllerTop.bsv
@@ -243,10 +243,10 @@ module mkQsfpX32ControllerTop (QsfpControllerTop);
     //
 
     // P0
-    ReadOnly#(Bool) qsfp0_hsc_en        <- mkOutputSyncFor(controller.qsfp[0].hsc.en);
+    ReadOnly#(Bool) qsfp0_hsc_en        <- mkOutputSyncFor(controller.qsfp[0].power_en);
     ReadOnly#(Bit#(1)) qsfp0_lpmode     <- mkOutputSyncFor(controller.qsfp[0].lpmode);
     ReadOnly#(Bit#(1)) qsfp0_resetl     <- mkOutputSyncFor(controller.qsfp[0].resetl);
-    InputReg#(Bool, 2) qsfp0_hsc_pg     <- mkInputSyncFor(controller.qsfp[0].hsc.pg);
+    InputReg#(Bool, 2) qsfp0_hsc_pg     <- mkInputSyncFor(controller.qsfp[0].power_good);
     InputReg#(Bit#(1), 2) qsfp0_intl    <- mkInputSyncFor(controller.qsfp[0].intl);
     InputReg#(Bit#(1), 2) qsfp0_modprsl <- mkInputSyncFor(controller.qsfp[0].modprsl);
     ReadOnly#(Bool) qsfp0_scl_out_en    <- mkOutputSyncFor(controller.qsfp[0].scl.out_en);
@@ -261,10 +261,10 @@ module mkQsfpX32ControllerTop (QsfpControllerTop);
     mkConnection(sync(qsfp0_sda_in), qsfp0_sda._read);
 
     // P1
-    ReadOnly#(Bool) qsfp1_hsc_en        <- mkOutputSyncFor(controller.qsfp[1].hsc.en);
+    ReadOnly#(Bool) qsfp1_hsc_en        <- mkOutputSyncFor(controller.qsfp[1].power_en);
     ReadOnly#(Bit#(1)) qsfp1_lpmode     <- mkOutputSyncFor(controller.qsfp[1].lpmode);
     ReadOnly#(Bit#(1)) qsfp1_resetl     <- mkOutputSyncFor(controller.qsfp[1].resetl);
-    InputReg#(Bool, 2) qsfp1_hsc_pg     <- mkInputSyncFor(controller.qsfp[1].hsc.pg);
+    InputReg#(Bool, 2) qsfp1_hsc_pg     <- mkInputSyncFor(controller.qsfp[1].power_good);
     InputReg#(Bit#(1), 2) qsfp1_intl    <- mkInputSyncFor(controller.qsfp[1].intl);
     InputReg#(Bit#(1), 2) qsfp1_modprsl <- mkInputSyncFor(controller.qsfp[1].modprsl);
     ReadOnly#(Bool) qsfp1_scl_out_en    <- mkOutputSyncFor(controller.qsfp[1].scl.out_en);
@@ -279,10 +279,10 @@ module mkQsfpX32ControllerTop (QsfpControllerTop);
     mkConnection(sync(qsfp1_sda_in), qsfp1_sda._read);
 
     // P2
-    ReadOnly#(Bool) qsfp2_hsc_en        <- mkOutputSyncFor(controller.qsfp[2].hsc.en);
+    ReadOnly#(Bool) qsfp2_hsc_en        <- mkOutputSyncFor(controller.qsfp[2].power_en);
     ReadOnly#(Bit#(1)) qsfp2_lpmode     <- mkOutputSyncFor(controller.qsfp[2].lpmode);
     ReadOnly#(Bit#(1)) qsfp2_resetl     <- mkOutputSyncFor(controller.qsfp[2].resetl);
-    InputReg#(Bool, 2) qsfp2_hsc_pg     <- mkInputSyncFor(controller.qsfp[2].hsc.pg);
+    InputReg#(Bool, 2) qsfp2_hsc_pg     <- mkInputSyncFor(controller.qsfp[2].power_good);
     InputReg#(Bit#(1), 2) qsfp2_intl    <- mkInputSyncFor(controller.qsfp[2].intl);
     InputReg#(Bit#(1), 2) qsfp2_modprsl <- mkInputSyncFor(controller.qsfp[2].modprsl);
     ReadOnly#(Bool) qsfp2_scl_out_en    <- mkOutputSyncFor(controller.qsfp[2].scl.out_en);
@@ -297,10 +297,10 @@ module mkQsfpX32ControllerTop (QsfpControllerTop);
     mkConnection(sync(qsfp2_sda_in), qsfp2_sda._read);
 
     // P3
-    ReadOnly#(Bool) qsfp3_hsc_en        <- mkOutputSyncFor(controller.qsfp[3].hsc.en);
+    ReadOnly#(Bool) qsfp3_hsc_en        <- mkOutputSyncFor(controller.qsfp[3].power_en);
     ReadOnly#(Bit#(1)) qsfp3_lpmode     <- mkOutputSyncFor(controller.qsfp[3].lpmode);
     ReadOnly#(Bit#(1)) qsfp3_resetl     <- mkOutputSyncFor(controller.qsfp[3].resetl);
-    InputReg#(Bool, 2) qsfp3_hsc_pg     <- mkInputSyncFor(controller.qsfp[3].hsc.pg);
+    InputReg#(Bool, 2) qsfp3_hsc_pg     <- mkInputSyncFor(controller.qsfp[3].power_good);
     InputReg#(Bit#(1), 2) qsfp3_intl    <- mkInputSyncFor(controller.qsfp[3].intl);
     InputReg#(Bit#(1), 2) qsfp3_modprsl <- mkInputSyncFor(controller.qsfp[3].modprsl);
     ReadOnly#(Bool) qsfp3_scl_out_en    <- mkOutputSyncFor(controller.qsfp[3].scl.out_en);
@@ -315,10 +315,10 @@ module mkQsfpX32ControllerTop (QsfpControllerTop);
     mkConnection(sync(qsfp3_sda_in), qsfp3_sda._read);
 
     // P4
-    ReadOnly#(Bool) qsfp4_hsc_en        <- mkOutputSyncFor(controller.qsfp[4].hsc.en);
+    ReadOnly#(Bool) qsfp4_hsc_en        <- mkOutputSyncFor(controller.qsfp[4].power_en);
     ReadOnly#(Bit#(1)) qsfp4_lpmode     <- mkOutputSyncFor(controller.qsfp[4].lpmode);
     ReadOnly#(Bit#(1)) qsfp4_resetl     <- mkOutputSyncFor(controller.qsfp[4].resetl);
-    InputReg#(Bool, 2) qsfp4_hsc_pg     <- mkInputSyncFor(controller.qsfp[4].hsc.pg);
+    InputReg#(Bool, 2) qsfp4_hsc_pg     <- mkInputSyncFor(controller.qsfp[4].power_good);
     InputReg#(Bit#(1), 2) qsfp4_intl    <- mkInputSyncFor(controller.qsfp[4].intl);
     InputReg#(Bit#(1), 2) qsfp4_modprsl <- mkInputSyncFor(controller.qsfp[4].modprsl);
     ReadOnly#(Bool) qsfp4_scl_out_en    <- mkOutputSyncFor(controller.qsfp[4].scl.out_en);
@@ -333,10 +333,10 @@ module mkQsfpX32ControllerTop (QsfpControllerTop);
     mkConnection(sync(qsfp4_sda_in), qsfp4_sda._read);
 
     // P5
-    ReadOnly#(Bool) qsfp5_hsc_en        <- mkOutputSyncFor(controller.qsfp[5].hsc.en);
+    ReadOnly#(Bool) qsfp5_hsc_en        <- mkOutputSyncFor(controller.qsfp[5].power_en);
     ReadOnly#(Bit#(1)) qsfp5_lpmode     <- mkOutputSyncFor(controller.qsfp[5].lpmode);
     ReadOnly#(Bit#(1)) qsfp5_resetl     <- mkOutputSyncFor(controller.qsfp[5].resetl);
-    InputReg#(Bool, 2) qsfp5_hsc_pg     <- mkInputSyncFor(controller.qsfp[5].hsc.pg);
+    InputReg#(Bool, 2) qsfp5_hsc_pg     <- mkInputSyncFor(controller.qsfp[5].power_good);
     InputReg#(Bit#(1), 2) qsfp5_intl    <- mkInputSyncFor(controller.qsfp[5].intl);
     InputReg#(Bit#(1), 2) qsfp5_modprsl <- mkInputSyncFor(controller.qsfp[5].modprsl);
     ReadOnly#(Bool) qsfp5_scl_out_en    <- mkOutputSyncFor(controller.qsfp[5].scl.out_en);
@@ -351,10 +351,10 @@ module mkQsfpX32ControllerTop (QsfpControllerTop);
     mkConnection(sync(qsfp5_sda_in), qsfp5_sda._read);
 
     // P6
-    ReadOnly#(Bool) qsfp6_hsc_en        <- mkOutputSyncFor(controller.qsfp[6].hsc.en);
+    ReadOnly#(Bool) qsfp6_hsc_en        <- mkOutputSyncFor(controller.qsfp[6].power_en);
     ReadOnly#(Bit#(1)) qsfp6_lpmode     <- mkOutputSyncFor(controller.qsfp[6].lpmode);
     ReadOnly#(Bit#(1)) qsfp6_resetl     <- mkOutputSyncFor(controller.qsfp[6].resetl);
-    InputReg#(Bool, 2) qsfp6_hsc_pg     <- mkInputSyncFor(controller.qsfp[6].hsc.pg);
+    InputReg#(Bool, 2) qsfp6_hsc_pg     <- mkInputSyncFor(controller.qsfp[6].power_good);
     InputReg#(Bit#(1), 2) qsfp6_intl    <- mkInputSyncFor(controller.qsfp[6].intl);
     InputReg#(Bit#(1), 2) qsfp6_modprsl <- mkInputSyncFor(controller.qsfp[6].modprsl);
     ReadOnly#(Bool) qsfp6_scl_out_en    <- mkOutputSyncFor(controller.qsfp[6].scl.out_en);
@@ -369,10 +369,10 @@ module mkQsfpX32ControllerTop (QsfpControllerTop);
     mkConnection(sync(qsfp6_sda_in), qsfp6_sda._read);
 
     // P7
-    ReadOnly#(Bool) qsfp7_hsc_en        <- mkOutputSyncFor(controller.qsfp[7].hsc.en);
+    ReadOnly#(Bool) qsfp7_hsc_en        <- mkOutputSyncFor(controller.qsfp[7].power_en);
     ReadOnly#(Bit#(1)) qsfp7_lpmode     <- mkOutputSyncFor(controller.qsfp[7].lpmode);
     ReadOnly#(Bit#(1)) qsfp7_resetl     <- mkOutputSyncFor(controller.qsfp[7].resetl);
-    InputReg#(Bool, 2) qsfp7_hsc_pg     <- mkInputSyncFor(controller.qsfp[7].hsc.pg);
+    InputReg#(Bool, 2) qsfp7_hsc_pg     <- mkInputSyncFor(controller.qsfp[7].power_good);
     InputReg#(Bit#(1), 2) qsfp7_intl    <- mkInputSyncFor(controller.qsfp[7].intl);
     InputReg#(Bit#(1), 2) qsfp7_modprsl <- mkInputSyncFor(controller.qsfp[7].modprsl);
     ReadOnly#(Bool) qsfp7_scl_out_en    <- mkOutputSyncFor(controller.qsfp[7].scl.out_en);
@@ -387,10 +387,10 @@ module mkQsfpX32ControllerTop (QsfpControllerTop);
     mkConnection(sync(qsfp7_sda_in), qsfp7_sda._read);
 
     // P8
-    ReadOnly#(Bool) qsfp8_hsc_en        <- mkOutputSyncFor(controller.qsfp[8].hsc.en);
+    ReadOnly#(Bool) qsfp8_hsc_en        <- mkOutputSyncFor(controller.qsfp[8].power_en);
     ReadOnly#(Bit#(1)) qsfp8_lpmode     <- mkOutputSyncFor(controller.qsfp[8].lpmode);
     ReadOnly#(Bit#(1)) qsfp8_resetl     <- mkOutputSyncFor(controller.qsfp[8].resetl);
-    InputReg#(Bool, 2) qsfp8_hsc_pg     <- mkInputSyncFor(controller.qsfp[8].hsc.pg);
+    InputReg#(Bool, 2) qsfp8_hsc_pg     <- mkInputSyncFor(controller.qsfp[8].power_good);
     InputReg#(Bit#(1), 2) qsfp8_intl    <- mkInputSyncFor(controller.qsfp[8].intl);
     InputReg#(Bit#(1), 2) qsfp8_modprsl <- mkInputSyncFor(controller.qsfp[8].modprsl);
     ReadOnly#(Bool) qsfp8_scl_out_en    <- mkOutputSyncFor(controller.qsfp[8].scl.out_en);
@@ -405,10 +405,10 @@ module mkQsfpX32ControllerTop (QsfpControllerTop);
     mkConnection(sync(qsfp8_sda_in), qsfp8_sda._read);
 
     // P9
-    ReadOnly#(Bool) qsfp9_hsc_en        <- mkOutputSyncFor(controller.qsfp[9].hsc.en);
+    ReadOnly#(Bool) qsfp9_hsc_en        <- mkOutputSyncFor(controller.qsfp[9].power_en);
     ReadOnly#(Bit#(1)) qsfp9_lpmode     <- mkOutputSyncFor(controller.qsfp[9].lpmode);
     ReadOnly#(Bit#(1)) qsfp9_resetl     <- mkOutputSyncFor(controller.qsfp[9].resetl);
-    InputReg#(Bool, 2) qsfp9_hsc_pg     <- mkInputSyncFor(controller.qsfp[9].hsc.pg);
+    InputReg#(Bool, 2) qsfp9_hsc_pg     <- mkInputSyncFor(controller.qsfp[9].power_good);
     InputReg#(Bit#(1), 2) qsfp9_intl    <- mkInputSyncFor(controller.qsfp[9].intl);
     InputReg#(Bit#(1), 2) qsfp9_modprsl <- mkInputSyncFor(controller.qsfp[9].modprsl);
     ReadOnly#(Bool) qsfp9_scl_out_en    <- mkOutputSyncFor(controller.qsfp[9].scl.out_en);
@@ -423,10 +423,10 @@ module mkQsfpX32ControllerTop (QsfpControllerTop);
     mkConnection(sync(qsfp9_sda_in), qsfp9_sda._read);
 
     // P10
-    ReadOnly#(Bool) qsfp10_hsc_en       <- mkOutputSyncFor(controller.qsfp[10].hsc.en);
+    ReadOnly#(Bool) qsfp10_hsc_en       <- mkOutputSyncFor(controller.qsfp[10].power_en);
     ReadOnly#(Bit#(1)) qsfp10_lpmode    <- mkOutputSyncFor(controller.qsfp[10].lpmode);
     ReadOnly#(Bit#(1)) qsfp10_resetl    <- mkOutputSyncFor(controller.qsfp[10].resetl);
-    InputReg#(Bool, 2) qsfp10_hsc_pg    <- mkInputSyncFor(controller.qsfp[10].hsc.pg);
+    InputReg#(Bool, 2) qsfp10_hsc_pg    <- mkInputSyncFor(controller.qsfp[10].power_good);
     InputReg#(Bit#(1), 2) qsfp10_intl   <- mkInputSyncFor(controller.qsfp[10].intl);
     InputReg#(Bit#(1), 2) qsfp10_modprsl<- mkInputSyncFor(controller.qsfp[10].modprsl);
     ReadOnly#(Bool) qsfp10_scl_out_en   <- mkOutputSyncFor(controller.qsfp[10].scl.out_en);
@@ -441,10 +441,10 @@ module mkQsfpX32ControllerTop (QsfpControllerTop);
     mkConnection(sync(qsfp10_sda_in), qsfp10_sda._read);
 
     // P11
-    ReadOnly#(Bool) qsfp11_hsc_en       <- mkOutputSyncFor(controller.qsfp[11].hsc.en);
+    ReadOnly#(Bool) qsfp11_hsc_en       <- mkOutputSyncFor(controller.qsfp[11].power_en);
     ReadOnly#(Bit#(1)) qsfp11_lpmode    <- mkOutputSyncFor(controller.qsfp[11].lpmode);
     ReadOnly#(Bit#(1)) qsfp11_resetl    <- mkOutputSyncFor(controller.qsfp[11].resetl);
-    InputReg#(Bool, 2) qsfp11_hsc_pg    <- mkInputSyncFor(controller.qsfp[11].hsc.pg);
+    InputReg#(Bool, 2) qsfp11_hsc_pg    <- mkInputSyncFor(controller.qsfp[11].power_good);
     InputReg#(Bit#(1), 2) qsfp11_intl   <- mkInputSyncFor(controller.qsfp[11].intl);
     InputReg#(Bit#(1), 2) qsfp11_modprsl<- mkInputSyncFor(controller.qsfp[11].modprsl);
     ReadOnly#(Bool) qsfp11_scl_out_en   <- mkOutputSyncFor(controller.qsfp[11].scl.out_en);
@@ -459,10 +459,10 @@ module mkQsfpX32ControllerTop (QsfpControllerTop);
     mkConnection(sync(qsfp11_sda_in), qsfp11_sda._read);
 
     // P12
-    ReadOnly#(Bool) qsfp12_hsc_en       <- mkOutputSyncFor(controller.qsfp[12].hsc.en);
+    ReadOnly#(Bool) qsfp12_hsc_en       <- mkOutputSyncFor(controller.qsfp[12].power_en);
     ReadOnly#(Bit#(1)) qsfp12_lpmode    <- mkOutputSyncFor(controller.qsfp[12].lpmode);
     ReadOnly#(Bit#(1)) qsfp12_resetl    <- mkOutputSyncFor(controller.qsfp[12].resetl);
-    InputReg#(Bool, 2) qsfp12_hsc_pg    <- mkInputSyncFor(controller.qsfp[12].hsc.pg);
+    InputReg#(Bool, 2) qsfp12_hsc_pg    <- mkInputSyncFor(controller.qsfp[12].power_good);
     InputReg#(Bit#(1), 2) qsfp12_intl   <- mkInputSyncFor(controller.qsfp[12].intl);
     InputReg#(Bit#(1), 2) qsfp12_modprsl<- mkInputSyncFor(controller.qsfp[12].modprsl);
     ReadOnly#(Bool) qsfp12_scl_out_en   <- mkOutputSyncFor(controller.qsfp[12].scl.out_en);
@@ -477,10 +477,10 @@ module mkQsfpX32ControllerTop (QsfpControllerTop);
     mkConnection(sync(qsfp12_sda_in), qsfp12_sda._read);
 
     // P13
-    ReadOnly#(Bool) qsfp13_hsc_en       <- mkOutputSyncFor(controller.qsfp[13].hsc.en);
+    ReadOnly#(Bool) qsfp13_hsc_en       <- mkOutputSyncFor(controller.qsfp[13].power_en);
     ReadOnly#(Bit#(1)) qsfp13_lpmode    <- mkOutputSyncFor(controller.qsfp[13].lpmode);
     ReadOnly#(Bit#(1)) qsfp13_resetl    <- mkOutputSyncFor(controller.qsfp[13].resetl);
-    InputReg#(Bool, 2) qsfp13_hsc_pg    <- mkInputSyncFor(controller.qsfp[13].hsc.pg);
+    InputReg#(Bool, 2) qsfp13_hsc_pg    <- mkInputSyncFor(controller.qsfp[13].power_good);
     InputReg#(Bit#(1), 2) qsfp13_intl   <- mkInputSyncFor(controller.qsfp[13].intl);
     InputReg#(Bit#(1), 2) qsfp13_modprsl<- mkInputSyncFor(controller.qsfp[13].modprsl);
     ReadOnly#(Bool) qsfp13_scl_out_en   <- mkOutputSyncFor(controller.qsfp[13].scl.out_en);
@@ -495,10 +495,10 @@ module mkQsfpX32ControllerTop (QsfpControllerTop);
     mkConnection(sync(qsfp13_sda_in), qsfp13_sda._read);
 
     // P14
-    ReadOnly#(Bool) qsfp14_hsc_en       <- mkOutputSyncFor(controller.qsfp[14].hsc.en);
+    ReadOnly#(Bool) qsfp14_hsc_en       <- mkOutputSyncFor(controller.qsfp[14].power_en);
     ReadOnly#(Bit#(1)) qsfp14_lpmode    <- mkOutputSyncFor(controller.qsfp[14].lpmode);
     ReadOnly#(Bit#(1)) qsfp14_resetl    <- mkOutputSyncFor(controller.qsfp[14].resetl);
-    InputReg#(Bool, 2) qsfp14_hsc_pg    <- mkInputSyncFor(controller.qsfp[14].hsc.pg);
+    InputReg#(Bool, 2) qsfp14_hsc_pg    <- mkInputSyncFor(controller.qsfp[14].power_good);
     InputReg#(Bit#(1), 2) qsfp14_intl   <- mkInputSyncFor(controller.qsfp[14].intl);
     InputReg#(Bit#(1), 2) qsfp14_modprsl<- mkInputSyncFor(controller.qsfp[14].modprsl);
     ReadOnly#(Bool) qsfp14_scl_out_en   <- mkOutputSyncFor(controller.qsfp[14].scl.out_en);
@@ -513,10 +513,10 @@ module mkQsfpX32ControllerTop (QsfpControllerTop);
     mkConnection(sync(qsfp14_sda_in), qsfp14_sda._read);
 
     // P15
-    ReadOnly#(Bool) qsfp15_hsc_en       <- mkOutputSyncFor(controller.qsfp[15].hsc.en);
+    ReadOnly#(Bool) qsfp15_hsc_en       <- mkOutputSyncFor(controller.qsfp[15].power_en);
     ReadOnly#(Bit#(1)) qsfp15_lpmode    <- mkOutputSyncFor(controller.qsfp[15].lpmode);
     ReadOnly#(Bit#(1)) qsfp15_resetl    <- mkOutputSyncFor(controller.qsfp[15].resetl);
-    InputReg#(Bool, 2) qsfp15_hsc_pg    <- mkInputSyncFor(controller.qsfp[15].hsc.pg);
+    InputReg#(Bool, 2) qsfp15_hsc_pg    <- mkInputSyncFor(controller.qsfp[15].power_good);
     InputReg#(Bit#(1), 2) qsfp15_intl   <- mkInputSyncFor(controller.qsfp[15].intl);
     InputReg#(Bit#(1), 2) qsfp15_modprsl<- mkInputSyncFor(controller.qsfp[15].modprsl);
     ReadOnly#(Bool) qsfp15_scl_out_en   <- mkOutputSyncFor(controller.qsfp[15].scl.out_en);


### PR DESCRIPTION
* Add 5ms debounce to power good, intl, and modprsl
* Keep lpmode low until power to the module is up and good (workaround for https://github.com/oxidecomputer/hardware-qsfp-x32/issues/47)

Fixes #109, fixes #111