### PR TITLE
basic-sink: fix message receive loop exit

### DIFF
--- a/hdl/ip/vhd/vunit_components/basic_stream/basic_sink.vhd
+++ b/hdl/ip/vhd/vunit_components/basic_stream/basic_sink.vhd
@@ -56,9 +56,9 @@ begin
                     push_std_ulogic_vector(reply_msg, data);
                     reply(net, msg, reply_msg);
                     ready <= '0';
+                    exit;
                 end if;
                 ready <= '0';
-                exit;
             end loop;
         else
             unexpected_msg_type(msg_type);

--- a/hdl/ip/vhd/vunit_components/basic_stream/sims/th_basic_stream.vhd
+++ b/hdl/ip/vhd/vunit_components/basic_stream/sims/th_basic_stream.vhd
@@ -31,22 +31,22 @@ begin
     clk   <= not clk after 4 ns;
 
     basic_source_vc : entity work.basic_source
-    generic map (
-        source  => source)
-    port map (
-        clk     => clk,
-        valid   => valid,
-        ready   => ready,
-        data    => data
-    );
+        generic map (
+            source  => source)
+        port map (
+            clk     => clk,
+            valid   => valid,
+            ready   => ready,
+            data    => data
+        );
 
-  basic_sink_vc : entity work.basic_sink
-    generic map (
-        sink    => sink)
-    port map (
-        clk     => clk,
-        valid   => valid,
-        ready   => ready,
-        data    => data
-    );
+    basic_sink_vc : entity work.basic_sink
+        generic map (
+            sink    => sink)
+        port map (
+            clk     => clk,
+            valid   => valid,
+            ready   => ready,
+            data    => data
+        );
 end architecture;


### PR DESCRIPTION
We should only `exit` in the message receive loop once we've sampled `valid` data. Currently it was leaving the message receive loop once `ready` was asserted, regardless if `valid` was too, leaving the message not replied to!