### PR TITLE
Fix bug in reset bridge where reset state... wasn't

### DIFF
--- a/hdl/ip/vhd/synchronizers/async_reset_bridge.vhd
+++ b/hdl/ip/vhd/synchronizers/async_reset_bridge.vhd
@@ -67,7 +67,7 @@ begin
     reset_reg : process (clk, reset_async)
     begin
         if reset_async = async_reset_active_level then
-            reset_flops <= (others => '0');
+            reset_flops <= (others => '1');
         elsif rising_edge(clk) then
             reset_flops                   <= shift_right(reset_flops, 1);
             reset_flops(reset_flops'left) <= '0';


### PR DESCRIPTION
We do actually want the reset bridges to assert reset when the input reset is asserted.  Due to a typo, they didn't until this change.