### PR TITLE
Support specification of VHDL standards for sim and synth

### DIFF
--- a/tools/vhdl-ls.bxl
+++ b/tools/vhdl-ls.bxl
@@ -76,7 +76,12 @@ def vhdl_toml_gen(ctx):
     # we add the "libraries" layer here
     # BXL can only generate json natively, but we've matched the expected structure
     # of the toml file so we can just run this through a converter
-    outjson = {"libraries": files_by_library_name}
+    # We default the editor's standards to the highest we support since the editor
+    # use-case doesn't make sense to limit and we don't know what our "top" is
+    outjson = {
+        "standard": "2019",
+        "libraries": files_by_library_name
+    }
     # Put it to std-out
     ctx.output.print_json(outjson)
 

--- a/tools/vivado.bzl
+++ b/tools/vivado.bzl
@@ -10,7 +10,7 @@ load(
     "PythonToolchainInfo",
 )
 
-load(":hdl.bzl", "HDLFileInfo", "UnitTSet")
+load(":hdl.bzl", "HDLFileInfo", "VHDLFileInfo", "HDLFileInfoTSet")
 
 VivadoConstraintInfo = provider(
     fields={
@@ -61,9 +61,8 @@ def synthesize(ctx):
     # output of this is a checkpoint file
 
     # Get list of all sources from the dep tree via the tset in HDLFileInfo
-    source_files_tset = ctx.attrs.top[HDLFileInfo].set
+    source_files_tset = ctx.attrs.top[HDLFileInfo].set_all
     source_files = source_files_tset.project_as_json("json", ordering="postorder")
-    
     out_json = {
         "flow": "synthesis",
         "part": ctx.attrs.part,

--- a/tools/vivado_gen/templates/synth.jinja2
+++ b/tools/vivado_gen/templates/synth.jinja2
@@ -27,7 +27,7 @@ read_verilog -sv {{source.path.absolute().as_posix()}}
 read_verilog {{source.path.absolute().as_posix()}}
 {% elif suffix in [".vhd"] %}
 {% set lib_cmd = "" if not source.library else "-library {} ".format(source.library) %}
-read_vhdl {{lib_cmd}}-vhdl2008 {{source.path.absolute().as_posix()}}
+read_vhdl {{lib_cmd}}-vhdl{{source.standard}} {{source.path.absolute().as_posix()}}
 {% elif suffix in [".xci"] %}
 read_ip {{source.path.absolute().as_posix()}}
 {% endif %}

--- a/tools/vivado_gen/vivado_gen.py
+++ b/tools/vivado_gen/vivado_gen.py
@@ -20,9 +20,10 @@ parser.add_argument("--output", dest="output", help="Explicit output list")
 args = parser.parse_args()
 
 class Source:
-    def __init__(self, path, library):
+    def __init__(self, path, library, standard):
         self.path = path
-        self.library = library 
+        self.library = library
+        self.standard = standard
 
 class Project:
     def __init__(self, 
@@ -51,7 +52,11 @@ class Project:
         srcs = inputs.get("sources", [])
         sources = []
         for file in srcs:
-            sources.append(Source(Path(file.get("artifact")), file.get("library")))
+            # Drop any non-synth files here
+            if not file.get("is_synth"):
+                print("Dropping non-synth file {}".format(file))
+                continue
+            sources.append(Source(Path(file.get("artifact")), file.get("library"), file.get("standard")))
         
         return cls(
             flow=inputs.get("flow"),

--- a/tools/vunit_gen/templates/run_py.jinja2
+++ b/tools/vunit_gen/templates/run_py.jinja2
@@ -39,6 +39,10 @@ if "-o" not in sys.argv:
 # via environment variables, and we don't have a great way of passing
 # those in via buck2
 os.environ["VUNIT_SIMULATOR"] = "{{simulator}}"
+# Our open-source simulators don't support mixed standard simulations
+# So we use the reduction provided to get the max standard needed for
+# this simulation and make everything use it
+os.environ["VUNIT_VHDL_STANDARD"] = "{{vhdl_standard}}"
 {% endif %}
 
 vu = VUnit.from_argv(compile_builtins=False)
@@ -52,9 +56,9 @@ vu.add_random()
 vu.add_verification_components()
 # Create libraries
 {% for library in libraries %}
-{{library.name}} = vu.add_library("{{library.name}}")
+{{library.name}} = vu.add_library("{{library.name}}", vhdl_standard="{{vhdl_standard}}")
 {% for file in library.files %}
-{{library.name}}.add_source_file("{{file}}")
+{{library.name}}.add_source_file("{{file}}", vhdl_standard="{{vhdl_standard}}")
 {% endfor %}
 {% endfor %}
 

--- a/tools/vunit_gen/vunit_gen_cli.py
+++ b/tools/vunit_gen/vunit_gen_cli.py
@@ -37,6 +37,7 @@ def main():
     # Parse the json we were handed
     with open(args.input) as fp:
         inputs = json.load(fp)
+
     # Load jinja templates
     env = Environment(
         loader=PackageLoader("vunit_gen"),
@@ -46,7 +47,7 @@ def main():
     template = env.get_template("run_py.jinja2")
     # Set up the default library
     libs.update({"lib": Library("lib")})
-    for x in inputs:
+    for x in inputs.get("files"):
         artifact = x.get("artifact")
         this_lib = x.get('library')
         # By default, libraries are blank and compiled into
@@ -69,6 +70,7 @@ def main():
     content = template.render(
         libraries=libs_list,
         simulator=args.simulator,
+        vhdl_standard=inputs.get("vhdl_std"),
         codec_packages=[],
         # vunit_out=args.vunit_out,
     )


### PR DESCRIPTION
Our simulation tools can't support multiple standards in the same simulation, this means that for simulation, we have to "lift" all of the files up to the maximum used VHDL standard. This PR addresses this.

Vivado can deal with mixed standards, but we didn't support that either, defaulting to 208 so this PR addresses this as well.

In order to make all of this work, additional properties had to be plumbed through, and this allows our synthesis generator to detect and drop non-synth files, which is something we needed to do long-term anyway. The big use-case here is that for simulation we're using VHDL models of the XPM library, but Vivado will provide those natively. We'd have dependencies in the tree for these models which we'd need to strip when making the list of files to synthesize. This PR resolves this as well since the features now exist to to the other plumbing.

Finally, we default the vhdl-lsp to 2019 mode, which should be the most useful editor mode. This does mean the LSP could detect valid 2019 syntax that a synth or sim tool doesn't yet support but there's not a lot to do about that.