### PR TITLE
Add basic stream VCs

### DIFF
--- a/hdl/ip/vhd/vunit_components/BUCK
+++ b/hdl/ip/vhd/vunit_components/BUCK
@@ -26,3 +26,16 @@ vunit_sim(
     deps = [":qspi_controller_vc"],
     visibility = ['PUBLIC'],
 )
+
+vhdl_unit(
+    name = "basic_stream",
+    srcs = glob(["basic_stream/*.vhd"]),
+    visibility = ['PUBLIC']
+)
+
+vunit_sim(
+    name = "tb_basic_stream",
+    srcs = glob(["basic_stream/sims/*.vhd"]),
+    deps = [":basic_stream"],
+    visibility = ['PUBLIC']
+)

--- a/hdl/ip/vhd/vunit_components/basic_stream/basic_sink.vhd
+++ b/hdl/ip/vhd/vunit_components/basic_stream/basic_sink.vhd
@@ -1,0 +1,62 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+-- Copyright 2024 Oxide Computer Company
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+library osvvm;
+use osvvm.RandomPkg.RandomPType;
+
+library vunit_lib;
+    context vunit_lib.vunit_context;
+    context vunit_lib.com_context;
+    context vunit_lib.vc_context;
+
+use work.basic_stream_pkg.all;
+
+entity basic_sink is
+    generic (
+        sink    : basic_sink_t
+    );
+    port (
+        clk     : in std_logic;
+        ready   : out std_logic := '0';
+        valid   : in std_logic;
+        data    : in std_logic_vector(data_length(sink)-1 downto 0)
+    );
+end entity;
+
+architecture model of basic_sink is
+begin
+
+    main: process
+        variable msg, reply_msg : msg_t;
+        variable msg_type       : msg_type_t;
+        variable rnd            : RandomPType;
+    begin
+        receive(net, sink.p_actor, msg);
+        msg_type := message_type(msg);
+
+        if msg_type = stream_pop_msg or msg_type = pop_basic_stream_msg then
+            -- loop until ready
+            while rnd.Uniform(0.0, 1.0) > sink.ready_high_probability loop
+                wait until rising_edge(clk);
+            end loop;
+            ready <= '1';
+            -- wait for a clk rising edge to sample valid
+            wait until ready = '1' and rising_edge(clk);
+            if valid = '1' then
+                push_std_ulogic_vector(reply_msg, data);
+            end if;
+
+            reply(net, msg, reply_msg);
+            ready <= '0';
+        else
+            unexpected_msg_type(msg_type);
+        end if;
+    end process;
+
+end architecture;

--- a/hdl/ip/vhd/vunit_components/basic_stream/basic_sink.vhd
+++ b/hdl/ip/vhd/vunit_components/basic_stream/basic_sink.vhd
@@ -3,6 +3,8 @@
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
 -- Copyright 2024 Oxide Computer Company
+--
+-- A basic sink for streamed data that can apply backpressure.
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/vunit_components/basic_stream/basic_source.vhd
+++ b/hdl/ip/vhd/vunit_components/basic_stream/basic_source.vhd
@@ -1,0 +1,59 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+-- Copyright 2024 Oxide Computer Company
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+library osvvm;
+use osvvm.RandomPkg.RandomPType;
+
+library vunit_lib;
+    context vunit_lib.vunit_context;
+    context vunit_lib.com_context;
+    context vunit_lib.vc_context;
+
+use work.basic_stream_pkg.all;
+
+entity basic_source is
+    generic (
+        source  : basic_source_t
+    );
+    port (
+        clk     : in std_logic;
+        ready   : in std_logic;
+        valid   : out std_logic := '0';
+        data    : out std_logic_vector(data_length(source)-1 downto 0) := (others => '0')
+    );
+end entity;
+
+architecture model of basic_source is
+begin
+
+    main: process
+        variable msg        : msg_t;
+        variable msg_type   : msg_type_t;
+        variable rnd        : RandomPType;
+    begin
+        receive(net, source.p_actor, msg);
+        msg_type := message_type(msg);
+
+        if msg_type = stream_push_msg or msg_type = push_basic_stream_msg then
+            -- loop until there will be valid data
+            while rnd.Uniform(0.0, 1.0) > source.valid_high_probability loop
+                wait until rising_edge(clk);
+            end loop;
+            valid   <= '1';
+            data    <= pop_std_ulogic_vector(msg);
+
+            -- wait until data should be accepted
+            wait until (valid and ready) = '1' and rising_edge(clk);
+            valid   <= '0';
+        else
+            unexpected_msg_type(msg_type);
+        end if;
+    end process;
+
+end architecture;

--- a/hdl/ip/vhd/vunit_components/basic_stream/basic_source.vhd
+++ b/hdl/ip/vhd/vunit_components/basic_stream/basic_source.vhd
@@ -3,6 +3,8 @@
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
 -- Copyright 2024 Oxide Computer Company
+--
+-- A basic source of streamed data that respects backpressure.
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/vunit_components/basic_stream/basic_stream_pkg.vhd
+++ b/hdl/ip/vhd/vunit_components/basic_stream/basic_stream_pkg.vhd
@@ -47,14 +47,13 @@ package basic_stream_pkg is
     ) return basic_sink_t;
 
     impure function data_length(source : basic_source_t) return natural;
-    impure function data_length(source : basic_sink_t) return natural;
+    impure function data_length(sink : basic_sink_t) return natural;
 
     impure function as_stream(source : basic_source_t) return stream_master_t;
     impure function as_stream(sink : basic_sink_t) return stream_slave_t;
 
     constant push_basic_stream_msg          : msg_type_t := new_msg_type("push basic stream");
     constant pop_basic_stream_msg           : msg_type_t := new_msg_type("pop basic stream");
-    constant basic_stream_transaction_msg   : msg_type_t := new_msg_type("basic stream transaction");
 
     procedure push_basic_stream(
         signal net      : inout network_t;
@@ -66,30 +65,6 @@ package basic_stream_pkg is
         signal net : inout network_t;
         basic_sink : basic_sink_t;
         variable data : inout std_logic_vector
-    );
-
-    type basic_stream_transaction_t is record
-        data : std_logic_vector;
-    end record;
-
-    procedure push_basic_stream_transaction(
-        msg : msg_t; 
-        basic_stream_transaction : basic_stream_transaction_t
-    );
-
-    procedure pop_basic_stream_transaction(
-        constant msg                        : in msg_t;
-        variable basic_stream_transaction   : out basic_stream_transaction_t
-    );
-
-    impure function new_basic_stream_transaction_msg(
-        basic_stream_transaction : basic_stream_transaction_t
-    ) return msg_t;
-
-    procedure handle_basic_stream_transaction(
-        variable msg_type           : inout msg_type_t;
-        variable msg                : inout msg_t;
-        variable basic_transaction  : out basic_stream_transaction_t
     );
 
 end package;
@@ -137,9 +112,9 @@ package body basic_stream_pkg is
         return source.p_data_length;
     end;
 
-    impure function data_length(source : basic_sink_t) return natural is
+    impure function data_length(sink : basic_sink_t) return natural is
     begin
-        return source.p_data_length;
+        return sink.p_data_length;
     end;
 
     impure function as_stream(source : basic_source_t) return stream_master_t is
@@ -158,10 +133,8 @@ package body basic_stream_pkg is
         data            : std_logic_vector
     ) is
         variable msg : msg_t := new_msg(push_basic_stream_msg);
-        variable basic_stream_transaction : basic_stream_transaction_t(data(data'length - 1 downto 0));
     begin
-        basic_stream_transaction.data := data;
-        push_basic_stream_transaction(msg, basic_stream_transaction);
+        push_std_ulogic_vector(msg, data);
         send(net, basic_source.p_actor, msg);
     end;
 
@@ -172,51 +145,12 @@ package body basic_stream_pkg is
     ) is
         variable reference : msg_t := new_msg(pop_basic_stream_msg);
         variable reply_msg : msg_t;
-        variable basic_stream_transaction : basic_stream_transaction_t(data(data'length - 1 downto 0));
     begin
         send(net, basic_sink.p_actor, reference);
         receive_reply(net, reference, reply_msg);
-        pop_basic_stream_transaction(reply_msg, basic_stream_transaction);
-        data := basic_stream_transaction.data;
+        data := pop_std_ulogic_vector(reply_msg);
         delete(reference);
         delete(reply_msg);
-    end;
-
-    procedure push_basic_stream_transaction(
-        msg                         : msg_t;
-        basic_stream_transaction    : basic_stream_transaction_t
-    ) is
-    begin
-        push_std_ulogic_vector(msg, basic_stream_transaction.data);
-    end;
-
-    procedure pop_basic_stream_transaction(
-        constant msg                        : in msg_t;
-        variable basic_stream_transaction   : out basic_stream_transaction_t
-    ) is
-    begin
-        basic_stream_transaction.data := pop_std_ulogic_vector(msg);
-    end;
-
-  impure function new_basic_stream_transaction_msg(
-    basic_stream_transaction : basic_stream_transaction_t
-  ) return msg_t is
-        variable msg : msg_t;
-    begin
-        msg := new_msg(basic_stream_transaction_msg);
-        push_basic_stream_transaction(msg, basic_stream_transaction);
-        return msg;
-    end;
-
-    procedure handle_basic_stream_transaction(
-        variable msg_type           : inout msg_type_t;
-        variable msg                : inout msg_t;
-        variable basic_transaction  : out basic_stream_transaction_t) is
-    begin
-        if msg_type = basic_stream_transaction_msg then
-            handle_message(msg_type);
-            pop_basic_stream_transaction(msg, basic_transaction);
-        end if;
     end;
 
 end package body;

--- a/hdl/ip/vhd/vunit_components/basic_stream/basic_stream_pkg.vhd
+++ b/hdl/ip/vhd/vunit_components/basic_stream/basic_stream_pkg.vhd
@@ -1,0 +1,222 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+-- Copyright 2024 Oxide Computer Company
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+library vunit_lib;
+    context vunit_lib.vunit_context;
+    context vunit_lib.com_context;
+    context vunit_lib.vc_context;
+
+package basic_stream_pkg is
+
+    type basic_source_t is record
+        valid_high_probability  : real range 0.0 to 1.0;
+        -- private
+        p_actor         : actor_t;
+        p_data_length   : natural;
+        p_logger        : logger_t;
+    end record;
+
+    type basic_sink_t is record
+        ready_high_probability  : real range 0.0 to 1.0;
+        -- private
+        p_actor         : actor_t;
+        p_data_length   : natural;
+        p_logger        : logger_t;
+    end record;
+
+    constant basic_stream_logger    : logger_t := get_logger("work:basic_stream_pkg");
+
+    impure function new_basic_source(
+        data_length             : natural;
+        valid_high_probability  : real := 1.0;
+        logger                  : logger_t := basic_stream_logger;
+        actor                   : actor_t := null_actor
+    ) return basic_source_t;
+
+    impure function new_basic_sink(
+        data_length             : natural;
+        ready_high_probability  : real := 1.0;
+        logger                  : logger_t := basic_stream_logger;
+        actor                   : actor_t := null_actor
+    ) return basic_sink_t;
+
+    impure function data_length(source : basic_source_t) return natural;
+    impure function data_length(source : basic_sink_t) return natural;
+
+    impure function as_stream(source : basic_source_t) return stream_master_t;
+    impure function as_stream(sink : basic_sink_t) return stream_slave_t;
+
+    constant push_basic_stream_msg          : msg_type_t := new_msg_type("push basic stream");
+    constant pop_basic_stream_msg           : msg_type_t := new_msg_type("pop basic stream");
+    constant basic_stream_transaction_msg   : msg_type_t := new_msg_type("basic stream transaction");
+
+    procedure push_basic_stream(
+        signal net      : inout network_t;
+        basic_source    : basic_source_t;
+        data            : std_logic_vector
+    );
+
+    procedure pop_basic_stream(
+        signal net : inout network_t;
+        basic_sink : basic_sink_t;
+        variable data : inout std_logic_vector
+    );
+
+    type basic_stream_transaction_t is record
+        data : std_logic_vector;
+    end record;
+
+    procedure push_basic_stream_transaction(
+        msg : msg_t; 
+        basic_stream_transaction : basic_stream_transaction_t
+    );
+
+    procedure pop_basic_stream_transaction(
+        constant msg                        : in msg_t;
+        variable basic_stream_transaction   : out basic_stream_transaction_t
+    );
+
+    impure function new_basic_stream_transaction_msg(
+        basic_stream_transaction : basic_stream_transaction_t
+    ) return msg_t;
+
+    procedure handle_basic_stream_transaction(
+        variable msg_type           : inout msg_type_t;
+        variable msg                : inout msg_t;
+        variable basic_transaction  : out basic_stream_transaction_t
+    );
+
+end package;
+
+package body basic_stream_pkg is
+
+    impure function new_basic_source(
+        data_length             : natural;
+        valid_high_probability  : real := 1.0;
+        logger                  : logger_t := basic_stream_logger;
+        actor                   : actor_t := null_actor
+    ) return basic_source_t is
+        variable p_actor : actor_t;
+    begin
+        p_actor := actor when actor /= null_actor else new_actor;
+
+        return (
+            valid_high_probability => valid_high_probability,
+            p_actor => p_actor,
+            p_data_length => data_length,
+            p_logger => logger
+        );
+    end;
+
+    impure function new_basic_sink(
+        data_length             : natural;
+        ready_high_probability  : real := 1.0;
+        logger                  : logger_t := basic_stream_logger;
+        actor                   : actor_t := null_actor)
+    return basic_sink_t is
+        variable p_actor : actor_t;
+    begin
+        p_actor := actor when actor /= null_actor else new_actor;
+
+        return (
+            ready_high_probability => ready_high_probability,
+            p_actor => p_actor,
+            p_data_length => data_length,
+            p_logger => logger
+        );
+    end;
+
+    impure function data_length(source : basic_source_t) return natural is
+    begin
+        return source.p_data_length;
+    end;
+
+    impure function data_length(source : basic_sink_t) return natural is
+    begin
+        return source.p_data_length;
+    end;
+
+    impure function as_stream(source : basic_source_t) return stream_master_t is
+    begin
+        return (p_actor => source.p_actor);
+    end;
+
+    impure function as_stream(sink : basic_sink_t) return stream_slave_t is
+    begin
+        return (p_actor => sink.p_actor);
+    end;
+
+    procedure push_basic_stream(
+        signal net      : inout network_t;
+        basic_source    : basic_source_t;
+        data            : std_logic_vector
+    ) is
+        variable msg : msg_t := new_msg(push_basic_stream_msg);
+        variable basic_stream_transaction : basic_stream_transaction_t(data(data'length - 1 downto 0));
+    begin
+        basic_stream_transaction.data := data;
+        push_basic_stream_transaction(msg, basic_stream_transaction);
+        send(net, basic_source.p_actor, msg);
+    end;
+
+    procedure pop_basic_stream(
+        signal net : inout network_t;
+        basic_sink : basic_sink_t;
+        variable data : inout std_logic_vector
+    ) is
+        variable reference : msg_t := new_msg(pop_basic_stream_msg);
+        variable reply_msg : msg_t;
+        variable basic_stream_transaction : basic_stream_transaction_t(data(data'length - 1 downto 0));
+    begin
+        send(net, basic_sink.p_actor, reference);
+        receive_reply(net, reference, reply_msg);
+        pop_basic_stream_transaction(reply_msg, basic_stream_transaction);
+        data := basic_stream_transaction.data;
+        delete(reference);
+        delete(reply_msg);
+    end;
+
+    procedure push_basic_stream_transaction(
+        msg                         : msg_t;
+        basic_stream_transaction    : basic_stream_transaction_t
+    ) is
+    begin
+        push_std_ulogic_vector(msg, basic_stream_transaction.data);
+    end;
+
+    procedure pop_basic_stream_transaction(
+        constant msg                        : in msg_t;
+        variable basic_stream_transaction   : out basic_stream_transaction_t
+    ) is
+    begin
+        basic_stream_transaction.data := pop_std_ulogic_vector(msg);
+    end;
+
+  impure function new_basic_stream_transaction_msg(
+    basic_stream_transaction : basic_stream_transaction_t
+  ) return msg_t is
+        variable msg : msg_t;
+    begin
+        msg := new_msg(basic_stream_transaction_msg);
+        push_basic_stream_transaction(msg, basic_stream_transaction);
+        return msg;
+    end;
+
+    procedure handle_basic_stream_transaction(
+        variable msg_type           : inout msg_type_t;
+        variable msg                : inout msg_t;
+        variable basic_transaction  : out basic_stream_transaction_t) is
+    begin
+        if msg_type = basic_stream_transaction_msg then
+            handle_message(msg_type);
+            pop_basic_stream_transaction(msg, basic_transaction);
+        end if;
+    end;
+
+end package body;

--- a/hdl/ip/vhd/vunit_components/basic_stream/sims/tb_basic_stream.vhd
+++ b/hdl/ip/vhd/vunit_components/basic_stream/sims/tb_basic_stream.vhd
@@ -1,0 +1,82 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+-- Copyright  Oxide Computer Company
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use ieee.numeric_std_unsigned.all;
+
+library vunit_lib;
+    context vunit_lib.com_context;
+    context vunit_lib.vunit_context;
+    context vunit_lib.vc_context;
+
+use work.basic_stream_pkg.all;
+
+entity tb_basic_stream is
+    generic (
+        runner_cfg : string
+    );
+end entity;
+
+architecture tb of tb_basic_stream is
+
+begin
+
+    th: entity work.th_basic_stream;
+
+    bench: process
+        alias clk is << signal th.clk : std_logic >>;
+        alias source is << constant th.basic_source_stream : basic_source_t >>;
+        alias sink is << constant th.basic_sink_stream : basic_sink_t >>;
+        
+        constant master_stream : stream_master_t := as_stream(source);
+        constant slave_stream : stream_slave_t := as_stream(sink);
+        variable temp   : std_logic_vector(data_length(sink)'range);
+    begin
+        -- Always the first thing in the process, set up things for the VUnit test runner
+        test_runner_setup(runner, runner_cfg);
+        set_format(display_handler, verbose, true);
+        show(sink.p_logger, display_handler, trace);
+
+        while test_suite loop
+            if run("test single push and pop") then
+                push_stream(net, master_stream, x"77");
+                pop_stream(net, slave_stream, temp);
+                check_equal(temp, std_logic_vector'(x"77"), "pop stream data");
+            elsif run("test double push and pop") then
+                push_stream(net, master_stream, x"66");
+                pop_stream(net, slave_stream, temp);
+                check_equal(temp, std_logic_vector'(x"66"), "pop stream first data");
+          
+                push_stream(net, master_stream, x"55");
+                pop_stream(net, slave_stream, temp);
+                check_equal(temp, std_logic_vector'(x"55"), "pop stream second data");
+            elsif run("push delay pop") then
+                push_stream(net, master_stream, x"de");
+                wait until rising_edge(clk);
+                wait until rising_edge(clk);
+                wait until rising_edge(clk);
+                pop_stream(net, slave_stream, temp);
+                check_equal(temp, std_logic_vector'(x"de"), "pop stream data");
+            elsif run("block push and pop") then
+                for i in 0 to 7 loop
+                    push_stream(net, master_stream, std_logic_vector(to_unsigned(i, 8)));
+                    pop_stream(net, slave_stream, temp);
+                    check_equal(temp, std_logic_vector(to_unsigned(i, 8)), "pop stream data"&natural'image(i));
+                end loop;
+            end if;
+        end loop;
+
+        wait for 2 us;
+        test_runner_cleanup(runner);
+        wait;
+    end process;
+
+    -- Example total test timeout dog
+    test_runner_watchdog(runner, 10 ms);
+
+end tb;

--- a/hdl/ip/vhd/vunit_components/basic_stream/sims/tb_basic_stream.vhd
+++ b/hdl/ip/vhd/vunit_components/basic_stream/sims/tb_basic_stream.vhd
@@ -24,9 +24,10 @@ end entity;
 
 architecture tb of tb_basic_stream is
 
+    -- Create the source/sinks with relatively low valid/ready probability to help esnure those
+    -- signals are being respected.
     constant basic_source_stream : basic_source_t :=
         new_basic_source(data_length => 8, valid_high_probability => 0.5);
-
     constant basic_sink_stream : basic_sink_t :=
         new_basic_sink(data_length => 8, ready_high_probability => 0.5);
 

--- a/hdl/ip/vhd/vunit_components/basic_stream/sims/tb_basic_stream.vhd
+++ b/hdl/ip/vhd/vunit_components/basic_stream/sims/tb_basic_stream.vhd
@@ -24,48 +24,54 @@ end entity;
 
 architecture tb of tb_basic_stream is
 
+    constant basic_source_stream : basic_source_t :=
+        new_basic_source(data_length => 8, valid_high_probability => 0.5);
+
+    constant basic_sink_stream : basic_sink_t :=
+        new_basic_sink(data_length => 8, ready_high_probability => 0.5);
+
 begin
 
-    th: entity work.th_basic_stream;
+    th: entity work.th_basic_stream
+        generic map (
+            source  => basic_source_stream,
+            sink    => basic_sink_stream
+        );
 
     bench: process
         alias clk is << signal th.clk : std_logic >>;
-        alias source is << constant th.basic_source_stream : basic_source_t >>;
-        alias sink is << constant th.basic_sink_stream : basic_sink_t >>;
-        
-        constant master_stream : stream_master_t := as_stream(source);
-        constant slave_stream : stream_slave_t := as_stream(sink);
-        variable temp   : std_logic_vector(data_length(sink)'range);
+
+        variable temp : std_logic_vector(data_length(basic_source_stream)-1 downto 0);
     begin
         -- Always the first thing in the process, set up things for the VUnit test runner
         test_runner_setup(runner, runner_cfg);
         set_format(display_handler, verbose, true);
-        show(sink.p_logger, display_handler, trace);
+        show(basic_sink_stream.p_logger, display_handler, trace);
 
         while test_suite loop
-            if run("test single push and pop") then
-                push_stream(net, master_stream, x"77");
-                pop_stream(net, slave_stream, temp);
+            if run("test_single_push_and_pop") then
+                push_basic_stream(net, basic_source_stream, x"77");
+                pop_basic_stream(net, basic_sink_stream, temp);
                 check_equal(temp, std_logic_vector'(x"77"), "pop stream data");
-            elsif run("test double push and pop") then
-                push_stream(net, master_stream, x"66");
-                pop_stream(net, slave_stream, temp);
+            elsif run("test_double_push_and_pop") then
+                push_basic_stream(net, basic_source_stream, x"66");
+                pop_basic_stream(net, basic_sink_stream, temp);
                 check_equal(temp, std_logic_vector'(x"66"), "pop stream first data");
           
-                push_stream(net, master_stream, x"55");
-                pop_stream(net, slave_stream, temp);
+                push_basic_stream(net, basic_source_stream, x"55");
+                pop_basic_stream(net, basic_sink_stream, temp);
                 check_equal(temp, std_logic_vector'(x"55"), "pop stream second data");
-            elsif run("push delay pop") then
-                push_stream(net, master_stream, x"de");
+            elsif run("push_delay_pop") then
+                push_basic_stream(net, basic_source_stream, x"de");
                 wait until rising_edge(clk);
                 wait until rising_edge(clk);
                 wait until rising_edge(clk);
-                pop_stream(net, slave_stream, temp);
+                pop_basic_stream(net, basic_sink_stream, temp);
                 check_equal(temp, std_logic_vector'(x"de"), "pop stream data");
-            elsif run("block push and pop") then
+            elsif run("block_push_and_pop") then
                 for i in 0 to 7 loop
-                    push_stream(net, master_stream, std_logic_vector(to_unsigned(i, 8)));
-                    pop_stream(net, slave_stream, temp);
+                    push_basic_stream(net, basic_source_stream, std_logic_vector(to_unsigned(i, 8)));
+                    pop_basic_stream(net, basic_sink_stream, temp);
                     check_equal(temp, std_logic_vector(to_unsigned(i, 8)), "pop stream data"&natural'image(i));
                 end loop;
             end if;

--- a/hdl/ip/vhd/vunit_components/basic_stream/sims/th_basic_stream.vhd
+++ b/hdl/ip/vhd/vunit_components/basic_stream/sims/th_basic_stream.vhd
@@ -16,26 +16,23 @@ library vunit_lib;
 use work.basic_stream_pkg.all;
 
 entity th_basic_stream is
+    generic (
+        source : basic_source_t;
+        sink: basic_sink_t
+    );
 end entity;
 
 architecture th of th_basic_stream is
-
-    constant basic_source_stream : basic_source_t :=
-        new_basic_source(data_length => 8, valid_high_probability => 0.1);
-
-    constant basic_sink_stream : basic_sink_t :=
-        new_basic_sink(data_length => 8, ready_high_probability => 0.3);
-
     signal clk   : std_logic := '0';
     signal valid : std_logic;
     signal ready : std_logic;
-    signal data  : std_logic_vector(data_length(basic_source_stream)-1 downto 0);
+    signal data  : std_logic_vector(data_length(source)-1 downto 0);
 begin
     clk   <= not clk after 4 ns;
 
     basic_source_vc : entity work.basic_source
     generic map (
-        source  => basic_source_stream)
+        source  => source)
     port map (
         clk     => clk,
         valid   => valid,
@@ -45,7 +42,7 @@ begin
 
   basic_sink_vc : entity work.basic_sink
     generic map (
-        sink    => basic_sink_stream)
+        sink    => sink)
     port map (
         clk     => clk,
         valid   => valid,

--- a/hdl/ip/vhd/vunit_components/basic_stream/sims/th_basic_stream.vhd
+++ b/hdl/ip/vhd/vunit_components/basic_stream/sims/th_basic_stream.vhd
@@ -1,0 +1,55 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+-- Copyright 2024 Oxide Computer Company
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library vunit_lib;
+    context vunit_lib.vunit_context;
+    context vunit_lib.com_context;
+    context vunit_lib.vc_context;
+
+use work.basic_stream_pkg.all;
+
+entity th_basic_stream is
+end entity;
+
+architecture th of th_basic_stream is
+
+    constant basic_source_stream : basic_source_t :=
+        new_basic_source(data_length => 8, valid_high_probability => 0.1);
+
+    constant basic_sink_stream : basic_sink_t :=
+        new_basic_sink(data_length => 8, ready_high_probability => 0.3);
+
+    signal clk   : std_logic := '0';
+    signal valid : std_logic;
+    signal ready : std_logic;
+    signal data  : std_logic_vector(data_length(basic_source_stream)-1 downto 0);
+begin
+    clk   <= not clk after 4 ns;
+
+    basic_source_vc : entity work.basic_source
+    generic map (
+        source  => basic_source_stream)
+    port map (
+        clk     => clk,
+        valid   => valid,
+        ready   => ready,
+        data    => data
+    );
+
+  basic_sink_vc : entity work.basic_sink
+    generic map (
+        sink    => basic_sink_stream)
+    port map (
+        clk     => clk,
+        valid   => valid,
+        ready   => ready,
+        data    => data
+    );
+end architecture;


### PR DESCRIPTION
This adds basic stream verification components. The basic stream source/sink occupy a middle ground with VUnit's stream master/slave being simpler (just push/pop of data) and VUnit's AXI/Avalon being richer (more framing and control options). These components allow for pushing and popping of data while respecting the source's `valid` and the sink's `ready`.