### PR TITLE
Bug-fix inferred loop/latch here. Variables only init at the *start*

### DIFF
--- a/hdl/ip/vhd/spi/axi_controller/spi_axi_pkg.vhd
+++ b/hdl/ip/vhd/spi/axi_controller/spi_axi_pkg.vhd
@@ -81,6 +81,7 @@ package body spi_axi_pkg is
             when spi_opcode_bit_clr =>
                 return rdata and (not wdata);
             when others =>
+                assert false report "invalid opcode for bit operation";
                 return rdata;
         end case;
 

--- a/hdl/ip/vhd/spi/axi_controller/spi_to_axi.vhd
+++ b/hdl/ip/vhd/spi/axi_controller/spi_to_axi.vhd
@@ -330,8 +330,9 @@ begin
     wvalid <= axi_r.wvalid;
 
     wdata_and_strobe:process(all)
-        variable dat_shift: std_logic_vector(31 downto 0) := (others => '0');
+        variable dat_shift: std_logic_vector(31 downto 0);
     begin
+        dat_shift := (others => '0');
         dat_shift(7 downto 0) := axi_r.wdata;
         dat_shift := shift_left(dat_shift, to_integer(unsigned(axi_r.req_addr(1 downto 0))) * 8);
     


### PR DESCRIPTION
a process doesn't re-init the variables on every call (duh). Yosys complained about comb loops for the vaules that had to hold thier state, we shouldn't do this.  Added back in the assert since we have figured out how to make ghdl drop them with the no-formal flag.