### PR TITLE
Warning cleanup

### DIFF
--- a/hdl/ip/vhd/espi/espi_spec_regs.vhd
+++ b/hdl/ip/vhd/espi/espi_spec_regs.vhd
@@ -2,7 +2,7 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
+-- Copyright 2025 Oxide Computer Company
 
 -- Note: Documentation can be rendered in VSCode using the TerosHDL
 -- plugin: https://terostechnology.github.io/terosHDLdoc/

--- a/hdl/ip/vhd/espi/espi_spec_regs.vhd
+++ b/hdl/ip/vhd/espi/espi_spec_regs.vhd
@@ -33,7 +33,7 @@ end entity;
 
 architecture rtl of espi_spec_regs is
 
-    signal device_id        : device_id_type;
+    constant device_id      : device_id_type := rec_reset;
     signal gen_capabilities : general_capabilities_type;
     signal ch0_capabilities : ch0_capabilities_type;
     signal ch1_capabilities : ch1_capabilities_type;
@@ -54,7 +54,6 @@ begin
     write_reg: process(clk, reset)
     begin
         if reset then
-            device_id <= rec_reset;
             gen_capabilities <= rec_reset;
             ch0_capabilities <= rec_reset;
             ch1_capabilities <= rec_reset;

--- a/hdl/ip/vhd/espi/sys_regs/espi_regs.vhd
+++ b/hdl/ip/vhd/espi/sys_regs/espi_regs.vhd
@@ -2,7 +2,7 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
+-- Copyright 2025 Oxide Computer Company
 
 -- SP-accessible registers for the eSPI block
 

--- a/hdl/ip/vhd/espi/sys_regs/espi_regs.vhd
+++ b/hdl/ip/vhd/espi/sys_regs/espi_regs.vhd
@@ -76,7 +76,10 @@ begin
             rvalid <= '0';
         elsif rising_edge(clk) then
             -- bvalid set on every write,
-            -- cleared after bvalid && bready
+            -- The tranfer occurs when bvalid && bready
+            -- but we can simplify the clearing logic to only
+            -- look at bready since we don't care if we set bvalid to 0
+            -- if it was already a 0
             if awready then
                 bvalid <= '1';
             elsif bready then

--- a/tools/vivado_gen/templates/synth.jinja2
+++ b/tools/vivado_gen/templates/synth.jinja2
@@ -43,6 +43,9 @@ source {{file.absolute().as_posix()}}
 read_xdc {{file.absolute().as_posix()}}
 {% endfor %}
 
+## Auto-detect xpm stuff
+auto_detect_xpm
+
 ## Synthesize Design
 set_param general.maxThreads {{project.max_threads}}
 eval "synth_design {{project.synth_args}} -top {{project.top_name}} -part {{project.part}}"


### PR DESCRIPTION
Fixes a few compile warnings  and a few other comment-like changes I had hanging around. No real functional changes here, we just hint to vivado to find the xpm stuff so it doesn't complain about the fact that it found them without a hint :)