### PR TITLE
Add support for "black-box" (ie no-implementation) entities

### DIFF
--- a/tools/hdl.bzl
+++ b/tools/hdl.bzl
@@ -207,6 +207,13 @@ vhdl_unit = rule(
             ),
             default=False,
         ),
+        "is_black_box": attrs.bool(
+            doc=(
+                "Set to true for code that will get dropped from synth and sim, but\
+                is used for LSP analysis (like generated IP shims)"
+            ),
+            default=False,
+        ),
         "codec_package": attrs.string(
             doc=(
                 "Set to True when you want to generate VUnit codec package\
@@ -252,4 +259,11 @@ def sim_only_model(**kwargs):
 # user doesn't have to do so
 def third_party(**kwargs):
     kwargs.update({"is_third_party": True})
+    vhdl_unit(**kwargs)
+
+# A helper macro for declaring empty entities in BUCK files
+# to keep the LSP happy (no missing entities) but these entities
+# are dropped from synthesis and simulation outputs
+def black_box(**kwargs):
+    kwargs.update({"is_black_box": True})
     vhdl_unit(**kwargs)

--- a/tools/multitool/multitool_cli.py
+++ b/tools/multitool/multitool_cli.py
@@ -66,7 +66,6 @@ def vunit_files():
     try:
         import vunit
         vunit_install_dir = Path(vunit.__file__).parent
-        print(vunit_install_dir)
     except:
         print("Error attempting to import vunit module."
               " Check tools/requirements.txt and install deps as necessary"


### PR DESCRIPTION
that are stripped from synth but keep the LSP happy.  This is currently targetted at generated IP for which we have no entity until synthesis runs.

This allows us to make empty ones and depend on them in the tree, but not export them for synthesis and/or simulation.

Also remove an extraneous print.