### PR TITLE
Unique maps. When one or more blocks depend on the something with an RDL provider, we only want unique copies

### DIFF
--- a/tools/vivado.bzl
+++ b/tools/vivado.bzl
@@ -112,12 +112,12 @@ def synthesize(ctx):
     maps = []
     json_maps = ctx.attrs.top.get(RDLJsonMaps)
     if json_maps != None:
-            for file in json_maps.files:
+            for file in set(json_maps.files):
                 new_file = ctx.actions.declare_output("maps", file.basename)
                 maps.append(ctx.actions.copy_file(new_file, file))
     html_maps = ctx.attrs.top.get(RDLHtmlMaps)
     if html_maps != None:
-            for file in html_maps.files:
+            for file in set(html_maps.files):
                 new_file = ctx.actions.declare_output("maps", file.basename)
                 maps.append(ctx.actions.copy_file(new_file, file))
 

--- a/tools/yosys.bzl
+++ b/tools/yosys.bzl
@@ -51,12 +51,12 @@ def yosys_vhdl_synth(ctx):
     maps = []
     json_maps = ctx.attrs.top.get(RDLJsonMaps)
     if json_maps != None:
-            for file in json_maps.files:
+            for file in set(json_maps.files):
                 new_file = ctx.actions.declare_output("maps", file.basename)
                 maps.append(ctx.actions.copy_file(new_file, file))
     html_maps = ctx.attrs.top.get(RDLHtmlMaps)
     if html_maps != None:
-            for file in html_maps.files:
+            for file in set(html_maps.files):
                 new_file = ctx.actions.declare_output("maps", file.basename)
                 maps.append(ctx.actions.copy_file(new_file, file))
 

--- a/tools/yosys_gen/templates/synth_py.jinja2
+++ b/tools/yosys_gen/templates/synth_py.jinja2
@@ -11,14 +11,16 @@ parser.add_argument("--log", dest="log", help="Explicit output yosys log")
 parser.add_argument("--ghdl_stderr", dest="ghdl_stderr", help="Explicit output ghdl stderr")
 
 args = parser.parse_args()
-files_str = (
+files_list = [
 {% for source in project.sources %}
 {% set suffix = source.path.suffix %}
 {% if suffix in [".vhd"] %}
-"{{source.path.absolute().as_posix()}} "
+"{{source.path.absolute().as_posix()}}",
 {% endif %}
 {% endfor %}
-)
+]
+
+files_str = " ".join(files_list)
 
 cmd = [
     "yosys",
@@ -34,9 +36,11 @@ cmd = [
 yosys = subprocess.run(
     cmd,
     encoding="utf-8", 
-    check=True, 
+    check=False, 
     capture_output=True)
 
 with open(args.ghdl_stderr, "w") as f:
     f.write(yosys.stderr)
 sys.stderr.write(yosys.stderr)
+
+sys.exit(yosys.returncode)


### PR DESCRIPTION
If a design had multiple blocks that depend on the same core component that also happened to have an RDL provider, when trying to generate the maps at the end of the build we'd get failures b/c we just loop on the RDLproviders and expected an output for each. That's fine, but when there were multiple of the same provider, we'd try to re-declare outputs and get errors from buck2.  We take the list of files and turn it into a set() which drops any duplicates before we loop them to generate our outputs. We only want one copy of each anyway, so this is perfect.