### PR TITLE
Fix incorrect/missing fifo generic discovered while debugging

### DIFF
--- a/hdl/ip/vhd/fifos/dcfifo_mixed_xpm.vhd
+++ b/hdl/ip/vhd/fifos/dcfifo_mixed_xpm.vhd
@@ -82,6 +82,7 @@ begin
             ecc_mode            => "no_ecc",
             fifo_memory_type    => "auto",
             fifo_write_depth    => wfifo_write_depth,
+            fifo_read_latency   => read_latency,
             full_reset_value    => 0,
             prog_empty_thresh   => PROG_EMPTY_THRESH,
             prog_full_thresh    => PROG_FULL_THRESH,

--- a/hdl/ip/vhd/fifos/dcfifo_xpm.vhd
+++ b/hdl/ip/vhd/fifos/dcfifo_xpm.vhd
@@ -79,6 +79,7 @@ begin
             ecc_mode            => "no_ecc",
             fifo_memory_type    => "auto",
             fifo_write_depth    => FIFO_WRITE_DEPTH,
+            fifo_read_latency   => read_latency,
             full_reset_value    => 0,
             prog_empty_thresh   => PROG_EMPTY_THRESH,
             prog_full_thresh    => PROG_FULL_THRESH,


### PR DESCRIPTION
xpm simulation, likely unrelated to issues noted.

This fixes a missing generic map, should be pretty non-controversial.