### PR TITLE
Inherit the range order from the config generic

### DIFF
--- a/hdl/ip/vhd/axi_blocks/axil_interconnect.vhd
+++ b/hdl/ip/vhd/axi_blocks/axil_interconnect.vhd
@@ -31,7 +31,7 @@ entity axil_interconnect is
         initiator : view axil26x32_pkg.axil_target;
 
         -- Initiator I/Fs to the responder blocks, which is a *controller* interface
-        responders : view (axil8x32_pkg.axil_controller) of axil8x32_pkg.axil_array_t(config_array'length - 1 downto 0)
+        responders : view (axil8x32_pkg.axil_controller) of axil8x32_pkg.axil_array_t(config_array'range)
 
     );
 end entity;


### PR DESCRIPTION
Previously, this assumed `High downto Low` indexing on the responders vector.

Due to a Vivado issue though we'd like the generic to come in unconstrained, which means that the instantiating entity wants to base the responders vector on the generic's range like so:

```
 constant config_array : axil_responder_cfg_array_t :=  -- unconstrained but then constrained by the assignment
     (0 => (base_addr => x"00000000", addr_span_bits => 8),
      1 => (base_addr => x"00000100", addr_span_bits => 8),
      2 => (base_addr => x"00000200", addr_span_bits => 8),
      3 => (base_addr => x"00000300", addr_span_bits => 8)
      );
    signal responders : axil8x32_pkg.axil_array_t(config_array'range); -- want to use range from the generic since it's known.
```

Annoyingly, unconstrained vectors typically default to `LOW to HIGH` range bounds. What this meant with the previous code here in axil_interconnect is that we'd accidentally reverse the responders index order if the user defined types as above with unconstrained bounds, but it would work fine for manually constrained bounds (so long as they were `High downto Low`).  This fixes things so that so long as the user at the top-level is consistent between the cfg_array and the responders array, the indexes will align as expected.

Also note that debugging such issues is extremely annoying as all the base addresses are essentially inverted... ie reading index 3 at 0x00000300 gets you responder 0's response which should have been available at 0x0.