### PR TITLE
Integration of a number of fixes discovered during sw integration.

### DIFF
--- a/hdl/ip/vhd/spi_nor_controller/sims/spi_nor_tb.vhd
+++ b/hdl/ip/vhd/spi_nor_controller/sims/spi_nor_tb.vhd
@@ -50,11 +50,12 @@ begin
         -- waveform inspection here.
         while test_suite loop
             if run("instr_only") then
-                write_instr(net, WRITE_ENABLE_OP);
+                write_data_size(net, 3);  -- read out 3 bytes
+                write_instr(net, READ_JEDEC_ID_OP);
             elsif run("write_24addr_no_dummy") then
-                write_data(net, x"AA55AA55");  -- do do words
-                write_data(net, x"55AA55AA");  -- do do words
-                write_data_size(net, 6);  -- write out 6 bytes
+                write_data(net, x"03020100");  -- do do words
+                write_data(net, x"07060504");  -- do do words
+                write_data_size(net, 8);  -- write out 6 bytes
                 write_instr(net, PAGE_PROGRAM_OP);
 
             elsif run("write_32addr_no_dummy") then
@@ -64,7 +65,7 @@ begin
                 write_instr(net, PAGE_PROGRAM_4BYTE_OP);
 
             elsif run("read_24addr_no_dummy") then
-                write_data_size(net, 6);  -- read out 6 bytes
+                write_data_size(net, 8);  -- read out 6 bytes
                 write_instr(net, READ_DATA_OP);
 
             elsif run("read_32addr_no_dummy") then
@@ -72,8 +73,8 @@ begin
                 write_instr(net, READ_DATA_4BYTE_OP);
 
             elsif run("read_24addr_dummy") then
-                write_data_size(net, 6);  -- read out 6 bytes
-                write_dummy(net, 8);  -- 8 dummy clocks
+                write_data_size(net, 1);  -- read out 6 bytes
+                write_dummy(net, 3);  -- 8 dummy clocks
                 write_instr(net, FAST_READ_4BYTE_OP);
 
             -- elsif run("read_32addr_dummy") then

--- a/hdl/ip/vhd/spi_nor_controller/spi_nor_regs.rdl
+++ b/hdl/ip/vhd/spi_nor_controller/spi_nor_regs.rdl
@@ -85,8 +85,9 @@ addrmap nor_flash_regs {
         name = "Data Byte Count Register";
         desc = "";
         field {
-            desc = "Specify # data bytes (not counting instruction, addr or dummy cycles to be transferred)";
-        } count[7:0] =  0;
+            desc = "Specify # data bytes -1 (not counting instruction, addr or dummy cycles to be transferred),
+            max of 255 here representing 255 + 1 as that's the largest transaction the flash can support";
+        } count[8:0] =  0;
      } DataBytes;
     
     reg {

--- a/hdl/ip/vhd/spi_nor_controller/spi_nor_top.vhd
+++ b/hdl/ip/vhd/spi_nor_controller/spi_nor_top.vhd
@@ -106,6 +106,7 @@ begin
         go_flag => go_strobe,
         -- link i/f
         cs_n => cs_n,
+        sclk => sclk,
         rx_byte_done => rx_byte_done,
         rx_link_byte => link_rx_byte,
         tx_byte_done => tx_byte_done,


### PR DESCRIPTION
This fixes up a number of issues discovered as we tried to use this in anger, including problems with the tx shifter which had undesirable behavior variance depending on byte being shifted out, and an issue where the state machine was issuing one more data or dummy cycle than was requested for the operation.