### PR TITLE
Fix multitool and build failure error reporting so RDL issues show up…

### DIFF
--- a/tools/multitool/multitool_cli.py
+++ b/tools/multitool/multitool_cli.py
@@ -65,13 +65,18 @@ def vhdl_ls_toml_gen(args):
     vhdlls_toml = root / "vhdl_ls.toml"
     # Call buck2 and get the list of vhdl files that we own for
     # formatting (ie no 3rd party things)
-    buck_bxl = subprocess.run(
+    # We capture stdout here because we need to parse the json but 
+    # allow the stderr to go to the console
+    buck_bxl = subprocess.Popen(
         ["buck2", "bxl", "//tools/vhdl-ls.bxl:vhdl_ls_toml_gen"], 
-        encoding="utf-8", 
-        check=True, 
-        capture_output=True
+        encoding="utf-8",
+        stdout=subprocess.PIPE
     )
-    vhdl_lsp_dict = json.loads(buck_bxl.stdout)
+    stdout, _ = buck_bxl.communicate()
+    if buck_bxl.returncode != 0:
+        sys.exit(buck_bxl.returncode)
+    
+    vhdl_lsp_dict = json.loads(stdout)
     if not args.print:
         # dump toml
         with open(vhdlls_toml, "wb") as f:

--- a/tools/vhdl-ls.bxl
+++ b/tools/vhdl-ls.bxl
@@ -25,9 +25,16 @@ def vhdl_toml_gen(ctx):
     # Filter for rdl files in the project
     rdl_files = ctx.cquery().kind("rdl.*", targets)
     gen_vhdl_from_rdl = []
-    for target, value in ctx.build(rdl_files).items():
-         for art in value.artifacts():
-             if art.extension == ".vhd":
+    bld = ctx.build(rdl_files)
+    for target, value in bld.items():
+        # Buck documentation appears to be incorrect here in that failures() can't be
+        # evaluated without iterating for whatever reason (if `value.failures()` always
+        # trips)
+        for f in value.failures():
+            fail_no_stacktrace("Failed to build {} RDL file".format(target))
+
+        for art in value.artifacts():
+            if art.extension == ".vhd":
                 # Locally materialize this output since we want it local
                 a = ctx.output.ensure(art)
                 gen_vhdl_from_rdl.append(a)

--- a/vhdl_ls.toml
+++ b/vhdl_ls.toml
@@ -1,3 +1,5 @@
+standard = "2019"
+
 [libraries.xpm]
 files = [
     "vnd/xpm/xpm_vhdl/src/xpm/xpm_VCOMP.vhd",


### PR DESCRIPTION
… in console.

https://github.com/oxidecomputer/quartz/pull/160 added this functionality to multi-tool but the sad-path, where errors such as RDL typos were not properly reported out to the user. This is basically around the fact that the running the bxl tool from python could have masked the errors and that without explicit failure, the build in the bxl could fail but he script would return status 0 anyway. Now RDL build failures will report out to the console.