### PR TITLE
Basic SGPIO blocks

### DIFF
--- a/hdl/ip/vhd/sgpio/BUCK
+++ b/hdl/ip/vhd/sgpio/BUCK
@@ -1,0 +1,23 @@
+load("//tools:hdl.bzl", "vhdl_unit", "vunit_sim")
+
+vhdl_unit(
+    name = "sgpio_top",
+    srcs = glob([
+        "*.vhd"
+    ]),
+    deps = [
+        "//hdl/ip/vhd/synchronizers:meta_sync",
+        "//hdl/ip/vhd/utilities:calc_pkg",
+        ],
+    standard = "2019",
+    visibility = ['PUBLIC']
+)
+
+vunit_sim(
+    name = "sgpio_tb",
+    srcs = glob(["sims/*.vhd"]),
+    deps = [
+        ":sgpio_top",
+    ],
+    visibility = ['PUBLIC'],
+)

--- a/hdl/ip/vhd/sgpio/sgpio_shift_in.vhd
+++ b/hdl/ip/vhd/sgpio/sgpio_shift_in.vhd
@@ -1,0 +1,65 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+-- Copyright 2024 Oxide Computer Company
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use ieee.numeric_std_unsigned.all;
+
+entity sgpio_shift_in is
+    generic (
+        BIT_COUNT : integer := 8;
+        INIT_VALUE : std_logic_vector(BIT_COUNT - 1 downto 0) := (others => '1');
+    );
+    port (
+        --! Latching clock input
+        clk : in    std_logic;
+        reset : in std_logic;
+        --! Output, sync'd to clk
+        sclk : in std_logic;
+        load : in std_logic;
+        di : in   std_logic;
+        in_reg : out std_logic_vector(BIT_COUNT - 1 downto 0);
+        in_reg_valid : out  std_logic;
+    );
+end entity;
+
+
+architecture rtl of sgpio_shift_in is
+    signal load_sr   : std_logic_vector(BIT_COUNT - 1 downto 0);
+    signal shift_reg : std_logic_vector(BIT_COUNT - 1 downto 0);
+    signal sclk_last : std_logic;
+
+begin
+
+    in_reg <= shift_reg;
+    -- data is valid when the sampled load signal shows 5 consecutive 0s
+    -- followed by a 1 indicating the last bit of the data.
+    in_reg_valid <= '1' when load_sr(5 downto 0) = 1 else '0';
+
+    process(clk, reset)
+    variable sclk_fedge : boolean := false;
+    begin
+        if reset then
+            shift_reg <= (others => '0');
+            load_sr <= (others => '0');
+            sclk_last <= '0';
+        elsif rising_edge(clk) then
+            sclk_fedge := sclk = '0' and sclk_last = '1';
+            sclk_last <= sclk;
+            if sclk_fedge then
+                -- Sample DI
+                shift_reg <= shift_left(shift_reg, 1);
+                shift_reg(0) <=di;
+                -- Sample LOAD
+                load_sr <= shift_left(load_sr, 1);
+                load_sr(0) <= load;
+            end if;
+        end if;
+    end process;
+
+
+end rtl;

--- a/hdl/ip/vhd/sgpio/sgpio_shift_out.vhd
+++ b/hdl/ip/vhd/sgpio/sgpio_shift_out.vhd
@@ -1,0 +1,56 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+-- Copyright 2024 Oxide Computer Company
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use ieee.numeric_std_unsigned.all;
+
+entity sgpio_shift_out is
+    generic (
+        BIT_COUNT : integer := 8;
+        INIT_VALUE : std_logic_vector(BIT_COUNT - 1 downto 0) := (others => '1');
+    );
+    port (
+        --! Latching clock input
+        clk : in    std_logic;
+        reset : in std_logic;
+        --! Output, sync'd to clk
+        sclk : in std_logic;
+        do : out   std_logic;
+        out_reg : in std_logic_vector(BIT_COUNT - 1 downto 0);
+        out_reg_load_en :in std_logic;
+    );
+end entity;
+
+architecture rtl of sgpio_shift_out is
+    signal shift_reg : std_logic_vector(BIT_COUNT - 1 downto 0);
+    signal sclk_last : std_logic;
+
+begin 
+
+    do <= shift_reg(shift_reg'high);
+
+    process(clk, reset)
+    variable sclk_redge : boolean := false;
+    begin
+        if reset then 
+            shift_reg <= INIT_VALUE;
+            sclk_last <= '0';
+        elsif rising_edge(clk) then
+            sclk_redge := sclk = '1' and sclk_last = '0';
+            sclk_last <= sclk;
+            if out_reg_load_en = '1' and sclk_redge then
+                shift_reg <= out_reg;
+            elsif sclk_redge then
+                shift_reg <= shift_left(shift_reg, 1);
+            end if;
+
+        end if;
+    end process;
+
+
+end rtl;

--- a/hdl/ip/vhd/sgpio/sgpio_top.vhd
+++ b/hdl/ip/vhd/sgpio/sgpio_top.vhd
@@ -1,0 +1,176 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+-- Copyright 2024 Oxide Computer Company
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use ieee.numeric_std_unsigned.all;
+
+use work.calc_pkg.all;
+
+entity sgpio_top is
+    generic(
+        LD_DEFAULT: std_logic_vector(3 downto 0) := x"5";
+        GPIO_WIDTH : integer;
+        CLK_DIV : integer
+    );
+    port(
+        clk : in std_logic;
+        reset : in std_logic;
+        -- Parallel interface
+        gpio_in : in std_logic_vector(GPIO_WIDTH - 1 downto 0);
+        gpio_out : out std_logic_vector(GPIO_WIDTH - 1 downto 0);
+        -- output interface
+        sclk : out std_logic;
+        do : out std_logic;
+        di : in std_logic;
+        load : out std_logic
+    );
+end entity;
+
+architecture rtl of sgpio_top is
+    signal di_syncd : std_logic;
+
+    -- SGPIO minimum size is 1 ending bit + 4 loads and 5 load low pulses
+    constant MIN_BITS : integer := (1 + 4 + 5);
+    constant TX_BITS : integer := maximum(GPIO_WIDTH, MIN_BITS);
+    constant TX_CNTR_DONE : integer := TX_BITS - 1;
+
+    constant LOAD_WORD : std_logic_vector(TX_BITS - 1 downto 0) := '1' & LD_DEFAULT & resize(x"0", TX_BITS - 5);
+    signal bit_counter : std_logic_vector(log2ceil(TX_BITS) - 1 downto 0);
+    signal sclk_gen_cntr : std_logic_vector(log2ceil(CLK_DIV) - 1 downto 0);
+    signal load_en : std_logic;
+    signal load_en_delay : std_logic;
+    signal sclk_last : std_logic;
+    signal ok_to_decode : std_logic;
+    signal in_reg : std_logic_vector(GPIO_WIDTH - 1 downto 0);
+    signal in_reg_valid : std_logic;
+
+
+begin
+
+    -- Gen divided clock
+    process(clk, reset)
+    begin
+        if reset then
+            sclk <= '0';
+            sclk_last <= '0';
+            sclk_gen_cntr <= (others => '0');
+        elsif rising_edge(clk) then
+            sclk_last <= sclk;
+            if sclk_gen_cntr = CLK_DIV - 1 then
+                sclk <= not sclk;
+                sclk_gen_cntr <= (others => '0');
+            else
+                sclk_gen_cntr <= sclk_gen_cntr + 1;
+            end if;
+        end if;
+    end process;
+
+    -- sync counter
+    process(clk, reset)
+         variable sclk_redge : boolean := false;
+    begin
+        if reset then
+            bit_counter <= (others => '0');
+            load_en <= '0';
+            load_en_delay <= '0';
+        elsif rising_edge(clk) then
+            sclk_redge := sclk = '1' and sclk_last = '0';
+            if sclk_redge then
+                load_en_delay <= load_en;
+            end if;
+
+            if sclk_redge and bit_counter = TX_CNTR_DONE then
+                bit_counter <= (others => '0');
+                load_en <= '1';
+            elsif sclk_redge then
+                bit_counter <= bit_counter + 1;
+                load_en <= '0';
+            end if;
+
+        end if;
+    end process;
+
+    -- input sync
+    sync: entity work.meta_sync
+     port map(
+        async_input => di,
+        clk => clk,
+        sycnd_output => di_syncd
+    );
+
+    -- for expediency, I'm setting this up like the ref platform
+    -- where the first load-word bit is actually the *end* of the previous
+    -- data. If we should desire to use this in a production system, I'd
+    -- like to re-do this to more properly represent how the SGPIO protocol
+    -- works, but for right now this is just to get a Ruby Dev system to
+    -- power up.
+
+    -- Use the output shift block to shift out the LOAD line, on load_en
+    -- where as the acutal DI will use a delayed version of load_en to 
+    -- align to the start of the frame.
+    -- load shifter
+    sgpio_load_shift_out_inst: entity work.sgpio_shift_out
+     generic map(
+        BIT_COUNT => TX_BITS
+    )
+     port map(
+        clk => clk,
+        reset => reset,
+        sclk => sclk,
+        do => load,
+        out_reg => LOAD_WORD,
+        out_reg_load_en => load_en
+    );
+    -- data out shifter
+    sgpio_do_shift_out_inst: entity work.sgpio_shift_out
+     generic map(
+        BIT_COUNT => TX_BITS,
+        INIT_VALUE => (others => '0')
+    )
+     port map(
+        clk => clk,
+        reset => reset,
+        sclk => sclk,
+        do => do,
+        out_reg => gpio_in,
+        out_reg_load_en => load_en_delay -- one clock behind
+    );
+    -- data in shifter
+    sgpio_shift_in_inst: entity work.sgpio_shift_in
+     generic map(
+        BIT_COUNT => TX_BITS
+    )
+     port map(
+        clk => clk,
+        reset => reset,
+        sclk => sclk,
+        load => load,
+        di => di_syncd,
+        in_reg => in_reg,
+        in_reg_valid => in_reg_valid
+    );
+
+    -- mask off rx'd data until we've seen a valid frame
+    process(clk, reset)
+    variable sclk_fedge : boolean := false;
+    begin
+        if reset then
+            gpio_out <= (others => '0');
+            ok_to_decode <= '0';
+        elsif rising_edge(clk) then
+            sclk_fedge := sclk = '0' and sclk_last = '1';
+            if sclk_fedge and in_reg_valid = '1' and ok_to_decode = '1' then
+                gpio_out <= in_reg(GPIO_WIDTH - 1 downto 0);
+            elsif sclk_fedge and in_reg_valid = '1' then
+                ok_to_decode <= '1';
+            end if;
+        end if;
+    end process;
+
+
+end rtl;

--- a/hdl/ip/vhd/sgpio/sims/sgpio_tb.vhd
+++ b/hdl/ip/vhd/sgpio/sims/sgpio_tb.vhd
@@ -1,0 +1,55 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+-- Copyright  Oxide Computer Company
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use ieee.numeric_std_unsigned.all;
+
+library vunit_lib;
+    context vunit_lib.com_context;
+    context vunit_lib.vunit_context;
+    context vunit_lib.vc_context;
+
+
+entity sgpio_tb is
+    generic (
+
+        runner_cfg : string
+    );
+end entity;
+
+architecture tb of sgpio_tb is
+
+begin
+
+    th: entity work.sgpio_th;
+
+    bench: process
+        alias reset is << signal th.reset : std_logic >>;
+    begin
+        -- Always the first thing in the process, set up things for the VUnit test runner
+        test_runner_setup(runner, runner_cfg);
+        -- Reach into the test harness, which generates and de-asserts reset and hold the
+        -- test cases off until we're out of reset. This runs for every test case
+        wait until reset = '0';
+        wait for 500 ns;  -- let the resets propagate
+
+        while test_suite loop
+            if run("gui_inspect") then
+                wait for 200 us;
+            end if;
+        end loop;
+
+        wait for 2 us;
+        test_runner_cleanup(runner);
+        wait;
+    end process;
+
+    -- -- Example total test timeout dog
+    test_runner_watchdog(runner, 10 ms);
+
+end tb;

--- a/hdl/ip/vhd/sgpio/sims/sgpio_th.vhd
+++ b/hdl/ip/vhd/sgpio/sims/sgpio_th.vhd
@@ -1,0 +1,52 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+-- Copyright 2024 Oxide Computer Company
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library vunit_lib;
+    context vunit_lib.vunit_context;
+    context vunit_lib.com_context;
+    context vunit_lib.vc_context;
+
+entity sgpio_th is
+end entity;
+
+architecture th of sgpio_th is
+
+    signal clk   : std_logic := '0';
+    signal reset : std_logic := '1';
+    signal gpio_in : std_logic_vector(15 downto 0) := x"AAAA";
+    signal sclk : std_logic;
+    signal do : std_logic;
+    signal di : std_logic := '0';
+    signal load : std_logic;
+
+begin
+
+     -- set up a fastish, clock for the sim
+    -- env and release reset after a bit of time
+    clk   <= not clk after 4 ns;
+    reset <= '0' after 200 ns;
+
+    sgpio_top_inst: entity work.sgpio_top
+     generic map(
+        GPIO_WIDTH => 16,
+        CLK_DIV => 4
+    )
+     port map(
+        clk => clk,
+        reset => reset,
+        gpio_in => gpio_in,
+        gpio_out => open,
+        sclk => sclk,
+        do => do,
+        di => di,
+        load => load
+    );
+
+end th;


### PR DESCRIPTION
This is a simple block with the sgpio shifter primitives to enable grapefruit working in ruby.  I don't love some of this but it was done in a quick and efficient manner to reduce risk. We don't plan on using this in product, just for gfruit dev so I'm not too worried about it, and it's been tested in hw and is functional.