### PR TITLE
We'd like the UART to be able to actually rx multiple bytes

### DIFF
--- a/hdl/ip/vhd/uart/base_uart/axi_st_uart.vhd
+++ b/hdl/ip/vhd/uart/base_uart/axi_st_uart.vhd
@@ -120,6 +120,8 @@ begin
       when IDLE =>
         -- Look for a start bit, and move to run state
         if rx_pin_syncd = START_LEVEL then
+          v.bit_num := 0;
+          v.sample_cnts := (others => '0');
           v.state := RUN;
         end if;
 

--- a/hdl/ip/vhd/uart/sims/uart_tb.vhd
+++ b/hdl/ip/vhd/uart/sims/uart_tb.vhd
@@ -60,6 +60,17 @@ begin
                 report "Sent byte 0x" & to_hstring(tx_byte);
                 pop_stream(net, rx_uart_stream, rx_byte);
                 check_equal(rx_byte, tx_byte, "Tx/Rx byte mismatch");
+            elsif run("send_two_bytes") then
+                tx_byte := rnd_stimuli.RandSlv(8);
+                push_stream(net, tx_uart_stream, tx_byte);
+                report "Sent byte 0x" & to_hstring(tx_byte);
+                pop_stream(net, rx_uart_stream, rx_byte);
+                check_equal(rx_byte, tx_byte, "Tx/Rx byte mismatch");
+                tx_byte := rnd_stimuli.RandSlv(8);
+                push_stream(net, tx_uart_stream, tx_byte);
+                report "Sent byte 0x" & to_hstring(tx_byte);
+                pop_stream(net, rx_uart_stream, rx_byte);
+                check_equal(rx_byte, tx_byte, "Tx/Rx byte mismatch");
             end if;
         end loop;
 


### PR DESCRIPTION
This fixes a bug where we both don't reset the sample count or the bit count when we detect a new start bit. We were correctly rx'ing one byte, but not anything after this.  New test added to capture this also.