### PR TITLE
Axi 2k8 work and cleanup

### DIFF
--- a/hdl/ip/vhd/axi_blocks/BUCK
+++ b/hdl/ip/vhd/axi_blocks/BUCK
@@ -1,8 +1,22 @@
 load("//tools:hdl.bzl", "vhdl_unit")
 
 vhdl_unit(
-    name = "axilite_common_pkgs",
-    srcs = glob(["*pkg.vhd"]),
+    name = "axilite_common_pkg",
+    srcs = glob(["axil_common_pkg.vhd"]),
+    standard = "2008",
+    visibility = ['PUBLIC'],
+)
+
+vhdl_unit(
+    name = "axilite_if_2k8_pkg",
+    srcs = glob(["*2k8_pkg.vhd"]),
+    standard = "2008",
+    visibility = ['PUBLIC'],
+)
+
+vhdl_unit(
+    name = "axilite_if_2k19_pkg",
+    srcs = glob(["*2k19_pkg.vhd"]),
     standard = "2019",
     visibility = ['PUBLIC'],
 )
@@ -11,8 +25,21 @@ vhdl_unit(
     name = "axil_interconnect",
     srcs = glob(["axil_interconnect.vhd"]),
     deps = [
-        ":axilite_common_pkgs",
+        ":axilite_common_pkg",
+        ":axilite_if_2k19_pkg",
+        ":axil_interconnect_2k8",
     ],
     standard = "2019",
+    visibility = ['PUBLIC'],
+)
+
+vhdl_unit(
+    name = "axil_interconnect_2k8",
+    srcs = glob(["axil_interconnect_2k8.vhd"]),
+    deps = [
+        ":axilite_common_pkg",
+        ":axilite_if_2k8_pkg",
+    ],
+    standard = "2008",
     visibility = ['PUBLIC'],
 )

--- a/hdl/ip/vhd/axi_blocks/axil_interconnect.vhd
+++ b/hdl/ip/vhd/axi_blocks/axil_interconnect.vhd
@@ -11,7 +11,7 @@ use ieee.numeric_std.all;
 use ieee.numeric_std_unsigned.all;
 
 use work.axil_common_pkg.all;
-use work.axilite_if_2008_pkg.all;
+use work.axilite_if_2k8_pkg.all;
 use work.axil8x32_pkg;
 use work.axil26x32_pkg;
 

--- a/hdl/ip/vhd/axi_blocks/axil_interconnect_2k8.vhd
+++ b/hdl/ip/vhd/axi_blocks/axil_interconnect_2k8.vhd
@@ -1,0 +1,196 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+-- Copyright 2024 Oxide Computer Company
+
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use ieee.numeric_std_unsigned.all;
+
+use work.axil_common_pkg.all;
+use work.axilite_if_2008_pkg.all;
+
+-- This is a somewhat naive implementation of an parameterized AXI-lite interconnect.
+-- It is intended to be function as an MVP implementation allowing for basic multi-responder
+-- usecases. It is not currently a full cross-bar implementation, but may grow to be one in the future.
+-- This is the VHDL 2k8 version which does not use interface views.
+
+entity axil_interconnect_2k8 is
+    generic (
+        initiator_addr_width : integer;
+        config_array : axil_responder_cfg_array_t
+    );
+    port (
+        -- Clock and reset
+        clk : in std_logic;
+        reset : in std_logic;
+
+        -- Responder I/F to the main initiator, which is a *target* interface
+        initiator_write_address_addr : in std_logic_vector(initiator_addr_width - 1 downto 0);
+        initiator_write_address_valid : in std_logic;
+        initiator_write_address_ready : out std_logic;
+
+        initiator_write_data_data : in std_logic_vector(31 downto 0);
+        initiator_write_data_strb : in std_logic_vector(3 downto 0);
+        initiator_write_data_ready : out std_logic;
+        initiator_write_data_valid : in std_logic;
+        
+        initiator_write_response_valid : out std_logic;
+        initiator_write_response_resp : out std_logic_vector(1 downto 0);
+        initiator_write_response_ready : in std_logic;
+
+        initiator_read_address_addr : in std_logic_vector(initiator_addr_width - 1 downto 0);
+        initiator_read_address_ready : out std_logic;
+        initiator_read_address_valid : in std_logic;
+
+        initiator_read_data_valid : out std_logic;
+        initiator_read_data_ready : in std_logic;
+        initiator_read_data_resp : out std_logic_vector(1 downto 0);
+        initiator_read_data_data : out std_logic_vector(31 downto 0);
+
+        -- Initiator I/Fs to the responder blocks, which is a *controller* interface
+        --responders : view (axil8x32_pkg.axil_controller) of axil8x32_pkg.axil_array_t(config_array'range)
+        responders_write_address_valid : out std_logic_vector(config_array'range);
+        responders_write_address_ready : in std_logic_vector(config_array'range);
+        responders_write_address_addr : out tgt_addr8_t(config_array'range);
+        
+        responders_write_data_valid : out std_logic_vector(config_array'range);
+        responders_write_data_ready : in std_logic_vector(config_array'range);
+        responders_write_data_data: out tgt_dat32_t(config_array'range);
+        responders_write_data_strb: out tgt_strb_t(config_array'range);
+        
+        responders_write_response_ready : out std_logic_vector(config_array'range);
+        responders_write_response_resp : in tgt_resp_t(config_array'range);
+        responders_write_response_valid : in std_logic_vector(config_array'range);
+
+        responders_read_address_valid : out std_logic_vector(config_array'range);
+        responders_read_address_addr : out tgt_addr8_t(config_array'range);
+        responders_read_address_ready : in std_logic_vector(config_array'range);
+
+        responders_read_data_ready : out std_logic_vector(config_array'range);
+        responders_read_data_resp : in tgt_resp_t(config_array'range);
+        responders_read_data_valid : in std_logic_vector(config_array'range);
+        responders_read_data_data : in tgt_dat32_t(config_array'range)
+
+    );
+end entity;
+
+architecture rtl of axil_interconnect_2k8 is
+
+    constant default_idx : integer := config_array'length;
+    -- We implement a catch-all responder that will respond with an error if no other responder does
+    -- so this signal is one larger than the number of responders
+    signal responder_sel : integer range 0 to config_array'length := default_idx;
+    signal write_done : std_logic;
+    signal read_done : std_logic;
+    signal in_txn : boolean;
+
+begin
+
+    write_done <= '1' when initiator_write_response_valid = '1' and initiator_write_response_ready = '1' else
+                 '0';
+    read_done <= '1' when initiator_read_data_valid = '1' and initiator_read_data_ready = '1' else
+                '0';
+
+    -- we're going to stall all the transactions until we have decoded and selected a responder,
+    -- flipped the muxes and then we can let the txn_through, and we keep the responder selected until
+    -- the txn is done.
+    -- There's a lot of combo logic here, we'll see how this goes.
+    decode: process(clk, reset)
+    begin
+        if reset = '1' then
+            responder_sel <= default_idx;
+            in_txn <= false;
+        elsif rising_edge(clk) then
+            if initiator_write_address_valid = '1' then
+                for i in 0 to config_array'length - 1 loop
+                    if (initiator_write_address_addr >= config_array(i).base_addr) and
+                       (initiator_write_address_addr < config_array(i).base_addr + 2**config_array(i).addr_span_bits) then
+                        responder_sel <= i;
+                    end if;
+                end loop;
+                in_txn <= true;
+            elsif initiator_read_address_valid = '1' then
+                for i in 0 to config_array'length - 1 loop
+                    if (initiator_read_address_addr >= config_array(i).base_addr) and
+                       (initiator_read_address_addr < config_array(i).base_addr + 2**config_array(i).addr_span_bits) then
+                        responder_sel <= i;
+                    end if;
+                end loop;
+                in_txn <= true;
+            elsif write_done or read_done then
+                responder_sel <= default_idx;
+                in_txn <= false;
+            end if;
+        end if;
+    end process;
+
+    mux: process(all)
+    begin
+        -- default no transaction state for all responders
+        for i in 0 to config_array'length - 1 loop
+            responders_write_address_valid(i) <= '0';
+            responders_write_address_addr(i) <= initiator_write_address_addr(responders_write_address_addr(i)'length - 1 downto 0);
+            responders_write_data_valid(i) <= '0';
+            responders_write_data_data(i) <= initiator_write_data_data;
+            responders_write_data_strb(i) <= initiator_write_data_strb;
+            responders_write_response_ready(i) <= '0';
+
+            responders_read_address_valid(i) <= '0';
+            responders_read_address_addr(i) <= initiator_read_address_addr(responders_read_address_addr(i)'length - 1 downto 0);
+            responders_read_data_ready(i) <= '0';
+
+        end loop;
+
+        -- deal with in-txn muxing
+        if in_txn and responder_sel < default_idx then
+            -- responder mux
+            responders_write_address_valid(responder_sel) <= initiator_write_address_valid;
+            responders_write_address_addr(responder_sel) <= initiator_write_address_addr(responders_write_address_addr(responder_sel)'length - 1 downto 0);
+            responders_write_data_valid(responder_sel) <= initiator_write_data_valid;
+            responders_write_data_data(responder_sel) <= initiator_write_data_data;
+            responders_write_data_strb(responder_sel) <= initiator_write_data_strb;
+            responders_write_response_ready(responder_sel) <= initiator_write_response_ready;
+
+            responders_read_address_valid(responder_sel) <= initiator_read_address_valid;
+            responders_read_address_addr(responder_sel) <= initiator_read_address_addr(responders_read_address_addr(responder_sel)'length - 1 downto 0);
+            responders_read_data_ready(responder_sel) <= initiator_read_data_ready;
+            -- initiator mux
+            initiator_write_address_ready <= responders_write_address_ready(responder_sel);
+            initiator_write_data_ready <= responders_write_data_ready(responder_sel);
+            initiator_write_response_resp <= responders_write_response_resp(responder_sel);
+            initiator_write_response_valid <= responders_write_response_valid(responder_sel);
+            initiator_read_address_ready <= responders_read_address_ready(responder_sel);
+            initiator_read_data_resp <= responders_read_data_resp(responder_sel);
+            initiator_read_data_valid <= responders_read_data_valid(responder_sel);
+            initiator_read_data_data <= responders_read_data_data(responder_sel);
+
+        elsif in_txn then
+            -- default response to not hang bus
+            initiator_write_address_ready <= '1';
+            initiator_write_data_ready <= '1';
+            initiator_write_response_resp <= SLVERR;
+            initiator_write_response_valid <= '1';
+            initiator_read_address_ready <= '1';
+            initiator_read_data_resp <= SLVERR;
+            initiator_read_data_valid <= '1';
+            initiator_read_data_data <= X"DEADBEEF";
+
+        else
+            -- hold for decode
+            -- default response to not hang bus
+            initiator_write_address_ready <= '0';
+            initiator_write_data_ready <= '0';
+            initiator_write_response_resp <= SLVERR;
+            initiator_write_response_valid <= '0';
+            initiator_read_address_ready <= '0';
+            initiator_read_data_resp <= SLVERR;
+            initiator_read_data_valid <= '0';
+            initiator_read_data_data <= (others => '0');
+        end if;
+    end process;
+    
+end rtl;

--- a/hdl/ip/vhd/axi_blocks/axil_interconnect_2k8.vhd
+++ b/hdl/ip/vhd/axi_blocks/axil_interconnect_2k8.vhd
@@ -11,7 +11,7 @@ use ieee.numeric_std.all;
 use ieee.numeric_std_unsigned.all;
 
 use work.axil_common_pkg.all;
-use work.axilite_if_2008_pkg.all;
+use work.axilite_if_2k8_pkg.all;
 
 -- This is a somewhat naive implementation of an parameterized AXI-lite interconnect.
 -- It is intended to be function as an MVP implementation allowing for basic multi-responder

--- a/hdl/ip/vhd/axi_blocks/axilite_if_2k19_pkg.vhd
+++ b/hdl/ip/vhd/axi_blocks/axilite_if_2k19_pkg.vhd
@@ -10,7 +10,7 @@ use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 use ieee.numeric_std_unsigned.all;
 
-package axilite_if_pkg is
+package axilite_if_2019_pkg is
    generic (
       addr_width : integer
    );
@@ -106,6 +106,6 @@ package axilite_if_pkg is
 end package;
 
 -- Some common sizes expected to be used
-package axil8x32_pkg is new work.axilite_if_pkg generic map(addr_width => 8);
-package axil24x32_pkg is new work.axilite_if_pkg generic map(addr_width => 24);
-package axil26x32_pkg is new work.axilite_if_pkg generic map(addr_width => 26);
+package axil8x32_pkg is new work.axilite_if_2019_pkg generic map(addr_width => 8);
+package axil24x32_pkg is new work.axilite_if_2019_pkg generic map(addr_width => 24);
+package axil26x32_pkg is new work.axilite_if_2019_pkg generic map(addr_width => 26);

--- a/hdl/ip/vhd/axi_blocks/axilite_if_2k19_pkg.vhd
+++ b/hdl/ip/vhd/axi_blocks/axilite_if_2k19_pkg.vhd
@@ -10,7 +10,7 @@ use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 use ieee.numeric_std_unsigned.all;
 
-package axilite_if_2019_pkg is
+package axilite_if_2k19_pkg is
    generic (
       addr_width : integer
    );
@@ -106,6 +106,6 @@ package axilite_if_2019_pkg is
 end package;
 
 -- Some common sizes expected to be used
-package axil8x32_pkg is new work.axilite_if_2019_pkg generic map(addr_width => 8);
-package axil24x32_pkg is new work.axilite_if_2019_pkg generic map(addr_width => 24);
-package axil26x32_pkg is new work.axilite_if_2019_pkg generic map(addr_width => 26);
+package axil8x32_pkg is new work.axilite_if_2k19_pkg generic map(addr_width => 8);
+package axil24x32_pkg is new work.axilite_if_2k19_pkg generic map(addr_width => 24);
+package axil26x32_pkg is new work.axilite_if_2k19_pkg generic map(addr_width => 26);

--- a/hdl/ip/vhd/axi_blocks/axilite_if_2k8_pkg.vhd
+++ b/hdl/ip/vhd/axi_blocks/axilite_if_2k8_pkg.vhd
@@ -10,7 +10,7 @@ use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 use ieee.numeric_std_unsigned.all;
 
-package axilite_if_2008_pkg is
+package axilite_if_2k8_pkg is
 
     type tgt_addr8_t is array (natural range <>) of std_logic_vector(7 downto 0);
     type tgt_dat32_t is array (natural range <>) of std_logic_vector(31 downto 0);
@@ -19,4 +19,4 @@ package axilite_if_2008_pkg is
 
 
 
-end package axilite_if_2008_pkg;
+end package axilite_if_2k8_pkg;

--- a/hdl/ip/vhd/axi_blocks/axilite_if_2k8_pkg.vhd
+++ b/hdl/ip/vhd/axi_blocks/axilite_if_2k8_pkg.vhd
@@ -1,0 +1,22 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+-- Copyright 2025 Oxide Computer Company
+
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use ieee.numeric_std_unsigned.all;
+
+package axilite_if_2008_pkg is
+
+    type tgt_addr8_t is array (natural range <>) of std_logic_vector(7 downto 0);
+    type tgt_dat32_t is array (natural range <>) of std_logic_vector(31 downto 0);
+    type tgt_strb_t is array (natural range <>) of std_logic_vector(3 downto 0);
+    type tgt_resp_t is array (natural range <>) of std_logic_vector(1 downto 0);
+
+
+
+end package axilite_if_2008_pkg;

--- a/hdl/ip/vhd/espi/BUCK
+++ b/hdl/ip/vhd/espi/BUCK
@@ -43,7 +43,7 @@ vhdl_unit(
         "//hdl/ip/vhd/crc:crc8atm_8wide",
         "//hdl/ip/vhd/fifos:dcfifo_xpm",
         "//hdl/ip/vhd/fifos:dcfifo_mixed_xpm",
-        "//hdl/ip/vhd/axi_blocks:axilite_common_pkgs",
+        "//hdl/ip/vhd/axi_blocks:axilite_if_2k19_pkg",
         "//hdl/ip/vhd/memories:dual_clock_simple_dpr",
         "//hdl/ip/vhd/uart:axi_fifo_uart",
         ],

--- a/hdl/ip/vhd/espi/sims/espi_th.vhd
+++ b/hdl/ip/vhd/espi/sims/espi_th.vhd
@@ -14,7 +14,6 @@ library vunit_lib;
     context vunit_lib.vc_context;
 
 use work.qspi_vc_pkg.all;
-use work.axil_common_pkg.all;
 use work.axil8x32_pkg;
 use work.espi_tb_pkg.all;
 

--- a/hdl/ip/vhd/fmc_if/BUCK
+++ b/hdl/ip/vhd/fmc_if/BUCK
@@ -12,7 +12,7 @@ vhdl_unit(
     srcs = glob(["stm32h7*.vhd"]),
     deps = [
         "//hdl/ip/vhd/fifos:dcfifo_xpm",
-        "//hdl/ip/vhd/axi_blocks:axilite_common_pkgs"
+        "//hdl/ip/vhd/axi_blocks:axilite_if_2k19_pkg"
         ],
     standard = "2019",
     visibility = ["PUBLIC"],

--- a/hdl/ip/vhd/info/BUCK
+++ b/hdl/ip/vhd/info/BUCK
@@ -45,7 +45,7 @@ vhdl_unit(
     srcs = ["info.vhd"],
     deps = [
         ":info_2k8",
-        "//hdl/ip/vhd/axi_blocks:axilite_common_pkgs",
+        "//hdl/ip/vhd/axi_blocks:axilite_if_2k19_pkg",
         ],
     standard = "2019",
     visibility = ['PUBLIC']

--- a/hdl/ip/vhd/spi_nor_controller/BUCK
+++ b/hdl/ip/vhd/spi_nor_controller/BUCK
@@ -25,7 +25,7 @@ vhdl_unit(
     deps = [
         ":spi_nor_rdl",
         "//hdl/ip/vhd/fifos:dcfifo_xpm",
-        "//hdl/ip/vhd/axi_blocks:axilite_common_pkgs",
+        "//hdl/ip/vhd/axi_blocks:axilite_if_2k19_pkg",
         ],
     visibility = ["PUBLIC"],
 )

--- a/hdl/projects/grapefruit/BUCK
+++ b/hdl/projects/grapefruit/BUCK
@@ -47,7 +47,7 @@ vhdl_unit (
     srcs = glob(["base_regs/*.vhd"]),
     deps = [
         ":base_regs_map",
-        "//hdl/ip/vhd/axi_blocks:axilite_common_pkgs",
+        "//hdl/ip/vhd/axi_blocks:axilite_if_2k19_pkg",
         ],
     standard = "2019",
 )
@@ -57,7 +57,7 @@ vhdl_unit (
     srcs = glob(["sgpio/*.vhd"]),
     deps = [
         ":gfruit_sgpio_regs",
-        "//hdl/ip/vhd/axi_blocks:axilite_common_pkgs",
+        "//hdl/ip/vhd/axi_blocks:axilite_if_2k19_pkg",
         "//hdl/ip/vhd/sgpio:sgpio_top",
         ],
     standard = "2019",
@@ -76,7 +76,6 @@ vhdl_unit(
         "//hdl/ip/vhd/info:info",
         "//hdl/ip/vhd/espi:espi_top",
         "//hdl/ip/vhd/uart:axi_fifo_uart",
-        "//hdl/ip/vhd/axi_blocks:axilite_common_pkgs",
         "//hdl/ip/vhd/axi_blocks:axil_interconnect",
         "//hdl/ip/vhd/spi_nor_controller:spi_nor_top",
         "//hdl/ip/vhd/fmc_if:stm32h7_fmc_target",


### PR DESCRIPTION
This moves the logic for our naive axi-lite fabric block down into a VHDL 2k8-compatible block and then adds a wrapper with the extant interface.  Doing this required adjusting the package names a bit so we could split the 2k19 and 2k9 code so you see the cascading changes in existing IP that pulled in 2k19-compatible packages.

