### PR TITLE
Change FPGA pin C5 to have an internal pull-up

### DIFF
--- a/hdl/projects/sidecar/mainboard/sidecar_mainboard_controller.lpf
+++ b/hdl/projects/sidecar/mainboard/sidecar_mainboard_controller.lpf
@@ -225,7 +225,7 @@ IOBUF PORT "pcie_host_to_fpga_smbdat" PULLMODE=NONE OPENDRAIN=ON IO_TYPE=LVCMOS3
 LOCATE COMP "pcie_host_to_fpga_smbclk" SITE "B4";
 IOBUF PORT "pcie_host_to_fpga_smbclk" PULLMODE=NONE OPENDRAIN=ON IO_TYPE=LVCMOS33;
 LOCATE COMP "pcie_host_to_fpga_perst" SITE "C5";
-IOBUF PORT "pcie_host_to_fpga_perst" PULLMODE=NONE IO_TYPE=LVCMOS33;
+IOBUF PORT "pcie_host_to_fpga_perst" PULLMODE=UP IO_TYPE=LVCMOS33;
 LOCATE COMP "pcie_host_to_fpga_pwren" SITE "D5";
 IOBUF PORT "pcie_host_to_fpga_pwren" PULLMODE=NONE IO_TYPE=LVCMOS33;
 


### PR DESCRIPTION
 to compensate for a missing hw pullup on pcie_host_to_fpga_perst input pin, this net can be pulled down by the U47 OpenDrain buffer but what happens when the output floats?  Nothing good, that's for sure!