### PR TITLE
I2C: A couple of fixes around SCL stretching is handled

### DIFF
--- a/hdl/ip/bsv/I2C/test/I2CBitControllerTests.bsv
+++ b/hdl/ip/bsv/I2C/test/I2CBitControllerTests.bsv
@@ -89,7 +89,6 @@ module mkBench (Bench);
     Reg#(Vector#(3,Bit#(8))) prev_written_bytes <- mkReg(replicate(0));
     Reg#(UInt#(2)) bytes_done                   <- mkReg(0);
     Reg#(Bool) is_last_byte                     <- mkReg(False);
-    Reg#(Bool) stretch_timeout                  <- mkReg(False);
 
     FSM write_seq <- mkFSMWithPred(seq
         dut.send.put(tagged Start);
@@ -120,7 +119,7 @@ module mkBench (Bench);
 
         dut.send.put(tagged Stop);
         check_peripheral_event(periph, tagged ReceivedStop, "Expected to receive STOP");
-    endseq, command_r.op == Write && !stretch_timeout);
+    endseq, command_r.op == Write && !dut.scl_stretch_timeout);
 
     FSM read_seq <- mkFSMWithPred(seq
         dut.send.put(tagged Start);
@@ -153,7 +152,7 @@ module mkBench (Bench);
 
         dut.send.put(tagged Stop);
         check_peripheral_event(periph, tagged ReceivedStop, "Expected to receive STOP");
-    endseq, command_r.op == Read && !stretch_timeout);
+    endseq, command_r.op == Read && !dut.scl_stretch_timeout);
 
     FSM rnd_read_seq <- mkFSMWithPred(seq
         dut.send.put(tagged Start);

--- a/hdl/ip/bsv/I2C/test/I2CCoreTests.bsv
+++ b/hdl/ip/bsv/I2C/test/I2CCoreTests.bsv
@@ -135,7 +135,7 @@ module mkBench (Bench);
             endaction
         endseq
         check_peripheral_event(periph, tagged ReceivedStop, "Expected to receive STOP");
-    endseq, command_r.op == Write);
+    endseq, command_r.op == Write && !dut.scl_stretch_timeout);
 
     FSM read_seq <- mkFSMWithPred(seq
         dut.send_command.put(command_r);
@@ -156,7 +156,7 @@ module mkBench (Bench);
         check_peripheral_event(periph, tagged ReceivedNack, "Expected to receive NACK to end the Read");
         check_peripheral_event(periph, tagged ReceivedStop, "Expected to receive STOP");
         bytes_done  <= 0;
-    endseq, command_r.op == Read);
+    endseq, command_r.op == Read && !dut.scl_stretch_timeout);
 
     FSM rand_read_seq <- mkFSMWithPred(seq
         dut.send_command.put(command_r);
@@ -181,7 +181,7 @@ module mkBench (Bench);
         check_peripheral_event(periph, tagged ReceivedNack, "Expected to receive NACK to end the Read");
         check_peripheral_event(periph, tagged ReceivedStop, "Expected to receive STOP");
         bytes_done  <= 0;
-    endseq, command_r.op == RandomRead);
+    endseq, command_r.op == RandomRead && !dut.scl_stretch_timeout);
 
     rule do_handle_stretch_timeout(dut.scl_stretch_timeout);
         write_seq.abort();

--- a/hdl/projects/sidecar/qsfp_x32/QSFPModule/test/QsfpModuleControllerTests.gtkw
+++ b/hdl/projects/sidecar/qsfp_x32/QSFPModule/test/QsfpModuleControllerTests.gtkw
@@ -1,34 +1,67 @@
 [*]
-[*] GTKWave Analyzer v3.3.100 (w)1999-2019 BSI
-[*] Mon Sep 16 21:06:14 2024
+[*] GTKWave Analyzer v3.3.104 (w)1999-2020 BSI
+[*] Fri Dec  6 18:48:29 2024
 [*]
-[dumpfile] "\\wsl$\Ubuntu-20.04\home\aaron\Oxide\git\quartz\build\vcd\QsfpModuleControllerTests_mkI2CSclStretchTimeoutTest.vcd"
-[dumpfile_mtime] "Mon Sep 16 17:50:10 2024"
-[dumpfile_size] 71544432
-[savefile] "\\wsl$\Ubuntu-20.04\home\aaron\Oxide\git\quartz\hdl\projects\sidecar\qsfp_x32\QSFPModule\test\QsfpModuleControllerTests.gtkw"
-[timestart] 15988190
-[size] 2558 1360
+[dumpfile] "/home/aaron/Oxide/git/quartz/build/vcd/QsfpModuleControllerTests_mkI2CSclStretchTimeoutTest.vcd"
+[dumpfile_mtime] "Fri Dec  6 18:47:48 2024"
+[dumpfile_size] 37880178
+[savefile] "/home/aaron/Oxide/git/quartz/hdl/projects/sidecar/qsfp_x32/QSFPModule/test/QsfpModuleControllerTests.gtkw"
+[timestart] 8337500
+[size] 2592 635
 [pos] -1 -1
-*-13.036575 16052670 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+*-15.176154 8552710 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
 [treeopen] main.
 [treeopen] main.top.
-[sst_width] 446
-[signals_width] 526
+[sst_width] 445
+[signals_width] 631
 [sst_expanded] 1
-[sst_vpaned_height] 404
+[sst_vpaned_height] 158
 @200
 -DUT - QsfpModuleController
 -Pins
 @28
 main.top.bench_controller_lpmode_
 main.top.bench_controller_resetl_
+main.top.bench_modprsl_r
 @200
 -
 @28
 main.top.bench_controller_hot_swap_enabled_r
 main.top.bench_hsc_pg_r
+main.top.bench_controller_power_good__output_r
 @200
 -
+@c00022
+main.top.bench_command_r[24:0]
+@28
+(0)main.top.bench_command_r[24:0]
+(1)main.top.bench_command_r[24:0]
+(2)main.top.bench_command_r[24:0]
+(3)main.top.bench_command_r[24:0]
+(4)main.top.bench_command_r[24:0]
+(5)main.top.bench_command_r[24:0]
+(6)main.top.bench_command_r[24:0]
+(7)main.top.bench_command_r[24:0]
+(8)main.top.bench_command_r[24:0]
+(9)main.top.bench_command_r[24:0]
+(10)main.top.bench_command_r[24:0]
+(11)main.top.bench_command_r[24:0]
+(12)main.top.bench_command_r[24:0]
+(13)main.top.bench_command_r[24:0]
+(14)main.top.bench_command_r[24:0]
+(15)main.top.bench_command_r[24:0]
+(16)main.top.bench_command_r[24:0]
+(17)main.top.bench_command_r[24:0]
+(18)main.top.bench_command_r[24:0]
+(19)main.top.bench_command_r[24:0]
+(20)main.top.bench_command_r[24:0]
+(21)main.top.bench_command_r[24:0]
+(22)main.top.bench_command_r[24:0]
+(23)main.top.bench_command_r[24:0]
+(24)main.top.bench_command_r[24:0]
+@1401200
+-group_end
+@200
 -State
 @28
 main.top.bench_controller_i2c_attempt
@@ -45,24 +78,46 @@ main.top.bench_controller_error[2:0]
 @28
 main.top.bench_controller_rdata_fifo_deq
 main.top.bench_controller_wdata_fifo_deq
+@22
+main.top.bench_bytes_done[7:0]
 @200
--
 -
 -I2CCore
+@28
+main.top.bench_controller_i2c_core_bit_ctrl_sda_out_en
+main.top.bench_controller_i2c_core_bit_ctrl_scl_out_en
+main.top.bench_controller_i2c_core_bit_ctrl_sda_in
+main.top.bench_controller_i2c_core_bit_ctrl_scl_in
 @22
 main.top.bench_controller_i2c_core_state_r[3:0]
+main.top.bench_controller_i2c_core_cur_command[25:0]
+@25
+main.top.bench_controller_i2c_core_bit_ctrl_state[2:0]
 @28
+main.top.bench_controller_i2c_core_state_cleared
+@22
+main.top.bench_controller_i2c_core_bytes_done[7:0]
+@28
+main.top.bench_controller_i2c_core_in_random_read
+main.top.bench_controller_i2c_core_write_acked
+main.top.bench_controller_i2c_core_in_write_ack_poll
+main.top.bench_periph_scl_redge
 main.top.bench_controller_i2c_core_bit_ctrl_scl_stretch_seen_r
-@29
 main.top.bench_controller_i2c_core_bit_ctrl_scl_stretch_timeout_r
-@28
 main.top.bench_controller_i2c_core_bit_ctrl_scl_stretching
+@24
+main.top.bench_periph_scl_stretch_countdown_count_r[15:0]
+@28
+main.top.bench_periph_scl_stretch_countdown_q
+@24
+main.top.bench_controller_i2c_core_bit_ctrl_scl_stretch_timeout_cntr_count[15:0]
+@28
+main.top.bench_controller_i2c_core_bit_ctrl_scl_stretch_timeout_cntr_q
+@24
+main.top.bench_controller_i2c_core_bit_ctrl_scl_stretch_sample_strobe_count[5:0]
+@28
+main.top.bench_controller_i2c_core_bit_ctrl_scl_stretch_sample_strobe_q
 @200
--FIFO: Next Command
--FIFO: BitControl Incoming Events
--FIFO: BitControl Outgoing Events
--FIFO: RX Data
--FIFO: TX Data
 -
 -WDATA FIFO
 @28
@@ -104,7 +159,6 @@ main.top.bench_controller_rdata_fifo_memory.ADDRB[7:0]
 main.top.bench_fifo_idx[7:0]
 @200
 -
--
 -Model - I2CPeripheralModel
 @28
 main.top.bench_periph_scl_in
@@ -113,13 +167,13 @@ main.top.bench_periph_sda_in
 main.top.bench_periph_sda_out
 main.top.bench_periph_addr_set
 @22
+main.top.bench_periph_cur_addr[7:0]
+@28
+main.top.bench_periph_is_read
+@22
 main.top.bench_periph_shift_bits[15:0]
 @800024
 main.top.bench_periph_state[2:0]
-@28
-(0)main.top.bench_periph_state[2:0]
-(1)main.top.bench_periph_state[2:0]
-(2)main.top.bench_periph_state[2:0]
 @1001200
 -group_end
 @22


### PR DESCRIPTION
This commit fixes a couple of bugs related to SCL stretching. First off, in the `I2CBitController` I adjusted how we sample SCL to detect stretching so we're not errantly sampling. Then in the `I2CCore` I added a mechanism to handle the SCL stretch timeouts when we see them. Before we lacked this and that meant if that was seen, we were wedged. The rest of the changes were to test cases in order to mimic the behavior observed that brought the problems to our attention.

Fixes #246
Fixes #247