### PR TITLE
Allow dumping of arrays in nvc

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ working in linux, and python 3.12 working in windows. Python 3.9 did not work in
 windows at least, we have no other data points on other python versions.
 - You'll need to install required python packages `pip install -r tools/requirements.txt`
 - You'll need to have nvc (https://github.com/nickg/nvc). For linux, this can be obtained as a .deb
-from the releases section, for windows there are also compiled binaries in the releases section.
+from the releases section, for windows there are also compiled binaries in the releases section. 
+Current minimum supported version is 1.13.1
 
 :warning: **Windows Users**: You need to be in Developer Mode for buck2 to be
 able to use symlinks, and should consider setting `LongPathsEnabled` in regedit at

--- a/tools/vunit_gen/templates/run_py.jinja2
+++ b/tools/vunit_gen/templates/run_py.jinja2
@@ -72,5 +72,9 @@ vu.add_verification_components()
 
 # Disable annoying ieee warnings across VUnit-supported simulators
 vu.set_sim_option("disable_ieee_warnings", True)
+{% if simulator == "nvc" %}
+# Dump arrays of records, may have a perf penalty
+vu.set_sim_option("nvc.sim_flags", ["--dump-arrays"])
+{% endif %}
 # Run vunit function
 vu.main()


### PR DESCRIPTION
With out this option, arrays of records aren't dumped into waveforms by default. This fixes this.  There could be a performance penalty to doing this, and if we find such a problem more work can be done to make this more configurable.

This updates the readme to document our currently supported nvc version also.