### PR TITLE
Need to specify the slice for encoding slv to enums

### DIFF
--- a/tools/site_cobble/rdl_pkg/templates/regpkg_vhdl.jinja2
+++ b/tools/site_cobble/rdl_pkg/templates/regpkg_vhdl.jinja2
@@ -158,7 +158,7 @@ package body {{module_name}} is
     begin
       {% for field in register.packed_fields %}
         {% if field.has_encode() %}
-        ret_rec.{{field.name}}:= encode(slv);
+        ret_rec.{{field.name}}:= encode(slv({{field.vhdl_bitslice_str()}}));
         {% elif field.width > 1 %}
         ret_rec.{{field.name}}:= unsigned(slv({{field.vhdl_bitslice_str()}}));
         {% else %}


### PR DESCRIPTION
Encode function signature requires slicing of the register-wide std_logic_vector into the appropriate bit slice for doing the encode. The length mismatch isn't noticed currently by the vhdl_ls so this slipped through until I tried to use it for real in simulation.

Fixes #158 