### PR TITLE
Update synchronizers to use resets, fix broken uart tb

### DIFF
--- a/hdl/ip/vhd/synchronizers/bacd.vhd
+++ b/hdl/ip/vhd/synchronizers/bacd.vhd
@@ -73,8 +73,10 @@ begin
     handshake_a_to_b: entity work.tacd(rtl)
         port map (
             clk_launch      => clk_launch,
+            reset_launch    => reset_launch,
             pulse_in_launch => write_a_in_masked,
             clk_latch       => clk_latch,
+            reset_latch     => reset_latch,
             pulse_out_latch => handshake_from_launch
         );
 
@@ -84,8 +86,10 @@ begin
         port
     map (
             clk_launch      => clk_latch,
+            reset_launch    => reset_latch,
             pulse_in_launch => handshake_from_launch,
             clk_latch       => clk_launch,
+            reset_latch     => reset_launch,
             pulse_out_latch => handshake_from_latch
         );
 

--- a/hdl/ip/vhd/synchronizers/sims/synchronizers_th.vhd
+++ b/hdl/ip/vhd/synchronizers/sims/synchronizers_th.vhd
@@ -77,8 +77,10 @@ begin
         port
     map (
             clk_launch      => clk_a,
+            reset_launch   => reset_a,
             pulse_in_launch => sim_gpio_out,
             clk_latch       => clk_b,
+            reset_latch     => reset_b,
             pulse_out_latch => tacd_latch_out
         );
 

--- a/hdl/ip/vhd/uart/sims/uart_th.vhd
+++ b/hdl/ip/vhd/uart/sims/uart_th.vhd
@@ -72,6 +72,7 @@ begin
         rts_pin => dut_rts_pin,
         cts_pin => dut_cts_pin,
         axi_clk => clk,
+        axi_reset => reset,
         rx_ready => dut_rx_ready,
         rx_data => dut_rx_data,
         rx_valid => dut_rx_valid,


### PR DESCRIPTION
This was a hold-over from me trying to be clever and not use async resets for some of these blocks.  I'm generally convinced doing this isn't worth the hassle and lack of clarity.  I found at least one bug or unexpected behavior where when the design comes out of reset but on of the lines here was held high we'd miss the handshake.  Adding back in the various domain resets to tacd resolves that issue with no real functionality change but the interface changes slightly to accommodate the additional resets.

Also fixed uart testbench which was missed on a previous change.