### PR TITLE
Fix meta sync to be generic for pipeline stages

### DIFF
--- a/hdl/ip/vhd/synchronizers/meta_sync.vhd
+++ b/hdl/ip/vhd/synchronizers/meta_sync.vhd
@@ -57,7 +57,7 @@ begin
         begin
             if rising_edge(clk) then
                 sr    <= shift_right(sr, 1);
-                sr(1) <= async_input;
+                sr(sr'left) <= async_input;
             end if;
         end process;
 
@@ -67,7 +67,7 @@ begin
         sync_regs: process(clk)
         begin
             if rising_edge(clk) then
-                sr(0) <= async_input;
+                sr(sr'left) <= async_input;
             end if;
         end process;
 


### PR DESCRIPTION
This fixes some generation issues with the block for sync_stages > 2.  This hasn't been a problem since we typically rely on the default 2 stages, but was noticed when debugging something else and I fixed it.