### PR TITLE
make the I2C Controller VC performance configurable

### DIFF
--- a/hdl/ip/vhd/i2c/common/i2c_common_pkg.vhd
+++ b/hdl/ip/vhd/i2c/common/i2c_common_pkg.vhd
@@ -14,6 +14,7 @@ package i2c_common_pkg is
     --
 
     type mode_t is (
+        SIMULATION, -- arbitrarily fast for simulation only
         STANDARD,   -- up to 100 Kbps
         FAST,       -- up to 400 Kbps
         FAST_PLUS   -- up to 1 Mbps
@@ -60,6 +61,15 @@ package body i2c_common_pkg is
         variable r : settings_t;
     begin
         case mode is
+            when SIMULATION =>
+                 r := (
+                    800,
+                    50, -- currently unused by our simulated controller
+                    200,
+                    200,
+                    200,
+                    50 -- currently unsed by our simulated controller
+                 );
             when STANDARD =>
                  r := (
                     10_000, -- 10^9 / 100_000Hz

--- a/hdl/ip/vhd/vunit_components/BUCK
+++ b/hdl/ip/vhd/vunit_components/BUCK
@@ -29,6 +29,7 @@ vhdl_unit(
 vhdl_unit(
     name = "i2c_controller_vc",
     srcs = glob(["i2c_controller/*.vhd"]),
+    deps = ["//hdl/ip/vhd/i2c/common:i2c_common_pkg"],
     visibility = ['PUBLIC'],
 )
 

--- a/hdl/ip/vhd/vunit_components/i2c_controller/i2c_ctrlr_vc.vhd
+++ b/hdl/ip/vhd/vunit_components/i2c_controller/i2c_ctrlr_vc.vhd
@@ -22,11 +22,13 @@ library vunit_lib;
     context vunit_lib.com_context;
 use vunit_lib.sync_pkg.all;
 
+use work.i2c_common_pkg.all;
 use work.i2c_ctrl_vc_pkg.all;
 
 entity i2c_controller_vc is
     generic (
-        i2c_ctrl_vc : i2c_ctrl_vc_t
+        i2c_ctrl_vc : i2c_ctrl_vc_t;
+        mode : mode_t := SIMULATION
     );
     port (
         scl : inout std_logic := 'Z';
@@ -35,10 +37,11 @@ entity i2c_controller_vc is
 end entity;
 
 architecture model of i2c_controller_vc is
-    constant sclk_per : time := 800 ns;
-    constant thd_sta : time := 200 ns;
-    constant tsu_sto : time := 200 ns;
-    constant tbuf : time := 200 ns;
+    constant settings : settings_t := get_i2c_settings(mode);
+    constant sclk_per : time := settings.fscl_period_ns * 1 ns;
+    constant thd_sta : time := settings.sta_su_hd_ns * 1 ns;
+    constant tsu_sto : time := settings.sto_su_ns * 1 ns;
+    constant tbuf : time := settings.sto_sta_buf_ns * 1 ns;
     type state_t is (IDLE, START, STOP, IN_DATA, OUT_DATA, ACK, NACK, GET_ACK_OR_NACK);
     signal state : state_t := IDLE;
     type flags_t is record


### PR DESCRIPTION
This commit makes the `i2c_controller_vc` performance configurable. It defaults to the  settings as originally designed. The ability to make this operate at a particular speed is useful for me in the SPD mux context where I want to simulate a controller at a certain speed.