### PR TITLE
Add a super basic set of constraints and pins for an FPGA image

### DIFF
--- a/hdl/projects/grapefruit/BUCK
+++ b/hdl/projects/grapefruit/BUCK
@@ -11,6 +11,6 @@ vivado_bitstream(
     name="grapefruit",
     top_entity_name="grapefruit_top",
     top= ":grapefruit_top",
-    part= "xc7s50csga324-1",
+    part= "xc7s100fgga484-1",
     constraints=glob(["*.xdc"]),
 )

--- a/hdl/projects/grapefruit/grapefruit_pins.xdc
+++ b/hdl/projects/grapefruit/grapefruit_pins.xdc
@@ -1,18 +1,3 @@
-set_property -dict { PACKAGE_PIN R2    IOSTANDARD SSTL135 } [get_ports { clk }]; #IO_L12P_T1_MRCC_34 Sch=ddr3_clk[200]
-set_property -dict { PACKAGE_PIN G15   IOSTANDARD LVCMOS33 } [get_ports { reset }]; #IO_L18N_T2_A23_15 Sch=btn[0]
-set_property -dict { PACKAGE_PIN E18   IOSTANDARD LVCMOS33 } [get_ports { ledn }]; #IO_L16N_T2_A27_15 Sch=led[2]
-
-## Configuration options, can be used for all designs
-set_property BITSTREAM.CONFIG.CONFIGRATE 50 [current_design]
-set_property CONFIG_VOLTAGE 3.3 [current_design]
-set_property CFGBVS VCCO [current_design]
-set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]
-set_property CONFIG_MODE SPIx4 [current_design]
-
-## SW3 is assigned to a pin M5 in the 1.35v bank. This pin can also be used as
-## the VREF for BANK 34. To ensure that SW3 does not define the reference voltage
-## and to be able to use this pin as an ordinary I/O the following property must
-## be set to enable an internal VREF for BANK 34. Since a 1.35v supply is being
-## used the internal reference is set to half that value (i.e. 0.675v). Note that
-## this property must be set even if SW3 is not used in the design.
-set_property INTERNAL_VREF 0.675 [get_iobanks 34]
+set_property -dict { PACKAGE_PIN L8    IOSTANDARD LVCMOS33 } [get_ports { clk }]; # FPGA_50MHz_CLK2
+set_property -dict { PACKAGE_PIN N15   IOSTANDARD LVCMOS33 } [get_ports { reset_l }]; # SP_TO_FPGA_LOGIC_RESET_L
+set_property -dict { PACKAGE_PIN C22   IOSTANDARD LVCMOS33 } [get_ports { ledn }]; # FPGA_SPARE_3V3_1

--- a/hdl/projects/grapefruit/grapefruit_timing.xdc
+++ b/hdl/projects/grapefruit/grapefruit_timing.xdc
@@ -1,1 +1,1 @@
-create_clock -add -name sys_clk_pin -period 10.000 -waveform {0 5.000}  [get_ports { clk }];
+create_clock -add -name sys_clk_pin -period 20.000 -waveform {0 10.000}  [get_ports { clk }];

--- a/hdl/projects/grapefruit/grapefruit_top.vhd
+++ b/hdl/projects/grapefruit/grapefruit_top.vhd
@@ -5,7 +5,7 @@ use ieee.numeric_std.all;
 entity grapefruit_top is
     port (
         clk   : in    std_logic;
-        reset : in    std_logic;
+        reset_l : in    std_logic;
 
         ledn : out   std_logic
     );
@@ -17,9 +17,9 @@ architecture rtl of grapefruit_top is
 
 begin
 
-    tst : process (clk, reset)
+    tst : process (clk, reset_l)
     begin
-        if reset = '1' then
+        if reset_l = '0' then
             counter <= (others => '0');
         elsif rising_edge(clk) then
             counter <= counter + 1;


### PR DESCRIPTION
This toggles a pin (FPGA_SPARE_3V3_1) at a human-readable frequency (< Hz scale) and can be measured with an o-scope if necessary.

This builds a bitstream for our desired device, which can then be used for configuration dev.