### PR TITLE
Add subtargets for the various vivado phases

### DIFF
--- a/tools/vivado.bzl
+++ b/tools/vivado.bzl
@@ -46,7 +46,19 @@ def _vivado_bitstream(ctx):
     placer =  place(ctx, opt, False)
     placer_opt = place(ctx, placer, True)
     router = route(ctx, placer_opt)
-    return bitstream(ctx, router)
+    bits = bitstream(ctx, router)
+    return [
+        DefaultInfo(
+            default_output=bits[0].default_outputs[0],
+            sub_targets = {
+                "synth": synth,
+                "opt":  opt,
+                "place": placer,
+                "place_opt": placer_opt,
+                "route": router,
+            }
+        )
+    ]
 
 
 def synthesize(ctx):


### PR DESCRIPTION
you can now run `buck2 build <some_targetfolder>:<some_target>[<synth, opt, place, place_out, route>] to get the checkpoint from the requested subtarget step i3c lines.