### PR TITLE
I2C controller: add ability to abort transactions

### DIFF
--- a/hdl/ip/vhd/i2c/common/sims/i2c_cmd_vc.vhd
+++ b/hdl/ip/vhd/i2c/common/sims/i2c_cmd_vc.vhd
@@ -23,6 +23,7 @@ entity i2c_cmd_vc is
     port (
         cmd     : out cmd_t     := CMD_RESET;
         valid   : out std_logic := '0';
+        abort   : out std_logic := '0';
         ready   : in std_logic;
     );
 end entity;
@@ -57,8 +58,16 @@ begin
             command.len     := pop(msg);
             cmd     <= command;
             valid   <= '1';
-            wait until ready;
+
+            -- once the command is accepted, release valid
+            wait until not ready;
             valid   <= '0';
+        elsif msg_type = abort_msg then
+            abort   <= '1';
+
+            -- once the core is ready, release abort
+            wait until ready;
+            abort   <= '0';
         else
             unexpected_msg_type(msg_type);
         end if;

--- a/hdl/ip/vhd/i2c/common/sims/i2c_cmd_vc_pkg.vhd
+++ b/hdl/ip/vhd/i2c/common/sims/i2c_cmd_vc_pkg.vhd
@@ -2,7 +2,7 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
+-- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;
@@ -32,12 +32,18 @@ package i2c_cmd_vc_pkg is
         logger  : logger_t  := i2c_cmd_vc_logger;
     ) return i2c_cmd_vc_t;
 
-    constant push_i2c_cmd_msg : msg_type_t := new_msg_type("push_i2c_cmd");
+    constant push_i2c_cmd_msg   : msg_type_t := new_msg_type("push_i2c_cmd");
+    constant abort_msg          : msg_type_t := new_msg_type("abort");
 
     procedure push_i2c_cmd(
         signal net  : inout network_t;
         i2c_cmd_vc  : i2c_cmd_vc_t;
         cmd         : cmd_t;
+    );
+
+    procedure push_abort(
+        signal net  : inout network_t;
+        i2c_cmd_vc  : i2c_cmd_vc_t;
     );
 
 end package;
@@ -82,5 +88,13 @@ package body i2c_cmd_vc_pkg is
         send(net, i2c_cmd_vc.p_actor, msg);
     end;
 
+    procedure push_abort(
+        signal net  : inout network_t;
+        i2c_cmd_vc  : i2c_cmd_vc_t;
+    ) is
+        variable msg : msg_t := new_msg(abort_msg);
+    begin
+        send(net, i2c_cmd_vc.p_actor, msg);
+    end;
 
 end package body;

--- a/hdl/ip/vhd/i2c/controller/txn_layer/i2c_ctrl_txn_layer.vhd
+++ b/hdl/ip/vhd/i2c/controller/txn_layer/i2c_ctrl_txn_layer.vhd
@@ -4,6 +4,15 @@
 --
 -- Copyright 2025 Oxide Computer Company
 
+-- I2C Controller Transaction Layer
+--
+-- This block orchestrates the actions to complete a supplied I2C command (`cmd`).
+--
+-- Notes:
+-- - For write transactions data is expected to be streamed in via `tx_st_if`
+-- - For read transactions data is expected to be streamed in via `rx_st_if`
+-- - A pulse of the `abort` signal will result in an I2C transaction being ended as fast as possible
+
 library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std_unsigned.all;
@@ -13,7 +22,7 @@ use work.tristate_if_pkg.all;
 
 use work.i2c_common_pkg.all;
 
-entity i2c_txn_layer is
+entity i2c_ctrl_txn_layer is
     generic (
         CLK_PER_NS  : positive;
         MODE        : mode_t;
@@ -29,6 +38,7 @@ entity i2c_txn_layer is
         -- I2C command interface
         cmd         : in cmd_t;
         cmd_valid   : in std_logic;
+        abort       : in std_logic;
         core_ready  : out std_logic;
 
         -- Transmit data stream
@@ -39,7 +49,7 @@ entity i2c_txn_layer is
     );
 end entity;
 
-architecture rtl of i2c_txn_layer is
+architecture rtl of i2c_ctrl_txn_layer is
 
     type state_t is (
         IDLE,
@@ -223,6 +233,12 @@ begin
                 end if;
         end case;
 
+        -- if a transaction is in progress and abort is asserted we should immediate STOP
+        if abort = '1' and v.state /= IDLE and v.state /= STOP and v.state /= WAIT_STOP then
+            v.state         := STOP;
+            v.next_valid    := '1';
+        end if;
+
         -- next state logic
         v.do_start  := '1' when v.state = START else '0';
         v.do_stop   := '1' when v.state = STOP else '0';
@@ -234,7 +250,6 @@ begin
 
         sm_reg_next <= v;
     end process;
-
 
     reg_sm: process(clk, reset)
     begin

--- a/hdl/ip/vhd/i2c/controller/txn_layer/i2c_ctrl_txn_layer.vhd
+++ b/hdl/ip/vhd/i2c/controller/txn_layer/i2c_ctrl_txn_layer.vhd
@@ -233,8 +233,9 @@ begin
                 end if;
         end case;
 
-        -- if a transaction is in progress and abort is asserted we should immediate STOP
-        if abort = '1' and v.state /= IDLE and v.state /= STOP and v.state /= WAIT_STOP then
+        -- if a transaction is in progress and abort is asserted we should immediately STOP
+        if abort = '1' and sm_reg.state /= IDLE and sm_reg.state /= STOP
+                and sm_reg.state /= WAIT_STOP then
             v.state         := STOP;
             v.next_valid    := '1';
         end if;

--- a/hdl/ip/vhd/i2c/controller/txn_layer/sims/i2c_ctrl_txn_layer_tb.gtkw
+++ b/hdl/ip/vhd/i2c/controller/txn_layer/sims/i2c_ctrl_txn_layer_tb.gtkw
@@ -1,22 +1,22 @@
 [*]
 [*] GTKWave Analyzer v3.3.104 (w)1999-2020 BSI
-[*] Wed Dec 11 22:39:03 2024
+[*] Fri Feb  7 21:04:37 2025
 [*]
-[dumpfile] "/home/aaron/Oxide/git/quartz/vunit_out/test_output/lib.i2c_ctrl_txn_layer_tb.write_and_read_many_bytes_713f701447aec89dff2ce07f3dce0c8020399b4e/nvc/i2c_ctrl_txn_layer_tb.fst"
-[dumpfile_mtime] "Wed Dec 11 22:34:30 2024"
-[dumpfile_size] 6129
+[dumpfile] "/home/aaron/Oxide/git/quartz/vunit_out/test_output/lib.i2c_ctrl_txn_layer_tb.abort_transaction_5030992a55fd175f5a816e54580c7a725cf50715/nvc/i2c_ctrl_txn_layer_tb.fst"
+[dumpfile_mtime] "Fri Feb  7 16:35:44 2025"
+[dumpfile_size] 5828
 [savefile] "/home/aaron/Oxide/git/quartz/hdl/ip/vhd/i2c/controller/txn_layer/sims/i2c_ctrl_txn_layer_tb.gtkw"
-[timestart] 455740000000
+[timestart] 0
 [size] 1344 1283
-[pos] -1 -1
-*-31.427509 459684000000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+[pos] 2559 23
+*-34.710972 86100000000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
 [treeopen] i2c_ctrl_txn_layer_tb.
 [treeopen] i2c_ctrl_txn_layer_tb.th.
 [treeopen] i2c_ctrl_txn_layer_tb.th.dut.
+[treeopen] i2c_ctrl_txn_layer_tb.th.dut.i2c_ctrl_link_layer_inst.
 [treeopen] i2c_ctrl_txn_layer_tb.th.dut.sm_reg.
 [treeopen] i2c_ctrl_txn_layer_tb.th.i2c_cmd_vc_inst.
-[treeopen] i2c_ctrl_txn_layer_tb.th.target.
-[sst_width] 389
+[sst_width] 280
 [signals_width] 361
 [sst_expanded] 1
 [sst_vpaned_height] 382
@@ -32,6 +32,8 @@ i2c_ctrl_txn_layer_tb.th.i2c_cmd_vc_inst.cmd.len[7:0]
 i2c_ctrl_txn_layer_tb.th.i2c_cmd_vc_inst.cmd.op
 @22
 i2c_ctrl_txn_layer_tb.th.i2c_cmd_vc_inst.cmd.reg[7:0]
+@28
+i2c_ctrl_txn_layer_tb.th.i2c_cmd_vc_inst.abort
 @200
 -
 -Transaction Layer
@@ -39,6 +41,7 @@ i2c_ctrl_txn_layer_tb.th.i2c_cmd_vc_inst.cmd.reg[7:0]
 i2c_ctrl_txn_layer_tb.th.dut.clk
 i2c_ctrl_txn_layer_tb.th.dut.cmd_valid
 i2c_ctrl_txn_layer_tb.th.dut.core_ready
+i2c_ctrl_txn_layer_tb.th.dut.abort
 @200
 -I2C Interface
 -SCL
@@ -60,7 +63,6 @@ i2c_ctrl_txn_layer_tb.th.dut.sm_reg.do_stop
 i2c_ctrl_txn_layer_tb.th.dut.ll_ready
 @22
 i2c_ctrl_txn_layer_tb.th.dut.sm_reg.bytes_done[7:0]
-@23
 i2c_ctrl_txn_layer_tb.th.dut.sm_reg.cmd.len[7:0]
 @28
 i2c_ctrl_txn_layer_tb.th.dut.sm_reg.next_valid
@@ -95,6 +97,8 @@ i2c_ctrl_txn_layer_tb.th.dut.i2c_ctrl_link_layer_inst.sm_reg.bits_shifted
 i2c_ctrl_txn_layer_tb.th.dut.i2c_ctrl_link_layer_inst.sm_reg.rx_ack_valid
 i2c_ctrl_txn_layer_tb.th.dut.i2c_ctrl_link_layer_inst.sm_reg.rx_ack
 i2c_ctrl_txn_layer_tb.th.dut.i2c_ctrl_link_layer_inst.sm_reg.ack_sending
+i2c_ctrl_txn_layer_tb.th.dut.i2c_ctrl_link_layer_inst.tx_stop
+i2c_ctrl_txn_layer_tb.th.dut.i2c_ctrl_link_layer_inst.sm_reg.stop_requested
 @200
 -Counter
 @22


### PR DESCRIPTION
A feature we need for the SPD mux testing is the ability for our controller to abort an in-progress transaction. This commit adds an `abort` port to the `i2c_ctrl_txn_layer` entity which will react to a pulse of that signal. In practice this means if the controller is writing it will send a STOP instead of the next bit. When reading, the controller will finish reading the byte, NACK, and then send a STOP.