### PR TITLE
Improve logging for the yosys toolchain

### DIFF
--- a/tools/yosys.bzl
+++ b/tools/yosys.bzl
@@ -73,13 +73,19 @@ def yosys_vhdl_synth(ctx):
     cmd.add(yosys_gen)
     cmd.add("--input", in_json_file)
     cmd.add("--output", yosys_py.as_output())
+   
 
     ctx.actions.run(cmd, category="yosys_synth_gen")
 
+    yosys_synth_log = ctx.actions.declare_output("synth.log")
+    yosys_ghdl_warns = ctx.actions.declare_output("ghdl_stderr.log")
     yosys_synth_cmd = cmd_args(hidden=[in_json_file, maps])
     yosys_synth_cmd.add(ctx.attrs._python[PythonToolchainInfo].interpreter)
     yosys_synth_cmd.add(yosys_py)
     yosys_synth_cmd.add("--output", yosys_json.as_output())
+    yosys_synth_cmd.add("--log", yosys_synth_log.as_output())
+    yosys_synth_cmd.add("--ghdl_stderr", yosys_ghdl_warns.as_output())
+
 
     ctx.actions.run(yosys_synth_cmd, category="yosys_run")
     providers.append(DefaultInfo(default_output=yosys_json))
@@ -92,6 +98,7 @@ def ice40_nextpnr(ctx, yoys_providers):
     yosys_json = yoys_providers[0].default_outputs[0]
 
     asc = ctx.actions.declare_output("{}.asc".format(ctx.attrs.name))
+    next_pnr_log = ctx.actions.declare_output("nextpnr.log")
     cmd = cmd_args()
     cmd.add(ctx.attrs._nextpnr_ice40[RunInfo])
     cmd.add(next_pnr_family_flags(ctx.attrs.family))
@@ -99,6 +106,7 @@ def ice40_nextpnr(ctx, yoys_providers):
     cmd.add("--pcf", ctx.attrs.pinmap)
     cmd.add("--json", yosys_json)
     cmd.add("--asc", asc.as_output())
+    cmd.add("--log", next_pnr_log.as_output())
 
     ctx.actions.run(cmd, category="next_pnr")
 

--- a/tools/yosys_gen/templates/synth_py.jinja2
+++ b/tools/yosys_gen/templates/synth_py.jinja2
@@ -3,26 +3,40 @@
 # Generated run.py from buck2
 import subprocess
 import argparse
+import sys
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--output", dest="output", help="Explicit output python")
+parser.add_argument("--output", dest="output", help="Explicit output yosys json")
+parser.add_argument("--log", dest="log", help="Explicit output yosys log")
+parser.add_argument("--ghdl_stderr", dest="ghdl_stderr", help="Explicit output ghdl stderr")
 
 args = parser.parse_args()
 files_str = (
 {% for source in project.sources %}
 {% set suffix = source.path.suffix %}
 {% if suffix in [".vhd"] %}
-"{{source.path.absolute().as_posix()}}"
+"{{source.path.absolute().as_posix()}} "
 {% endif %}
 {% endfor %}
 )
 
 cmd = [
     "yosys",
+    "-l",
+    f"{args.log}",
     "-m",
     "ghdl",
     "-p",
     f'ghdl --std=08 {files_str} -e {{project.top_entity_name}}; {{project.synth_family}} -json {args.output}',
 ]
 
-a = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+#a = subprocess.run(cmd, stdout=subprocess.PIPE, check=False)
+yosys = subprocess.run(
+    cmd,
+    encoding="utf-8", 
+    check=True, 
+    capture_output=True)
+
+with open(args.ghdl_stderr, "w") as f:
+    f.write(yosys.stderr)
+sys.stderr.write(yosys.stderr)


### PR DESCRIPTION
The yosys toolchain was mostly slapped together as proof of concept. After using it in anger for a bit I've found some missing functionality around the logs we're exposing so this exposes more of the correct logs, like we'd like to get warnings from the ghdl synthesizer, the yosys log and the next pnr log with area and timing.

The ghdl thing is a bit strange in that it logs warnings to stderr when run as a plugin in yosys but the warnings don't make it into the log file, probably due to how yosys is logging things. I've captured the stderr there and written it to a file, and printed it to stderr so that when we get a non-zero exit you see the errors in the terminal.