### PR TITLE
Vendor spi vc which is languishing in a PR over in VUnit

### DIFF
--- a/hdl/ip/vhd/vunit_components/BUCK
+++ b/hdl/ip/vhd/vunit_components/BUCK
@@ -1,4 +1,4 @@
-load("//tools:hdl.bzl", "vhdl_unit", "vunit_sim")
+load("//tools:hdl.bzl", "vhdl_unit", "vunit_sim", "third_party")
 load("//tools:rdl.bzl", "rdl_file")
 
 vhdl_unit(
@@ -26,9 +26,17 @@ vhdl_unit(
     visibility = ['PUBLIC'],
 )
 
+third_party(
+    name = "spi_vcs",
+    srcs = glob(["spi_controller/*.vhd"]),
+    library = "vunit_lib",
+    visibility = ['PUBLIC'],
+)
+
 vhdl_unit(
     name = "basic_stream",
     srcs = glob(["basic_stream/*.vhd"]),
+
     visibility = ['PUBLIC']
 )
 

--- a/hdl/ip/vhd/vunit_components/qspi_controller/qspi_vc_pkg.vhd
+++ b/hdl/ip/vhd/vunit_components/qspi_controller/qspi_vc_pkg.vhd
@@ -11,7 +11,10 @@ use ieee.numeric_std.all;
 library vunit_lib;
     context vunit_lib.vunit_context;
     context vunit_lib.com_context;
+    context vunit_lib.vc_context;
+
 use vunit_lib.sync_pkg.all;
+
 
 package qspi_vc_pkg is
 
@@ -48,13 +51,15 @@ package qspi_vc_pkg is
         p_actor     : actor_t;
         p_ack_actor : actor_t;
         p_logger    : logger_t;
+        p_checker   : checker_t;
     end record;
-
-    constant qspi_vc_logger : logger_t := get_logger("work:qspi_vc");
 
     impure function new_qspi_vc (
         name : string := "";
-        logger : logger_t := qspi_vc_logger
+        logger : logger_t := null_logger;
+        checker: checker_t := null_checker;
+        actor : actor_t := null_actor;
+        unexpected_msg_type_policy : unexpected_msg_type_policy_t := fail
     )
         return qspi_vc_t;
 
@@ -130,15 +135,20 @@ package body qspi_vc_pkg is
         return qspi_mode_t'val(to_integer(unsigned(mode_vec)));
     end;
 
+    -- VUnit VC rule #2: constructor starts with "new_"
     impure function new_qspi_vc (
         name : string := "";
-        logger : logger_t := qspi_vc_logger
+        logger : logger_t := null_logger;
+        checker: checker_t := null_checker;
+        actor : actor_t := null_actor;
+        unexpected_msg_type_policy : unexpected_msg_type_policy_t := fail
     )
       return qspi_vc_t is
     begin
         return (p_actor => new_actor(name),
               p_ack_actor => new_actor(name & " read-ack"),
-              p_logger => logger
+              p_logger => logger,
+              p_checker => checker
           );
     end;
 

--- a/hdl/ip/vhd/vunit_components/spi_controller/README.md
+++ b/hdl/ip/vhd/vunit_components/spi_controller/README.md
@@ -1,0 +1,9 @@
+These represent a "vendoring" of the files from 
+https://github.com/VUnit/vunit/pull/1041/files
+a PR that hasn't merged into VUnit proper. Rather
+than write our own, or continue waiting, we've pulled
+them in here and will adjust/deprecate/remove when/if
+the PR finally lands in VUnit or VUnit figures out what
+to do with the impending "verification component restructure"
+
+From here: https://github.com/n8tlarsen/vunit/tree/vc-spi

--- a/hdl/ip/vhd/vunit_components/spi_controller/spi_master.vhd
+++ b/hdl/ip/vhd/vunit_components/spi_controller/spi_master.vhd
@@ -1,0 +1,115 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+use work.com_pkg.net;
+use work.com_pkg.receive;
+use work.com_pkg.reply;
+use work.com_types_pkg.all;
+use work.stream_master_pkg.all;
+use work.stream_slave_pkg.all;
+use work.sync_pkg.all;
+use work.spi_pkg.all;
+use work.queue_pkg.all;
+use work.sync_pkg.all;
+use work.print_pkg.all;
+use work.log_levels_pkg.all;
+use work.logger_pkg.all;
+use work.log_handler_pkg.all;
+
+entity spi_master is
+generic (
+    spi : spi_master_t
+);
+port (
+    sclk : out std_logic := spi.p_cpol_mode;
+    mosi : out std_logic := spi.p_idle_state;
+    miso : in  std_logic
+);
+end entity;
+
+architecture a of spi_master is
+
+    constant din_queue : queue_t := new_queue;
+
+begin
+
+    main : process
+    
+        procedure spi_transaction(
+            dout          : std_logic_vector;
+            frequency     : integer;
+            signal sclk   : out std_logic;
+            signal mosi   : out std_logic;
+            signal miso   : in  std_logic
+        ) is
+            constant half_bit_time : time := (10**9 / (frequency*2)) * 1 ns;
+            variable din  : std_logic_vector(dout'length-1 downto 0);
+            variable clk  : std_logic := spi.p_cpol_mode;
+        begin
+            debug("Transmitting " & to_string(dout));
+            sclk <= clk;
+            mosi <= dout(dout'length-1);
+            if (spi.p_cpha_mode = '0') then
+                wait for half_bit_time;
+            end if;
+            clk := not clk;
+            sclk <= clk;
+            if (spi.p_cpha_mode = '0') then
+                din(dout'length-1) := miso;
+            end if;
+            for b in dout'length-2 downto 0 loop
+                wait for half_bit_time;
+                clk := not clk;    
+                sclk <= clk;
+                if (spi.p_cpha_mode = '0') then
+                    mosi <= dout(b);
+                else
+                    din(b) := miso;
+                end if;
+                wait for half_bit_time;
+                clk := not clk;    
+                sclk <= clk;
+                if (spi.p_cpha_mode = '1') then
+                    mosi <= dout(b);
+                else
+                    din(b) := miso;
+                end if;
+            end loop;
+            wait for half_bit_time;
+            sclk <= spi.p_cpol_mode;
+            push_std_ulogic_vector(din_queue, din);
+        end procedure;
+
+        variable query_msg : msg_t;
+        variable reply_msg : msg_t;
+        variable frequency : natural := spi.p_frequency;
+        variable msg_type : msg_type_t;
+        variable din : std_logic_vector(7 downto 0);
+
+    begin
+
+        receive(net, spi.p_actor, query_msg);
+        msg_type := message_type(query_msg);
+
+        handle_sync_message(net, msg_type, query_msg);
+
+        if    msg_type = stream_push_msg then
+            spi_transaction(pop_std_ulogic_vector(query_msg), frequency, sclk, mosi, miso);
+        elsif msg_type = stream_pop_msg then
+            if (length(din_queue) > 0) then
+                reply_msg := new_msg;
+                push_std_ulogic_vector(reply_msg, pop_std_ulogic_vector(din_queue));
+                push_boolean(reply_msg, false);
+                reply(net, query_msg, reply_msg);
+            else
+                unexpected_msg_type(msg_type);
+            end if;
+        elsif msg_type = spi_set_frequency_msg then
+            frequency := pop(query_msg);
+        else
+            unexpected_msg_type(msg_type);
+        end if;
+
+    end process;
+
+end architecture;

--- a/hdl/ip/vhd/vunit_components/spi_controller/spi_pkg.vhd
+++ b/hdl/ip/vhd/vunit_components/spi_controller/spi_pkg.vhd
@@ -1,0 +1,132 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+context work.com_context;
+use work.stream_master_pkg.all;
+use work.stream_slave_pkg.all;
+use work.sync_pkg.all;
+use work.integer_vector_ptr_pkg.all;
+use work.queue_pkg.all;
+
+package spi_pkg is
+
+    type spi_master_t is record
+        p_actor      : actor_t;
+        p_cpol_mode  : std_logic;
+        p_cpha_mode  : std_logic;
+        p_idle_state : std_logic;
+        p_frequency  : natural;
+    end record;
+
+    type spi_slave_t is record
+        p_actor     : actor_t;
+        p_cpol_mode : std_logic;
+        p_cpha_mode : std_logic;
+    end record;
+
+    procedure set_frequency(
+        signal net : inout network_t;
+        spi_master : spi_master_t;
+        frequency  : natural
+    );
+
+    constant default_cpol_mode  : std_logic := '0';
+    constant default_cpha_mode  : std_logic := '0';
+    constant default_idle_state : std_logic := '0';
+    constant default_frequency  : natural := 1000000;
+    
+    impure function new_spi_master(
+        cpol_mode         : std_logic := default_cpol_mode;
+        cpha_mode         : std_logic := default_cpha_mode;
+        idle_state        : std_logic := default_idle_state;
+        initial_frequency : natural   := default_frequency
+    ) return spi_master_t;
+
+    impure function new_spi_slave(
+        cpol_mode : std_logic := default_cpol_mode;
+        cpha_mode : std_logic := default_cpha_mode
+    ) return spi_slave_t;
+
+    impure function as_stream(spi_master : spi_master_t) return stream_master_t;
+    impure function as_stream(spi_master : spi_master_t) return stream_slave_t;
+    impure function as_stream(spi_slave  : spi_slave_t)  return stream_master_t;
+    impure function as_stream(spi_slave  : spi_slave_t)  return stream_slave_t;
+    impure function as_sync  (spi_master : spi_master_t) return sync_handle_t;
+    impure function as_sync  (spi_slave  : spi_slave_t)  return sync_handle_t;
+
+    constant spi_set_frequency_msg : msg_type_t := new_msg_type("spi set frequency");
+    
+end package spi_pkg;
+
+package body spi_pkg is
+    
+    impure function new_spi_master(
+        cpol_mode         : std_logic := default_cpol_mode;
+        cpha_mode         : std_logic := default_cpha_mode;
+        idle_state        : std_logic := default_idle_state;
+        initial_frequency : natural   := default_frequency
+    ) return spi_master_t is
+    begin
+        return (
+            p_actor      => new_actor,
+            p_cpol_mode  => cpol_mode,
+            p_cpha_mode  => cpha_mode,
+            p_idle_state => default_idle_state,
+            p_frequency  => initial_frequency
+        );
+    end function new_spi_master;
+
+    impure function new_spi_slave(
+        cpol_mode : std_logic := default_cpol_mode;
+        cpha_mode : std_logic := default_cpha_mode
+    ) return spi_slave_t is
+    begin
+        return (
+            p_actor     => new_actor,
+            p_cpol_mode => cpol_mode,
+            p_cpha_mode => cpha_mode
+        );
+    end function new_spi_slave;
+
+    impure function as_stream(spi_master : spi_master_t) return stream_master_t is
+    begin
+        return stream_master_t'(p_actor => spi_master.p_actor);
+    end function as_stream;
+
+    impure function as_stream(spi_master : spi_master_t) return stream_slave_t is
+    begin
+        return stream_slave_t'(p_actor => spi_master.p_actor);
+    end function as_stream;
+
+    impure function as_stream(spi_slave  : spi_slave_t) return stream_master_t is
+    begin
+        return stream_master_t'(p_actor => spi_slave.p_actor);
+    end function as_stream;
+
+    impure function as_stream(spi_slave  : spi_slave_t) return stream_slave_t is
+    begin
+        return stream_slave_t'(p_actor => spi_slave.p_actor);
+    end function as_stream;
+    
+    impure function as_sync(spi_master : spi_master_t) return sync_handle_t is
+    begin
+        return spi_master.p_actor;
+    end function as_sync;
+
+    impure function as_sync(spi_slave  : spi_slave_t) return sync_handle_t is
+    begin
+        return spi_slave.p_actor;
+    end function as_sync;
+
+    procedure set_frequency(
+        signal net : inout network_t;
+        spi_master : spi_master_t;                    
+        frequency  : natural
+    ) is
+        variable msg : msg_t := new_msg(spi_set_frequency_msg);
+    begin
+        push(msg, frequency);
+        send(net,spi_master.p_actor,msg);
+    end procedure set_frequency;
+
+end package body spi_pkg;

--- a/hdl/ip/vhd/vunit_components/spi_controller/spi_slave.vhd
+++ b/hdl/ip/vhd/vunit_components/spi_controller/spi_slave.vhd
@@ -1,0 +1,108 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+use work.com_pkg.net;
+use work.com_pkg.receive;
+use work.com_pkg.reply;
+use work.com_types_pkg.all;
+use work.stream_slave_pkg.all;
+use work.spi_pkg.all;
+use work.queue_pkg.all;
+use work.print_pkg.all;
+use work.log_levels_pkg.all;
+use work.logger_pkg.all;
+use work.log_handler_pkg.all;
+
+entity spi_slave is
+generic (
+    spi : spi_slave_t
+);
+port (
+    sclk : in  std_logic := spi.p_cpol_mode;
+    ss_n : in  std_logic := '0';
+    mosi : in  std_logic;
+    miso : out std_logic
+);
+end entity;
+
+architecture a of spi_slave is
+
+    constant din_queue : queue_t := new_queue;
+    signal local_event : std_logic := '0';
+
+begin
+
+    main : process
+
+        variable reply_msg, query_msg : msg_t;
+        variable msg_type : msg_type_t;
+
+    begin
+
+        receive(net, spi.p_actor, query_msg);
+        msg_type := message_type(query_msg);
+
+        if msg_type = stream_pop_msg then
+            reply_msg := new_msg;
+            if not (length(din_queue) > 0) then
+                wait on local_event until length(din_queue) > 0;
+            end if;
+            push_std_ulogic_vector(reply_msg, pop_std_ulogic_vector(din_queue));
+            push_boolean(reply_msg, false);
+            reply(net, query_msg, reply_msg);
+        else
+            unexpected_msg_type(msg_type);
+        end if;
+
+    end process;
+
+    recv : process
+
+        procedure spi_transaction(
+            variable data : out std_logic_vector;
+            signal sclk   : in  std_logic;
+            signal mosi   : in  std_logic
+        ) is
+            variable din_vector : std_logic_vector(7 downto 0);
+            variable bit_count  : natural := 7;
+        begin
+            while (ss_n = '0') loop
+                if ((spi.p_cpha_mode = '0') and (spi.p_cpol_mode = '0')) then
+                    wait until rising_edge(sclk) or ss_n = '1'; wait for 1 ps;
+                elsif ((spi.p_cpha_mode = '0') and (spi.p_cpol_mode = '1')) then
+                    wait until falling_edge(sclk) or ss_n = '1'; wait for 1 ps;
+                elsif ((spi.p_cpha_mode = '1') and (spi.p_cpol_mode = '0')) then
+                    wait until falling_edge(sclk) or ss_n = '1'; wait for 1 ps;
+                elsif ((spi.p_cpha_mode = '1') and (spi.p_cpol_mode = '1')) then
+                    wait until rising_edge(sclk) or ss_n = '1'; wait for 1 ps;
+                end if;
+                if (ss_n = '0') then
+                    din_vector(bit_count) := mosi;
+                    if (bit_count = 0) then
+                        bit_count := 7;
+                        debug("Received " & to_string(din_vector));
+                        push_std_ulogic_vector(din_queue, din_vector);
+                    else
+                        bit_count := bit_count-1;
+                    end if;
+                end if;
+            end loop;
+        end procedure;
+
+        variable data : std_logic_vector(7 downto 0);
+
+    begin
+
+        wait until ss_n = '0';
+        spi_transaction(data, sclk, mosi);
+        local_event <= '1';
+        wait for 1 fs;
+        local_event <= '0';
+        wait for 1 fs;
+
+    end process;
+
+    -- Data loopback
+    miso <= mosi;
+
+end architecture;

--- a/tools/hdl.bzl
+++ b/tools/hdl.bzl
@@ -255,7 +255,7 @@ def sim_only_model(**kwargs):
     vhdl_unit(**kwargs)
 
 # A helper macro for declaring top-level simulations in BUCK files
-# This helper just sets the "is_tb" and "is_model" fields so the
+# This helper just sets the "is_third_party" field so the
 # user doesn't have to do so
 def third_party(**kwargs):
     kwargs.update({"is_third_party": True})

--- a/tools/multitool/multitool_cli.py
+++ b/tools/multitool/multitool_cli.py
@@ -113,6 +113,14 @@ def vhdl_ls_toml_gen(args):
     vunit = {"vunit_lib": {"files": vunit_dict["vunit_lib"]}}
     osvvm = {"osvvm": {"files": vunit_dict["osvvm"]}}
 
+    # We may have provided additional, vendored files in these libraries.
+    our_vunit_files = vhdl_lsp_dict["libraries"].get("vunit_lib", {}).get("files", [])
+    our_osvvm_files = vhdl_lsp_dict["libraries"].get("osvvm", {}).get("files", [])
+
+    # Now combine these with the vunit and osvvm files we just found
+    vunit["vunit_lib"]["files"].extend(our_vunit_files)
+    osvvm["osvvm"]["files"].extend(our_osvvm_files)
+
     # Update the running structure with these new libraries
     vhdl_lsp_dict["libraries"].update(vunit)
     vhdl_lsp_dict["libraries"].update(osvvm)

--- a/tools/vunit_gen/templates/run_py.jinja2
+++ b/tools/vunit_gen/templates/run_py.jinja2
@@ -56,7 +56,7 @@ vu.add_random()
 vu.add_verification_components()
 # Create libraries
 {% for library in libraries %}
-{{library.name}} = vu.add_library("{{library.name}}", vhdl_standard="{{vhdl_standard}}")
+{{library.name}} = vu.add_library("{{library.name}}", vhdl_standard="{{vhdl_standard}}", allow_duplicate=True)
 {% for file in library.files %}
 {{library.name}}.add_source_file("{{file}}", vhdl_standard="{{vhdl_standard}}")
 {% endfor %}
@@ -75,8 +75,7 @@ vu.set_sim_option("disable_ieee_warnings", True)
 {% if simulator == "nvc" %}
 # Dump arrays of records, may have a perf penalty
 vu.set_sim_option("nvc.sim_flags", ["--dump-arrays"])
+vu.set_sim_option("nvc.global_flags", ["--ignore-time"])
 {% endif %}
-# saved here for when we upgrade VUnit
-#vu.set_sim_option("nvc.global_flags", ["--ignore-time"])
 # Run vunit function
 vu.main()


### PR DESCRIPTION
This pulls in some code that hasn't yet made it upstream in VUnit due to some discussion over there around re-structuring VCs etc. I'd rather just use this than write new so I'm vendoring it here for now and we can dump it later should this, or something similar merge upstream.

In doing this, I noticed a gap in our lsp-toml process, we can specify any library for sources added but were blindly replacing the libraries "vunit_lib" and "osvvm" with the files we found locally.  We actually want to concatenate any user-specified files and the automatically found ones when generating the lsp-toml, so that is now done for both of these libraries.

I also added a few transparent updates to the qspi-vc to better align with my understanding of the eventual VUnit VC spec, but it's still not fully documented so it is possible there is more to do there eventually.

This adds the new nvc ignore-time option since VUnit is managing the hashes and compiling differences.  When we rebase or bounce around in source control the times adjust but VUnit will re-compile when contents change as expected and we can silence nvc warning us that the timestamps have changed.  Fixes #145 