### PR TITLE
Fix TofinoDebugPortTest

### DIFF
--- a/hdl/projects/sidecar/mainboard/TofinoDebugPort.bsv
+++ b/hdl/projects/sidecar/mainboard/TofinoDebugPort.bsv
@@ -118,8 +118,7 @@ module mkTofinoDebugPort #(
     I2CCore i2c <- mkI2CCore(system_frequency_hz,
                                 i2c_frequency_hz,
                                 system_period_ns,
-                                tofino_i2c_stretch_timeout_us
-                            );
+                                tofino_i2c_stretch_timeout_us);
     ConfigReg#(Maybe#(Error)) error <- mkConfigReg(tagged Invalid);
 
     // Buffer and connections to the module interface.

--- a/hdl/projects/sidecar/mainboard/test/BUILD
+++ b/hdl/projects/sidecar/mainboard/test/BUILD
@@ -21,10 +21,10 @@ bluesim_tests('PCIeEndpointControllerTests',
     deps = [
         ':MockTofino2Sequencer',
         '//hdl/ip/bsv:PowerRail',
-        '//hdl/projects/sidecar/mainboard:PCIeEndpointController',
         '//hdl/ip/bsv:Strobe',
         '//hdl/ip/bsv:TestUtils',
         '//hdl/ip/bsv:Debouncer',
+        '//hdl/projects/sidecar/mainboard:PCIeEndpointController',
     ])
 
 bluesim_tests('TofinoDebugPortTests',


### PR DESCRIPTION
#210 missed TofinoDebugPortTest. This diff refactors the tests to use the I2CTestParam struct for initialization and reflect the fact that the controller will ack poll.