### PR TITLE
Fix register slice generation

### DIFF
--- a/tools/site_cobble/rdl_pkg/models.py
+++ b/tools/site_cobble/rdl_pkg/models.py
@@ -55,7 +55,7 @@ class BaseModel:
     @property
     def fields_by_bytes(self) -> List[List[Tuple[Tuple[int,int], "Field"]]]:
         view_files_in_bytes = []
-        for byte_high_index in range(0, 4):
+        for byte_high_index in range(0, self.node.size):
             high = self.width - 1 - 8 * byte_high_index
             low = self.width -1 - 8 * byte_high_index - 7
             view_files_in_bytes.append(((high, low), self.fields_between_bits(high, low)))


### PR DESCRIPTION
We were naively generating 4-byte slices for every single register even when they weren't 4 bytes wide. While that didn't impact anything functionally, it resulted in this abnormality in our docs:
![image](https://github.com/user-attachments/assets/ab9af5a7-89ef-4f29-9ccf-33c7ce868b2a)

Generating slices based off of how many bytes (i.e. the `node.size`) lets us handle slice generation more dynamically.
![image](https://github.com/user-attachments/assets/59a666b4-d00f-4220-9ea7-7193ef39466c)
