### PR TITLE
Fixup quad flash commands

### DIFF
--- a/hdl/ip/vhd/spi_nor_controller/sims/spi_nor_tb.vhd
+++ b/hdl/ip/vhd/spi_nor_controller/sims/spi_nor_tb.vhd
@@ -77,6 +77,12 @@ begin
                 write_dummy(net, 3);  -- 8 dummy clocks
                 write_instr(net, FAST_READ_4BYTE_OP);
 
+            elsif run("write_32addr_quad") then
+                write_data_size(net, 5);  -- write out 5 bytes
+                write_data(net, x"03020100");  -- do do words
+                write_data(net, x"07060504");  -- do do words
+                write_instr(net, QUAD_INPUT_PAGE_PROGRAM_OP);
+
             -- elsif run("read_32addr_dummy") then
             end if;
         end loop;

--- a/hdl/ip/vhd/spi_nor_controller/spi_link.vhd
+++ b/hdl/ip/vhd/spi_nor_controller/spi_link.vhd
@@ -17,7 +17,7 @@ entity spi_link is
         clk : in std_logic;
         reset : in std_logic;
         -- system interface
-        cur_io_mode  : in io_mode;
+        req_io_mode  : in io_mode;
         divisor : in unsigned(15 downto 0);
         in_tx_phases : in boolean;
         in_rx_phases : in boolean;
@@ -46,6 +46,7 @@ signal sclk_last         : std_logic;
 signal shift_amt         : integer range 1 to 4;
 signal csn_last          : std_logic;
 signal is_last_bit       : boolean;
+signal cur_io_mode  : io_mode;
 
 begin
 
@@ -61,8 +62,16 @@ begin
     begin
         if reset then
             sclk_last <= '0';
+            cur_io_mode <= single;
         elsif rising_edge(clk) then
             sclk_last <= sclk;
+            if cs_n = '0' and sclk_fedge then
+                -- only update the io mode on the falling edge
+                -- so that we're done with the current bit
+                cur_io_mode <= req_io_mode;
+            elsif cs_n = '1' then
+                cur_io_mode <= req_io_mode;
+            end if;
         end if;
     end process;
 

--- a/hdl/ip/vhd/spi_nor_controller/spi_nor_top.vhd
+++ b/hdl/ip/vhd/spi_nor_controller/spi_nor_top.vhd
@@ -73,7 +73,7 @@ begin
         reset => reset,
 
         
-        cur_io_mode => cur_io_mode,
+        req_io_mode => cur_io_mode,
         divisor => div_val,
         in_tx_phases => in_tx_phases,
         in_rx_phases => in_rx_phases,

--- a/hdl/ip/vhd/spi_nor_controller/spi_txn_mgr.vhd
+++ b/hdl/ip/vhd/spi_nor_controller/spi_txn_mgr.vhd
@@ -245,7 +245,7 @@ begin
         -- out what state we're going to be in next
         if v.state = cs_assert then
             v.csn := '0';
-        elsif v.state = cs_deassert and r.counter = 1 then
+        elsif v.state = cs_deassert and v.counter = 1 then
             v.csn := '1';
         end if;
 


### PR DESCRIPTION
Quad spi writes were hanging, quad spi reads were returning gibberish.

The shift from single to quad spi was happening during the final bit which messed eveything up. Fix to only update on sclk_fedge when in a transaction. Additionally noted that the cs_deassert delay wasn't working correctly so that was fixed up too. The quad spi reads and writes now work through hubris and the core reverts to single mode once the transaction is done.