### PR TITLE
QSFP Controller: make power control and readback separate

### DIFF
--- a/hdl/projects/sidecar/qsfp_x32/QSFPModule/QsfpModuleController.bsv
+++ b/hdl/projects/sidecar/qsfp_x32/QSFPModule/QsfpModuleController.bsv
@@ -97,7 +97,7 @@ interface QsfpModuleController;
     method Action lpmode(Bit#(1) val);
 
     // Software controlled hot swap controller power enable
-    method Action power_en(Bit#(1) val);
+    method Action sw_power_en(Bit#(1) val);
 
     // Power fault state from the controller
     method Bool pg;
@@ -388,7 +388,7 @@ module mkQsfpModuleController #(Parameters parameters) (QsfpModuleController);
     method modprsl  = modprsl_;
     method intl     = intl_;
 
-    method power_en     = power_en_sw._write;
+    method sw_power_en  = power_en_sw._write;
     method pg           = hot_swap.pin_state.good;
     method pg_timeout   = hot_swap.timed_out;
     method pg_lost      = hot_swap.aborted;

--- a/hdl/projects/sidecar/qsfp_x32/QSFPModule/qsfp_modules_top.rdl
+++ b/hdl/projects/sidecar/qsfp_x32/QSFPModule/qsfp_modules_top.rdl
@@ -189,7 +189,31 @@ addrmap qsfp_modules_top {
     port_control PORT15_CONTROL;
 
     reg {
-        name = "Ports 0 -> 7 HSC Enable. Clear bit to remove module power.";
+        name = "Ports 0 -> 7 SW control of HSC enable. Clear bit to remove module power.";
+        field {} PORT7[7:7] = 1;
+        field {} PORT6[6:6] = 1;
+        field {} PORT5[5:5] = 1;
+        field {} PORT4[4:4] = 1;
+        field {} PORT3[3:3] = 1;
+        field {} PORT2[2:2] = 1;
+        field {} PORT1[1:1] = 1;
+        field {} PORT0[0:0] = 1;
+    } SW_POWER_EN0;
+
+    reg {
+        name = "Ports 8 -> 15 SW control of HSC enable. Clear bit to remove module power.";
+        field {} PORT15[7:7] = 1;
+        field {} PORT14[6:6] = 1;
+        field {} PORT13[5:5] = 1;
+        field {} PORT12[4:4] = 1;
+        field {} PORT11[3:3] = 1;
+        field {} PORT10[2:2] = 1;
+        field {} PORT9[1:1] = 1;
+        field {} PORT8[0:0] = 1;
+    } SW_POWER_EN1;
+
+    reg {
+        name = "Ports 0 -> 7 HSC enable pin state. Enabled when the corresponding SW_POWER_EN0 and MODPRSL0 bits are asserted.";
         default sw = r;
         field {} PORT7[7:7] = 1;
         field {} PORT6[6:6] = 1;
@@ -202,7 +226,7 @@ addrmap qsfp_modules_top {
     } POWER_EN0;
 
     reg {
-        name = "Ports 8 -> 15 HSC Enable. Clear bit to remove module power.";
+        name = "Ports 8 -> 15 HSC enable pin state. Enabled when the corresponding SW_POWER_EN1 and MODPRSL1 bits are asserted.";
         default sw = r;
         field {} PORT15[7:7] = 1;
         field {} PORT14[6:6] = 1;

--- a/hdl/projects/sidecar/qsfp_x32/QSFPModule/test/QsfpModuleControllerTests.bsv
+++ b/hdl/projects/sidecar/qsfp_x32/QSFPModule/test/QsfpModuleControllerTests.bsv
@@ -58,8 +58,8 @@ interface Bench;
     // A way to expose if the I2C read/write is finished
     method Bool i2c_busy();
 
-    // Control of the hot swap power enable pin
-    method Action set_power_en(Bit#(1) v);
+    // Software control of the hot swap power enable pin
+    method Action set_sw_power_en(Bit#(1) v);
     // Readback of the enable pin
     method Bool hsc_en;
     // Control of the hot swap power good pin
@@ -115,9 +115,9 @@ module mkBench (Bench);
     mkConnection(controller.lpmode, lpmode_r);
 
     // Hot swap
-    Reg#(Bit#(1)) power_en_r  <- mkReg(1);
+    Reg#(Bit#(1)) sw_power_en_r  <- mkReg(1);
     Reg#(Bool) hsc_pg_r     <- mkReg(False);
-    mkConnection(controller.power_en, power_en_r);
+    mkConnection(controller.sw_power_en, sw_power_en_r);
     mkConnection(controller.pins.power_good, hsc_pg_r);
 
     Strobe#(16) tick_1khz   <-
@@ -273,8 +273,8 @@ module mkBench (Bench);
         lpmode_r    <= v;
     endmethod
 
-    method Action set_power_en(Bit#(1) v);
-        power_en_r <= v;
+    method Action set_sw_power_en(Bit#(1) v);
+        sw_power_en_r <= v;
     endmethod
 
     method Action set_hsc_pg(Bit#(1) v);
@@ -420,7 +420,7 @@ module mkRemovePowerEnableTest (Empty);
         assert_eq(unpack(bench.registers.port_status.error[2:0]),
             NoError,
             "NoPower should be present when attempting to communicate when the hot swap is stable.");
-        bench.set_power_en(0);
+        bench.set_sw_power_en(0);
         delay(2);
         bench.set_hsc_pg(0);
         // power good is debounced and thus won't transition immediately

--- a/hdl/projects/sidecar/qsfp_x32/QsfpX32ControllerSpiServer.bsv
+++ b/hdl/projects/sidecar/qsfp_x32/QsfpX32ControllerSpiServer.bsv
@@ -118,6 +118,8 @@ module mkSpiServer #(VSC8562::Registers vsc8562,
                 fromInteger(qsfpPort14ControlOffset): read(qsfp_top.mod_controls[14]);
                 fromInteger(qsfpPort15ControlOffset): read(qsfp_top.mod_controls[15]);
                 fromInteger(qsfpI2cCtrlOffset): read(qsfp_top.i2c_ctrl);
+                fromInteger(qsfpSwPowerEn0Offset): read(qsfp_top.sw_power_en0);
+                fromInteger(qsfpSwPowerEn1Offset): read(qsfp_top.sw_power_en1);
                 fromInteger(qsfpPowerEn0Offset): read(qsfp_top.power_en0);
                 fromInteger(qsfpPowerEn1Offset): read(qsfp_top.power_en1);
                 fromInteger(qsfpPowerGood0Offset): read(qsfp_top.power_good0);
@@ -199,10 +201,10 @@ module mkSpiServer #(VSC8562::Registers vsc8562,
                 update(spi_request.op, qsfp_top.i2c_bcast0, spi_request.wdata);
             fromInteger(qsfpI2cCtrlOffset):
                 update(spi_request.op, qsfp_top.i2c_ctrl, spi_request.wdata);
-            fromInteger(qsfpPowerEn0Offset):
-                update(spi_request.op, qsfp_top.power_en0, spi_request.wdata);
-            fromInteger(qsfpPowerEn1Offset):
-                update(spi_request.op, qsfp_top.power_en1, spi_request.wdata);
+            fromInteger(qsfpSwPowerEn0Offset):
+                update(spi_request.op, qsfp_top.sw_power_en0, spi_request.wdata);
+            fromInteger(qsfpSwPowerEn1Offset):
+                update(spi_request.op, qsfp_top.sw_power_en1, spi_request.wdata);
             fromInteger(qsfpModResetl0Offset):
                 update(spi_request.op, qsfp_top.mod_resetl0, spi_request.wdata);
             fromInteger(qsfpModResetl1Offset):


### PR DESCRIPTION
The current state of upstack software understanding module power control is confusing. The actual hardware power control had an additional level of gating the FPGA that enforced a module being present before turning power on. However, when software comes by to read the `POWER_ENx` registers it sees the modules as being enabled. This is confusing!

This PR splits out the software control of the power enable into a separate `SW_POWER_ENx` registers from the true pin-level hardware state (post-gating) shown in the `POWER_ENx` registers.

The software impact of this changes are minimal. When fetching state the `POWER_ENx` register will represent the what a user would expect. When modifying if a power _should_ be enabled or not, the `SW_POWER_ENx` registers will need to be hit instead.

fixes #280