### PR TITLE
Wire back up OOB as our path of choice for now

### DIFF
--- a/hdl/ip/vhd/espi/espi_target_top.vhd
+++ b/hdl/ip/vhd/espi/espi_target_top.vhd
@@ -72,6 +72,8 @@ architecture rtl of espi_target_top is
     signal pc_avail : std_logic;
     signal np_free : std_logic;
     signal np_avail : std_logic;
+    signal oob_free : std_logic;
+    signal oob_avail : std_logic;
     signal host_to_sp_espi : st_uart_t;
     signal sp_to_host_espi : uart_resp_t;
     signal aborted_due_to_bad_crc : boolean;
@@ -250,6 +252,8 @@ begin
             pc_avail => pc_avail,
             np_free => np_free,
             np_avail => np_avail,
+            oob_free => oob_free,
+            oob_avail => oob_avail,
             vwire_avail => vwire_avail
         );
 
@@ -294,11 +298,13 @@ begin
        from_sp_uart_data => from_sp_uart_data,
        from_sp_uart_valid => from_sp_uart_valid,
        from_sp_uart_ready => from_sp_uart_ready,
-        msg_not_oob => msg_en,
+       msg_not_oob => msg_en,
        pc_free => pc_free,
        pc_avail => pc_avail,
        np_free => np_free,
-       np_avail => np_avail
+       np_avail => np_avail,
+       oob_avail => oob_avail,
+       oob_free => oob_free
    );
 
    -- vwire channel logic

--- a/hdl/ip/vhd/espi/link_layer/cmd_sizer.vhd
+++ b/hdl/ip/vhd/espi/link_layer/cmd_sizer.vhd
@@ -102,8 +102,9 @@ begin
 
             when tag_len =>
                 if byte_transfer then
-                    v.state := tag_len;
-                    v.hdr.len(11 downto 8) := cmd.data(3 downto 0);
+                    v.state := len;
+                    v.hdr.len(7 downto 0) := cmd.data(7 downto 0);
+                    v.state := len;
                 end if;
                 if cs_n = '1' then
                     v.size_info.valid := '0';
@@ -111,7 +112,7 @@ begin
                 end if;
 
             when len =>
-                if known_size_by_cycle_type(r.hdr) then
+                if known_size_by_length(r.hdr) then
                     v.state := size_known;
                     v.size_info.size := size_by_header(r.hdr);
                 elsif byte_transfer then

--- a/hdl/ip/vhd/espi/link_layer/link_layer_pkg.vhd
+++ b/hdl/ip/vhd/espi/link_layer/link_layer_pkg.vhd
@@ -84,8 +84,7 @@ package body link_layer_pkg is
         -- '-' (don't care) values.
         case? h.opcode is
             when opcode_put_np |
-                 opcode_get_pc |
-                 opcode_get_oob =>
+                 opcode_get_pc =>
                 return true;
             when others =>
                 return false;
@@ -163,7 +162,7 @@ package body link_layer_pkg is
         end case?;
     end function;
 
-    -- Function overloading hacks for restting records
+    -- Function overloading hacks for resetting records
     function rec_reset return size_info_t is
         variable rec: size_info_t := (
             (others => '0'),

--- a/hdl/ip/vhd/espi/sims/models/espi_controller_vc_pkg.vhd
+++ b/hdl/ip/vhd/espi/sims/models/espi_controller_vc_pkg.vhd
@@ -83,6 +83,14 @@ package espi_controller_vc_pkg is
         variable crc_ok : inout boolean
     );
 
+    procedure put_oob_no_pec(
+        signal net : inout network_t;
+        constant payload: in queue_t;
+        variable response_code: inout std_logic_vector(7 downto 0);
+        variable status : inout std_logic_vector(15 downto 0);
+        variable crc_ok : inout boolean
+    );
+
     procedure get_any_pending_alert(
         signal net : inout network_t;
         variable alert : out boolean
@@ -288,6 +296,29 @@ package body espi_controller_vc_pkg is
         response_code := std_logic_vector(to_unsigned(pop_byte(rx_queue), 8));
         status := get_status_from_queue_and_flush(rx_queue);
     end procedure;
+
+    procedure put_oob_no_pec(
+        signal net : inout network_t;
+        constant payload: in queue_t;
+        variable response_code: inout std_logic_vector(7 downto 0);
+        variable status : inout std_logic_vector(15 downto 0);
+        variable crc_ok : inout boolean
+    ) is
+
+        variable cmd : cmd_t := (new_queue, 0);
+        variable rx_bytes : integer   := 4;  -- response, 16bit status, 1 crc, 
+        variable msg_target : actor_t := find("espi_vc");
+        variable rx_queue : queue_t := new_queue;
+    begin
+        cmd := build_put_oob_no_pec_cmd(payload);
+        enqueue_tx_data_bytes(net, msg_target,  cmd.num_bytes, cmd.queue);
+        enqueue_transaction(net, msg_target, cmd.num_bytes, rx_bytes);
+        get_rx_queue(net, msg_target, rx_queue);
+        crc_ok := check_queue_crc(rx_queue); -- non-destructive to queue
+        response_code := std_logic_vector(to_unsigned(pop_byte(rx_queue), 8));
+        status := get_status_from_queue_and_flush(rx_queue);
+    end procedure;
+
     
     procedure get_any_pending_alert(
         signal net : inout network_t;

--- a/hdl/ip/vhd/espi/sims/models/espi_dbg_vc_pkg.vhd
+++ b/hdl/ip/vhd/espi/sims/models/espi_dbg_vc_pkg.vhd
@@ -55,12 +55,19 @@ package espi_dbg_vc_pkg is
         signal net : inout network_t;
         variable size  : inout integer
     );
-    procedure dbg_send_uart_data_cmd(
+    procedure dbg_send_uart_msg_w_data_cmd(
+        signal net : inout network_t;
+        payload : queue_t
+    );
+    procedure dbg_send_uart_oob_no_pec_cmd(
         signal net : inout network_t;
         payload : queue_t
     );
 
-    procedure dbg_get_uart_data_cmd(
+    procedure dbg_get_uart_msg_w_data_cmd(
+        signal net : inout network_t;
+    );
+    procedure dbg_get_uart_oob_no_pec_cmd(
         signal net : inout network_t;
     );
 
@@ -213,19 +220,36 @@ package body espi_dbg_vc_pkg is
         size := to_integer(fifo_status.resp_used_wds);
     end procedure;
 
-    procedure dbg_send_uart_data_cmd(
+    procedure dbg_send_uart_msg_w_data_cmd(
         signal net : inout network_t;
         payload : queue_t
     ) is
-        variable cmd : cmd_t := build_put_uart_data_cmd(payload);
+        variable cmd : cmd_t := build_put_msg_w_data_cmd(payload);
     begin
         dbg_send_cmd(net, cmd);
     end procedure;
 
-    procedure dbg_get_uart_data_cmd(
+    procedure dbg_get_uart_msg_w_data_cmd(
         signal net : inout network_t;
     ) is
-        variable cmd : cmd_t := build_get_uart_data_cmd;
+        variable cmd : cmd_t := build_get_msg_w_data_cmd;
+    begin
+        dbg_send_cmd(net, cmd);
+    end procedure;
+
+    procedure dbg_send_uart_oob_no_pec_cmd(
+        signal net : inout network_t;
+        payload : queue_t
+    ) is
+        variable cmd : cmd_t := build_put_oob_no_pec_cmd(payload);
+    begin
+        dbg_send_cmd(net, cmd);
+    end procedure;
+
+    procedure dbg_get_uart_oob_no_pec_cmd(
+        signal net : inout network_t;
+    ) is
+        variable cmd : cmd_t := build_get_oob_no_pec_cmd;
     begin
         dbg_send_cmd(net, cmd);
     end procedure;

--- a/hdl/ip/vhd/espi/txn_layer/espi_base_types_pkg.vhd
+++ b/hdl/ip/vhd/espi/txn_layer/espi_base_types_pkg.vhd
@@ -339,7 +339,7 @@ package body espi_base_types_pkg is
         ret.vwire_avail := '0';
         ret.np_avail := '0';
         ret.pc_avail := '0';
-        ret.oob_free := '0';
+        ret.oob_free := '1';
         ret.vwire_free := '1';
         ret.np_free := '0';
         ret.pc_free := '1';

--- a/hdl/ip/vhd/espi/txn_layer/espi_protocol_pkg.vhd
+++ b/hdl/ip/vhd/espi/txn_layer/espi_protocol_pkg.vhd
@@ -50,8 +50,6 @@ package espi_protocol_pkg is
     constant flash_write : std_logic_vector(7 downto 0) := "00000001";
     constant flash_erase : std_logic_vector(7 downto 0) := "00000010";
 
-    constant message_with_data : std_logic_vector(7 downto 0) := "00010001";
-
     -- Header Indices for general eSPI packages
     constant cycle_type_idx : integer := 0;
     constant tag_len_idx : integer    := 1;
@@ -69,6 +67,7 @@ package espi_protocol_pkg is
     constant split_first_complete : std_logic_vector(1 downto 0) := "01";
     constant split_last_complete : std_logic_vector(1 downto 0)  := "10";
     constant split_only_complete : std_logic_vector(1 downto 0)  := "11";
+    constant message_with_data : std_logic_vector(7 downto 0) := "00010001";
     constant oob_cycle_type : std_logic_vector(7 downto 0) := "00100001";
 
     constant accept : std_logic_vector(1 downto 0)      := "00";

--- a/hdl/ip/vhd/espi/txn_layer/txn_layer_top.vhd
+++ b/hdl/ip/vhd/espi/txn_layer/txn_layer_top.vhd
@@ -41,6 +41,8 @@ entity txn_layer_top is
         np_free : in std_logic;
         np_avail: in std_logic;
         vwire_avail : in std_logic;
+        oob_avail : in std_logic;
+        oob_free : in std_logic;
 
         -- Link-layer connections
         is_rx_crc_byte     : out   boolean;
@@ -134,7 +136,6 @@ begin
             command_header => command_header,
             response_done  => response_done,
             regs_if        => resp_regs_if,
-            chip_sel_active => chip_sel_active,
             is_tx_last_byte => is_tx_crc_byte,
             clear_tx_crc   => clear_tx_crc,
             data_to_host   => data_to_host,
@@ -163,6 +164,8 @@ begin
         live_status.pc_free <= pc_free;
         live_status.np_avail <= np_avail;
         live_status.np_free <= np_free;
+        live_status.oob_free <= oob_free;
+        live_status.oob_avail <= oob_avail;
     end process;
 
 end rtl;


### PR DESCRIPTION
We have the OOB message path basically working with the SP5, so we're going to plumb this all up a little more formally.

I had most of this in place before, but it was kind of hacked in and didn't have test coverage (and also not right in some places!) So this adds this path, as the enabled default and includes a test case that shoots UART data through.

This is still pending a tiny bit of testing on hw but assuming that goes well I'll merge this in.