### PR TITLE
Bump oss-cad-suite toolchain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
         - name: Update pip reqs
           run : python3 -m pip install --upgrade -r tools/requirements.txt --break-system-packages
         - name: buck path
-          run: echo "~/.cargo/bin:/opt/Xilinx/Vivado/2024.1/bin:/opt/oss-cad-suite-20240513/bin" >> "$GITHUB_PATH"
+          run: echo "~/.cargo/bin:/opt/Xilinx/Vivado/2024.1/bin:/opt/oss-cad-suite-20250211/bin" >> "$GITHUB_PATH"
         - name: Build cosmo_hp bitstream
           run: buck2 build //hdl/projects/cosmo_hp:cosmo_hp --show-output
         - uses: actions/upload-artifact@v4

--- a/BUILD.vars.gha
+++ b/BUILD.vars.gha
@@ -4,11 +4,11 @@ bin = "/opt/bsc-2022.01/bin/bsc"
 libdir = "/opt/bsc-2022.01/lib/"
 
 [yosys]
-bin = "/opt/oss-cad-suite-20240513/bin/yosys"
-libdir = "/opt/oss-cad-suite-20240513/share/yosys"
+bin = "/opt/oss-cad-suite-20250211/bin/yosys"
+libdir = "/opt/oss-cad-suite-20250211/share/yosys"
 
 [nextpnr]
-ecp5 = "/opt/oss-cad-suite-20240513/bin/nextpnr-ecp5"
-ecp5_pack = "/opt/oss-cad-suite-20240513/bin/ecppack"
-ice40 = "/opt/oss-cad-suite-20240513/bin/nextpnr-ice40"
-ice40_pack = "/opt/oss-cad-suite-20240513/bin/icepack"
+ecp5 = "/opt/oss-cad-suite-20250211/bin/nextpnr-ecp5"
+ecp5_pack = "/opt/oss-cad-suite-20250211/bin/ecppack"
+ice40 = "/opt/oss-cad-suite-20250211/bin/nextpnr-ice40"
+ice40_pack = "/opt/oss-cad-suite-20250211/bin/icepack"

--- a/hdl/projects/psc/BUILD
+++ b/hdl/projects/psc/BUILD
@@ -7,7 +7,6 @@
 bluespec_verilog('IgnitionTargetPSC',
     top = 'IgnitionTargetPSC.bsv',
     modules = [
-        'mkPSCRevAResetButton',
         'mkPSCRevBResetButton',
         'mkPSCRevBResetButtonNoPowerFaultMonitor',
         'mkPSCRevB',
@@ -15,26 +14,6 @@ bluespec_verilog('IgnitionTargetPSC',
     deps = [
         '//hdl/ip/bsv/ignition:Target',
         '//hdl/ip/bsv/ignition:TargetWrapper',
-    ])
-
-yosys_design('ignition_target_psc_rev_a_reset_button_top',
-    top_module = 'mkPSCRevAResetButton',
-    sources = [
-        ':IgnitionTargetPSC#mkPSCRevAResetButton',
-        '//vnd/bluespec:Verilog.v#Verilog.v',
-        '../../ip/bsv/InitialReset.v',
-    ],
-    deps = [
-        ':IgnitionTargetPSC',
-        '//vnd/bluespec:Verilog.v',
-    ])
-
-nextpnr_ice40_bitstream('ignition_target_psc_rev_a_reset_button',
-    env = 'ignition_target',
-    design = ':ignition_target_psc_rev_a_reset_button_top#' \
-                'ignition_target_psc_rev_a_reset_button_top.json',
-    deps = [
-        ':ignition_target_psc_rev_a_reset_button_top',
     ])
 
 # Rev B targets

--- a/hdl/projects/sidecar/ignition_target/BUILD
+++ b/hdl/projects/sidecar/ignition_target/BUILD
@@ -7,8 +7,6 @@
 bluespec_verilog('IgnitionTargetSidecar',
     top = 'IgnitionTargetSidecar.bsv',
     modules = [
-        'mkSidecarRevATargetWithResetButton',
-        'mkSidecarRevATargetWithPowerButton',
         'mkSidecarRevBTargetWithResetButton',
         'mkSidecarRevBTargetWithPowerButton',
         'mkSidecarRevBTarget',
@@ -16,48 +14,6 @@ bluespec_verilog('IgnitionTargetSidecar',
     deps = [
         '//hdl/ip/bsv/ignition:Target',
         '//hdl/ip/bsv/ignition:TargetWrapper',
-    ])
-
-# Rev A targets
-
-yosys_design('ignition_target_rev_a_reset_button_top',
-    top_module = 'mkSidecarRevATargetWithResetButton',
-    sources = [
-        ':IgnitionTargetSidecar#mkSidecarRevATargetWithResetButton',
-        '//vnd/bluespec:Verilog.v#Verilog.v',
-        '../../../ip/bsv/InitialReset.v',
-    ],
-    deps = [
-        ':IgnitionTargetSidecar',
-        '//vnd/bluespec:Verilog.v',
-    ])
-
-nextpnr_ice40_bitstream('ignition_target_sidecar_rev_a_reset_button',
-    env = 'ignition_target',
-    design = ':ignition_target_rev_a_reset_button_top#' \
-                'ignition_target_rev_a_reset_button_top.json',
-    deps = [
-        ':ignition_target_rev_a_reset_button_top',
-    ])
-
-yosys_design('ignition_target_rev_a_power_button_top',
-    top_module = 'mkSidecarRevATargetWithPowerButton',
-    sources = [
-        ':IgnitionTargetSidecar#mkSidecarRevATargetWithPowerButton',
-        '//vnd/bluespec:Verilog.v#Verilog.v',
-        '../../../ip/bsv/InitialReset.v',
-    ],
-    deps = [
-        ':IgnitionTargetSidecar',
-        '//vnd/bluespec:Verilog.v',
-    ])
-
-nextpnr_ice40_bitstream('ignition_target_sidecar_rev_a_power_button',
-    env = 'ignition_target',
-    design = ':ignition_target_rev_a_power_button_top#' \
-                'ignition_target_rev_a_power_button_top.json',
-    deps = [
-        ':ignition_target_rev_a_power_button_top',
     ])
 
 # Rev B, C targets


### PR DESCRIPTION
We need some fixes in ghdl for more modern vhdl files such as https://github.com/ghdl/ghdl/issues/2682

I've installed the new toolchain, we'll see how ci goes.  We can walk this back as the old toolchain is still present on the build machine.