### PR TITLE
Make register records use std_logic_vector types vs unsigned

### DIFF
--- a/hdl/ip/vhd/spi_nor_controller/spi_nor_top.vhd
+++ b/hdl/ip/vhd/spi_nor_controller/spi_nor_top.vhd
@@ -132,10 +132,10 @@ begin
             rx_fifo_write => rx_fifo_write8
         );
     -- Hubris spi command intrface
-    hubris_cmd.addr <= std_logic_vector(addr_reg.addr);
-    hubris_cmd.data_bytes <= std_logic_vector(data_bytes_reg.count);
-    hubris_cmd.dummy_cycles <= std_logic_vector(dummy_cycles_reg.count);
-    hubris_cmd.instr <= std_logic_vector(instr_reg.opcode);
+    hubris_cmd.addr <= addr_reg.addr;
+    hubris_cmd.data_bytes <= data_bytes_reg.count;
+    hubris_cmd.dummy_cycles <= dummy_cycles_reg.count;
+    hubris_cmd.instr <= instr_reg.opcode;
     hubris_cmd.go_flag <= go_strobe;
     -- Mux between espi and register interface for read data (rx fifos)
     reg_fifo_write_allowed <= '1' when spicr_reg.sp5_owns_flash = '0' else '0';
@@ -184,11 +184,11 @@ begin
             -- Write interface ()
             wclk => clk,
             -- Reset interface, sync to write clock domain
-            reset              => tx_fifo_reset,
-            write_en           => tx_fifo_write_reg,
-            wdata              => tx_fifo_wdata_reg,
-            wfull              => spisr_reg.tx_full,
-            unsigned(wusedwds) => spisr_reg.tx_used_wds,
+            reset    => tx_fifo_reset,
+            write_en => tx_fifo_write_reg,
+            wdata    => tx_fifo_wdata_reg,
+            wfull    => spisr_reg.tx_full,
+            wusedwds => spisr_reg.tx_used_wds,
             -- Read interface
             rclk     => clk,
             rdata    => tx_fifo_data32,
@@ -225,11 +225,11 @@ begin
             wfull    => open,
             wusedwds => open,
             -- Read interface
-            rclk               => clk,
-            rdata              => rx_fifo_rdata_reg,
-            rdreq              => rx_fifo_read_ack_reg,
-            rempty             => spisr_reg.rx_empty,
-            unsigned(rusedwds) => spisr_reg.rx_used_wds
+            rclk     => clk,
+            rdata    => rx_fifo_rdata_reg,
+            rdreq    => rx_fifo_read_ack_reg,
+            rempty   => spisr_reg.rx_empty,
+            rusedwds => spisr_reg.rx_used_wds
         );
 
     spisr_reg.rx_full <= '1' when spisr_reg.rx_used_wds = 64 else '0';

--- a/tools/site_cobble/rdl_pkg/templates/regpkg_vhdl.jinja2
+++ b/tools/site_cobble/rdl_pkg/templates/regpkg_vhdl.jinja2
@@ -76,8 +76,7 @@ package {{module_name}} is
         {% if field.has_encode() %}
       {{field.name}}  : {{reg_name}}_{{field.name|lower}};
         {% elif field.width > 1 %}
-        {# Todo: fix for slv by custom property? #}
-      {{field.name}}{{' : unsigned(%s downto 0);' % (field.width-1)}}
+      {{field.name}}{{' : std_logic_vector(%s downto 0);' % (field.width-1)}}
         {% elif field.width == 1 %}
       {{field.name}}    : std_logic;
         {%endif%}
@@ -161,7 +160,7 @@ package body {{module_name}} is
         {% if field.has_encode() %}
         ret_rec.{{field.name}}:= encode(slv({{field.vhdl_bitslice_str()}}));
         {% elif field.width > 1 %}
-        ret_rec.{{field.name}}:= unsigned(slv({{field.vhdl_bitslice_str()}}));
+        ret_rec.{{field.name}}:= slv({{field.vhdl_bitslice_str()}});
         {% else %}
         ret_rec.{{field.name}}:= slv({{field.vhdl_bitslice_str()}});
         {% endif %}
@@ -216,7 +215,7 @@ package body {{module_name}} is
           {% if  field.has_encode() %}
         ret_rec.{{field.name}} := encode(vec({{ns.bit -1}} downto {{ns.bit-field.width}}));
           {% elif field.width > 1 %}
-        ret_rec.{{field.name}} := unsigned(vec({{ns.bit -1}} downto {{ns.bit-field.width}}));
+        ret_rec.{{field.name}} := vec({{ns.bit -1}} downto {{ns.bit-field.width}});
           {% else %}
         ret_rec.{{field.name}} := vec({{ns.bit -1}});
           {% endif %}


### PR DESCRIPTION
This always felt a little gross but by and large users wanted to use multi-bit fields as counters etc so making them unsigned  was an easy way to facilitate that. With the advent of  ieee.numeric_std_unsigned support, consumers of std_logic_vectors can now opt-in to "unsigned" behavior of the std_logic_vectors when desired, and this works on tools that support VHDL2008+ so we make records slv types again. This represents an interface change but this change includes the only block using this and already in mainline quartz right now.