### PR TITLE
Use .bin files not .bit files with a header

### DIFF
--- a/tools/vivado.bzl
+++ b/tools/vivado.bzl
@@ -294,11 +294,13 @@ def bitstream(ctx, input_checkpoint):
     vivado_flow_tcl, _ = _vivado_tcl_gen_common(ctx, flow, out_json)
     
     # create a bitstream file
-    bitstream = ctx.actions.declare_output("{}.bit".format(ctx.attrs.name))
+    bitstream_bit = ctx.actions.declare_output("{}.bit".format(ctx.attrs.name))
+    bitstream_bin = ctx.actions.declare_output("{}.bin".format(ctx.attrs.name))
     vivado = _make_vivado_common(ctx, name_and_flow, vivado_flow_tcl)
     # Add output files to tclargs
     vivado.add("-tclargs", 
-        bitstream.as_output(),
+        bitstream_bit.as_output(),
+        bitstream_bin.as_output(),
     )
     # because we're using the inputs to generate a tcl that *just* lists them,
     # irrespective of their content, we make the checkpoint a hidden input
@@ -307,7 +309,7 @@ def bitstream(ctx, input_checkpoint):
     # constraint file content changes
     vivado.hidden(input_checkpoint)
     ctx.actions.run(vivado, category="vivado_{}".format(flow))
-    providers.append(DefaultInfo(default_output=bitstream))
+    providers.append(DefaultInfo(default_output=bitstream_bin))
     return providers
 
 

--- a/tools/vivado_gen/templates/bitstream.jinja2
+++ b/tools/vivado_gen/templates/bitstream.jinja2
@@ -9,13 +9,18 @@
 #
 # Expects 1 argument: 
 # [0]: output bitfile
+# [1]: output binfile
 
 # Get tclargs here
 set output_bit [lindex $argv 0]
+set output_bin [lindex $argv 1]
 
 
 set_param general.maxThreads {{project.max_threads}}
 open_checkpoint {{project.input_checkpoint.absolute().as_posix()}}
 
 #write_debug_probes -force $PROJ_DIR/${PROJ_NAME}.ltx
+# This is a bit funky with buck2 in that this command writes out both the
+# .bit and the .bin. We take both names in as arguments to make buck2 happy
+# and assume the share the same name with different extensions.
 write_bitstream -force $output_bit -bin_file


### PR DESCRIPTION
.bit files have a header that according to Xilinx should not be sent to the device. While this was generally working ok, we have one or more bitstreams that seemed to be flaky configuring without being very reproducible. During the investigation, @mkeeter noticed that we should really be using the header-less file here so we change the build system to propagate the bin file into the compressor instead of the bit file.