### PR TITLE
Adjust time_pkg::private_internal_calc to remove truncation warning

### DIFF
--- a/hdl/ip/vhd/common/utils/time_pkg.vhd
+++ b/hdl/ip/vhd/common/utils/time_pkg.vhd
@@ -146,7 +146,7 @@ package body time_pkg is
     begin
         -- Not all values work out evenly since we're dividing, so we round up the value as needed
         -- to be greater than or equal to the requested value
-        ret_num := to_unsigned(natural(ceil(real(desired * sacle_factor) / real(clk_per_ns))), 32)(return_size-1 downto 0);
+        ret_num := resize(to_unsigned(natural(ceil(real(desired * sacle_factor) / real(clk_per_ns))), 32), return_size);
         return ret_num;
     end;
 

--- a/hdl/ip/vhd/common/utils/time_pkg.vhd
+++ b/hdl/ip/vhd/common/utils/time_pkg.vhd
@@ -146,7 +146,7 @@ package body time_pkg is
     begin
         -- Not all values work out evenly since we're dividing, so we round up the value as needed
         -- to be greater than or equal to the requested value
-        ret_num := to_unsigned(natural(ceil(real(desired * sacle_factor) / real(clk_per_ns))), ret_num'length);
+        ret_num := to_unsigned(natural(ceil(real(desired * sacle_factor) / real(clk_per_ns))), 32)(return_size-1 downto 0);
         return ret_num;
     end;
 


### PR DESCRIPTION
When we actually construct the return value in [`private_internal_calc`](https://github.com/oxidecomputer/quartz/blob/main/hdl/ip/vhd/common/utils/time_pkg.vhd#L149), anything less than the size of VHDL's `INTEGER` type of 32-bits yields a vector truncation warning since we're trimming down a `NATURAL` (an `INTEGER` between 0 and 2^31).

```vhdl
constant TEST : unsigned(7 downto 0) := calc_ns(SOME_TEST_NS, CLK_PER_NS, 8);
```
```
** Warning: NUMERIC_STD.TO_UNSIGNED: vector truncated
...
   Function TO_UNSIGNED [NATURAL, NATURAL return UNRESOLVED_UNSIGNED] at ../lib/ieee.08/numeric_std-body.vhdl:3078
   Function PRIVATE_INTERNAL_CALC [POSITIVE, POSITIVE, POSITIVE, POSITIVE return UNSIGNED] at /home/aaron/Oxide/git/quartz/hdl/ip/vhd/common/utils/time_pkg.vhd:149
   Function CALC_NS [POSITIVE, POSITIVE, POSITIVE return UNSIGNED] at /home/aaron/Oxide/git/quartz/hdl/ip/vhd/common/utils/time_pkg.vhd:125
 ...
```

Given the type system I don't think there's a way around this? Unless, perhaps, we could suppress the warning in this particular function call.

Otherwise if we want a smaller constant, we'd just need to call the calc function with a `return_size=32` and slice the returned value.
```vhdl
constant TEST : unsigned(7 downto 0) := calc_ns(SOME_TEST_NS, CLK_PER_NS, 32)(7 downto 0);
```
This feels a bit silly since at that case we might as well just remove the `return_size` parameter all together. I think the cleanest solution here is to call `to_unsigned` on with the full `INTEGER` size of 32 and then slice it into the return variable's size. This cleans up the warning in a way that is transparent to the user.