### PR TITLE
Build improvements for better hubris integration.

### DIFF
--- a/.github/cleanup.sh
+++ b/.github/cleanup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset -o xtrace -o pipefail
+shopt -s inherit_errexit nullglob dotglob
+
+rm -rf "${GITHUB_WORKSPACE:?}"/*
+
+if test "${RUNNER_DEBUG:-0}" != '1'; then
+  set +o xtrace
+fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,8 @@ jobs:
           with:
             name: gfruit-image
             path: "./buck-out/v2/gen/root/**/*"
+        - name: Cleanup
+          run: bash .github/cleanup.sh
 
   cosmo_seq:
     needs: changes
@@ -63,6 +65,8 @@ jobs:
           with:
             name: cosmo-seq-image
             path: "./buck-out/v2/gen/root/**/*"
+        - name: Cleanup
+          run: bash .github/cleanup.sh
 
   cosmo_hp:
     needs: changes
@@ -84,6 +88,8 @@ jobs:
           with:
             name: cosmo-hp-image
             path: "./buck-out/v2/gen/root/**/*"
+        - name: Cleanup
+          run: bash .github/cleanup.sh
 
   bsv-streams:
     needs: changes
@@ -114,3 +120,5 @@ jobs:
           with:
             name: bsv-images
             path: "./build/latest/**/*"
+        - name: Cleanup
+          run: bash .github/cleanup.sh

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -35,6 +35,8 @@ jobs:
           run: echo "~/.cargo/bin" >> "$GITHUB_PATH"
         - name: Run VUnit tests
           run: set -o pipefail; buck2 bxl //tools/vunit-sims.bxl:vunit_sim_gen | while IFS= read -r line; do eval "$line" ; done
+        - name: Cleanup
+          run: bash .github/cleanup.sh
   
   bsv-sim:
     needs: changes
@@ -61,3 +63,5 @@ jobs:
           working-directory: ./build
         - name: backup build-dir
           run: cp -R ./build /tmp/cobble_build_bkup
+        - name: Cleanup
+          run: bash .github/cleanup.sh

--- a/hdl/projects/grapefruit/BUCK
+++ b/hdl/projects/grapefruit/BUCK
@@ -32,7 +32,8 @@ rdl_file(
         "//hdl/ip/vhd/espi:espi_regs_pkg",
     ],
     outputs = [
-        "gfruit_top_map.html",
+        "gfruit_top_map.html", 
+        "gfruit_top_map.json"
     ]
 )
 

--- a/tools/compress.bzl
+++ b/tools/compress.bzl
@@ -1,0 +1,14 @@
+
+load(
+    "@prelude//python:toolchain.bzl",
+    "PythonToolchainInfo",
+)
+
+
+def compress_bitstream(ctx, bitstream_providers):
+    compressed = ctx.actions.declare_output("{}.bz2".format(ctx.attrs.name))
+    bz2compress = cmd_args(ctx.attrs._bz2compress[RunInfo])
+    bz2compress.add("--input", bitstream_providers[0].default_outputs[0])
+    bz2compress.add("--output", compressed.as_output())
+    ctx.actions.run(bz2compress, category="bitstream_compress")
+    return [DefaultInfo(default_output=compressed)]

--- a/tools/site_cobble/rdl_pkg/rdl_cli.py
+++ b/tools/site_cobble/rdl_pkg/rdl_cli.py
@@ -21,7 +21,7 @@ try:
 except ModuleNotFoundError:
     from rdl_pkg.exporter import MapExporter, MapofMapsExporter
     from rdl_pkg.listeners import PreExportListener, MyModelPrintingListener
-    from rdl_pkg.json_dump import convert_to_json
+    from rdl_pkg.json_dump import convert_to_json, convert_only_map_to_json
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -64,6 +64,13 @@ def main():
         # Dump Jinja template-based outputs (filter out .json)
         exporter = MapofMapsExporter()
         exporter.export(pre_export.maps[0], output_filenames_no_json)
+        json_files = [x for x in output_filenames if ".json" in str(x)]
+        if len(json_files) == 1:
+            json_name = Path(json_files[0])
+            convert_only_map_to_json(rdlc, root, json_name)
+        elif len(json_files) > 1:
+            raise Exception(f'Specified too many .json outputs: {json_files.join(",")}')
+
     else:
         # For each standard map, we're going to generate:
         # Standard bsv package from this base address

--- a/tools/vivado.bzl
+++ b/tools/vivado.bzl
@@ -18,6 +18,10 @@ load(
     "RDLJsonMaps",
 )
 
+load(
+    ":compress.bzl", "compress_bitstream",
+)
+
 VivadoConstraintInfo = provider(
     fields={
         "srcs": provider_field(Artifact),
@@ -315,16 +319,6 @@ def bitstream(ctx, input_checkpoint):
     ctx.actions.run(vivado, category="vivado_{}".format(flow))
     providers.append(DefaultInfo(default_output=bitstream_bin))
     return providers
-
-
-def compress_bitstream(ctx, bitstream_providers):
-
-    compressed = ctx.actions.declare_output("{}.bz2".format(ctx.attrs.name))
-    bz2compress = cmd_args(ctx.attrs._bz2compress[RunInfo])
-    bz2compress.add("--input", bitstream_providers[0].default_outputs[0])
-    bz2compress.add("--output", compressed.as_output())
-    ctx.actions.run(bz2compress, category="bitstream_compress")
-    return [DefaultInfo(default_output=compressed)]
 
 
 def _vivado_tcl_gen_common(ctx, flow, json):


### PR DESCRIPTION
3 changes here:
Firstly, we're going to compress the ice40 bitstreams also. I factored out the compression logic into its own spot so that it can be shared from one place between the vivado and ice40 flows.  Fixes #276 

Secondly, chatting with @mkeeter, we wanted to also spit out a top-level json file as part of the build that has the appropriate offsets mapped so that hubris can better code-gen drivers etc, so this is done here also when we ask for a top-level .json output in our top-level BUCK files.

And finally, added a post-job cleanup action so we stop filling the build machine disk.  Fixes #267

top level json generates output that looks like this for reference. We're already generating the individual .json files for each peripheral just without the fully-elaborated address_offset (which is intentional to allow for generic, address-independent drivers that will take an offset either known at compile time or passed in on init, however matt chooses to do it:
```
{
    "type": "addrmap",
    "inst_name": "top_level_map",
    "addr_offset": 0,
    "children": [
        {
            "type": "addrmap",
            "inst_name": "base",
            "addr_offset": 0,
            "children": []
        },
        {
            "type": "addrmap",
            "inst_name": "spi_nor",
            "addr_offset": 256,
            "children": []
        },
        {
            "type": "addrmap",
            "inst_name": "espi",
            "addr_offset": 512,
            "children": []
        },
        {
            "type": "addrmap",
            "inst_name": "sgpio",
            "addr_offset": 768,
            "children": []
        }
    ]
}
```