### PR TITLE
Add an SPD proxy mux

### DIFF
--- a/hdl/ip/vhd/i2c/controller/txn_layer/sims/i2c_ctrl_txn_layer_th.vhd
+++ b/hdl/ip/vhd/i2c/controller/txn_layer/sims/i2c_ctrl_txn_layer_th.vhd
@@ -14,7 +14,6 @@ library vunit_lib;
     context vunit_lib.vc_context;
 
 use work.i2c_common_pkg.all;
-use work.i2c_common_pkg.all;
 use work.tristate_if_pkg.all;
 use work.stream8_pkg;
 

--- a/hdl/ip/vhd/vunit_components/i2c_controller/i2c_ctrlr_vc.vhd
+++ b/hdl/ip/vhd/vunit_components/i2c_controller/i2c_ctrlr_vc.vhd
@@ -120,7 +120,7 @@ begin
                 sda <= 'Z';
                 wait for 60 ns; -- need to be longer than 50ns glitch timing
                 sda <= '0';
-                wait for thd_sta * 4;
+                wait for thd_sta;
                 wait until falling_edge(aligner_int);
                 scl <= '0';     -- scl is now low, ready for bits
                 wait for 60 ns; -- need to be longer than 50ns glitch timing

--- a/hdl/projects/cosmo_seq/spd_proxy/BUCK
+++ b/hdl/projects/cosmo_seq/spd_proxy/BUCK
@@ -1,0 +1,27 @@
+load("//tools:hdl.bzl", "vhdl_unit", "vunit_sim")
+
+vhdl_unit(
+    name = "spd_proxy_top",
+    srcs = glob(["*.vhd"]),
+    deps = [
+        "//hdl/ip/vhd/common:tristate_if_pkg",
+        "//hdl/ip/vhd/i2c/common:i2c_common_pkg",
+        "//hdl/ip/vhd/i2c/common:i2c_glitch_filter",
+        "//hdl/ip/vhd/i2c/controller:i2c_ctrl_txn_layer",
+    ],
+    standard = "2019",
+    visibility = ['PUBLIC']
+)
+
+vunit_sim(
+    name = "spd_proxy_top_tb",
+    srcs = glob(["sims/*.vhd"]),
+    deps = [
+        ":spd_proxy_top",
+        "//hdl/ip/vhd/vunit_components:basic_stream",
+        "//hdl/ip/vhd/vunit_components:i2c_cmd_vc",
+        "//hdl/ip/vhd/vunit_components:i2c_target_vc",
+        "//hdl/ip/vhd/vunit_components:i2c_controller_vc"
+    ],
+    visibility = ['PUBLIC'],
+)

--- a/hdl/projects/cosmo_seq/spd_proxy/sims/spd_proxy_top_tb.gtkw
+++ b/hdl/projects/cosmo_seq/spd_proxy/sims/spd_proxy_top_tb.gtkw
@@ -1,0 +1,75 @@
+[*]
+[*] GTKWave Analyzer v3.3.104 (w)1999-2020 BSI
+[*] Wed Feb 19 22:29:57 2025
+[*]
+[dumpfile] "/home/aaron/Oxide/git/quartz/vunit_out/test_output/lib.spd_proxy_top_tb.cpu_with_simulated_start_009e7a6b9dbd8a7136824e0237951cc80f6be48b/nvc/spd_proxy_top_tb.fst"
+[dumpfile_mtime] "Wed Feb 19 22:23:27 2025"
+[dumpfile_size] 5095
+[savefile] "/home/aaron/Oxide/git/quartz/hdl/projects/cosmo_seq/spd_proxy/sims/spd_proxy_top_tb.gtkw"
+[timestart] 0
+[size] 2816 1283
+[pos] 1074 -22
+*-34.132660 19580000000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+[treeopen] spd_proxy_top_tb.
+[treeopen] spd_proxy_top_tb.th.
+[treeopen] spd_proxy_top_tb.th.spd_proxy_top_inst.
+[treeopen] spd_proxy_top_tb.th.spd_proxy_top_inst.i2c_ctrl_txn_layer_inst.
+[treeopen] spd_proxy_top_tb.th.spd_proxy_top_inst.i2c_ctrl_txn_layer_inst.i2c_ctrl_link_layer_inst.
+[sst_width] 281
+[signals_width] 337
+[sst_expanded] 1
+[sst_vpaned_height] 382
+@200
+-CPU Bus
+@28
+spd_proxy_top_tb.th.i2c_controller_vc_inst.state
+spd_proxy_top_tb.th.cpu_scl
+spd_proxy_top_tb.th.cpu_sda
+@200
+-
+-DIMM Bus
+@28
+spd_proxy_top_tb.th.i2c_target_vc_inst.state
+spd_proxy_top_tb.th.dimm_scl
+spd_proxy_top_tb.th.dimm_sda
+@200
+-
+-FPGA Bus
+@28
+spd_proxy_top_tb.th.spd_proxy_top_inst.fpga_scl_if.i
+spd_proxy_top_tb.th.spd_proxy_top_inst.fpga_sda_if.i
+@200
+-
+-SPD Proxy Logic
+@28
+spd_proxy_top_tb.th.spd_proxy_top_inst.cpu_start_detected
+spd_proxy_top_tb.th.spd_proxy_top_inst.cpu_stop_detected
+spd_proxy_top_tb.th.spd_proxy_top_inst.cpu_busy
+spd_proxy_top_tb.th.spd_proxy_top_inst.cpu_has_mux
+spd_proxy_top_tb.th.spd_proxy_top_inst.ctrlr_has_int_mux
+@200
+-
+-Simulated START State
+@28
+spd_proxy_top_tb.th.spd_proxy_top_inst.scl_sim
+spd_proxy_top_tb.th.spd_proxy_top_inst.sda_sim
+@29
+spd_proxy_top_tb.th.spd_proxy_top_inst.sda_sim_fedge
+@28
+spd_proxy_top_tb.th.spd_proxy_top_inst.need_start
+spd_proxy_top_tb.th.spd_proxy_top_inst.start_simulated
+@200
+-
+-Internal I2C Controller
+-Transaction Layer
+@28
+spd_proxy_top_tb.th.spd_proxy_top_inst.i2c_ctrl_txn_layer_inst.abort
+spd_proxy_top_tb.th.spd_proxy_top_inst.i2c_ctrl_txn_layer_inst.sm_reg.do_stop
+spd_proxy_top_tb.th.spd_proxy_top_inst.i2c_ctrl_txn_layer_inst.sm_reg.state
+@200
+-Link Layer
+@28
+spd_proxy_top_tb.th.spd_proxy_top_inst.i2c_ctrl_txn_layer_inst.i2c_ctrl_link_layer_inst.sm_reg.stop_requested
+spd_proxy_top_tb.th.spd_proxy_top_inst.i2c_ctrl_txn_layer_inst.i2c_ctrl_link_layer_inst.sm_reg.state
+[pattern_trace] 1
+[pattern_trace] 0

--- a/hdl/projects/cosmo_seq/spd_proxy/sims/spd_proxy_top_tb.vhd
+++ b/hdl/projects/cosmo_seq/spd_proxy/sims/spd_proxy_top_tb.vhd
@@ -1,0 +1,129 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+-- Copyright 2025 Oxide Computer Company
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std_unsigned.all;
+
+library osvvm;
+use osvvm.RandomPkg.RandomPType;
+
+library vunit_lib;
+    context vunit_lib.com_context;
+    context vunit_lib.vunit_context;
+    context vunit_lib.vc_context;
+
+-- VCs
+use work.basic_stream_pkg.all;
+use work.i2c_cmd_vc_pkg.all;
+use work.i2c_common_pkg.all;
+use work.i2c_ctrl_vc_pkg.all;
+use work.i2c_target_vc_pkg.all;
+
+use work.spd_proxy_top_tb_pkg.all;
+
+entity spd_proxy_top_tb is
+    generic (
+        runner_cfg : string
+    );
+end entity;
+
+architecture tb of spd_proxy_top_tb is
+begin
+
+    th: entity work.spd_proxy_top_th;
+
+    bench: process
+        alias reset is << signal th.reset : std_logic >>;
+        variable rnd    : RandomPType;
+        variable i2c_ctrlr_msg : msg_t;
+
+        variable command    : cmd_t;
+        variable ack        : boolean := false;
+
+        variable data       : std_logic_vector(7 downto 0);
+        variable exp_addr   : std_logic_vector(7 downto 0);
+        variable exp_data   : std_logic_vector(7 downto 0);
+        variable byte_len   : natural;
+        variable byte_idx   : natural;
+
+        variable cpu_tx_q   : queue_t   := new_queue;
+        variable cpu_ack_q  : queue_t   := new_queue;
+        variable fpga_tx_q  : queue_t   := new_queue;
+        variable fpga_exp_q : queue_t   := new_queue;
+
+        -- helper to get the internal FPGA controller doing _something_ before we have the CPU
+        -- attempting to interrupt
+        procedure init_controller is
+        begin
+            -- arbitrary for the test
+            exp_addr    := X"00";
+            byte_len    := 8;
+            for i in 0 to byte_len - 1 loop
+                push_byte(fpga_tx_q, rnd.RandInt(0, 255));
+            end loop;
+            fpga_exp_q := copy(fpga_tx_q);
+
+            -- write some data in
+            command := (
+                op      => WRITE,
+                addr    => address(I2C_TGT_VC),
+                reg     => std_logic_vector(exp_addr), 
+                len     => to_std_logic_vector(byte_len, command.len'length)
+            );
+            issue_i2c_cmd(net, command, fpga_tx_q);
+        end procedure;
+    begin
+        -- Always the first thing in the process, set up things for the VUnit test runner
+        test_runner_setup(runner, runner_cfg);
+        -- Reach into the test harness, which generates and de-asserts reset and hold the
+        -- test cases off until we're out of reset. This runs for every test case
+        wait until reset = '0';
+        wait for 500 ns;  -- let the resets propagate
+
+        while test_suite loop
+            if run("no_cpu_transaction") then
+                init_controller;
+
+                byte_idx := to_integer(exp_addr);
+                while not is_empty(fpga_exp_q) loop
+                    data        := to_std_logic_vector(pop_byte(fpga_exp_q), data'length);
+                    exp_addr    := to_std_logic_vector(byte_idx, exp_addr'length);
+                    check_written_byte(net, I2C_TGT_VC, data, exp_addr);
+                    byte_idx := byte_idx + 1;
+                end loop;
+
+                expect_stop(net, I2C_TGT_VC);
+            elsif run("cpu_transaction") then
+                -- Get the FPGA controller started on a transaction
+                init_controller;
+
+                -- At some point into the transaction, have the CPU start its own
+                wait for rnd.RandInt(500, 4000) * 1 ns;
+
+                push_byte(cpu_tx_q, to_integer(rnd.RandSlv(0, 255, 8)));
+                i2c_write_txn(net, address(I2C_TGT_VC), cpu_tx_q, cpu_ack_q, I2C_CTRL_VC.p_actor);
+
+            elsif run("cpu_with_simulated_start") then
+                -- Get the FPGA controller started on a transaction
+                init_controller;
+
+                -- At some point into the transaction, have the CPU start its own
+                wait for 9500 ns;
+
+                push_byte(cpu_tx_q, to_integer(rnd.RandSlv(0, 255, 8)));
+                i2c_write_txn(net, address(I2C_TGT_VC), cpu_tx_q, cpu_ack_q, I2C_CTRL_VC.p_actor);
+            end if;
+        end loop;
+
+        wait for 2 us;
+        test_runner_cleanup(runner);
+        wait;
+    end process;
+
+    test_runner_watchdog(runner, 10 ms);
+
+end architecture;

--- a/hdl/projects/cosmo_seq/spd_proxy/sims/spd_proxy_top_tb_pkg.vhd
+++ b/hdl/projects/cosmo_seq/spd_proxy/sims/spd_proxy_top_tb_pkg.vhd
@@ -1,0 +1,59 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+-- Copyright 2025 Oxide Computer Company
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std_unsigned.all;
+
+library vunit_lib;
+    context vunit_lib.vunit_context;
+    context vunit_lib.com_context;
+    context vunit_lib.vc_context;
+
+use work.i2c_cmd_vc_pkg.all;
+use work.i2c_ctrl_vc_pkg.all;
+use work.i2c_target_vc_pkg.all;
+use work.basic_stream_pkg.all;
+
+use work.i2c_common_pkg.all;
+
+package spd_proxy_top_tb_pkg is
+    -- Constants
+    constant CLK_PER_NS : positive := 8;
+
+    -- Verification Components
+    constant I2C_CTRL_VC        : i2c_ctrl_vc_t     := new_i2c_ctrl_vc("cpu_i2c_vc");
+    constant I2C_TGT_VC         : i2c_target_vc_t   := new_i2c_target_vc("dimm_i2c_vc");
+    constant I2C_CMD_VC         : i2c_cmd_vc_t      := new_i2c_cmd_vc;
+    constant TX_DATA_SOURCE_VC  : basic_source_t    := new_basic_source(8);
+    constant RX_DATA_SINK_VC    : basic_sink_t      := new_basic_sink(8);
+
+    procedure issue_i2c_cmd (
+        signal net  : inout network_t;
+        constant command : cmd_t;
+        constant tx_data : queue_t;
+    );
+
+end package;
+
+package body spd_proxy_top_tb_pkg is
+
+    procedure issue_i2c_cmd (
+        signal net  : inout network_t;
+        constant command : cmd_t;
+        constant tx_data : queue_t;
+    ) is
+        variable ack    : boolean := FALSE;
+    begin
+        push_i2c_cmd(net, I2C_CMD_VC, command);
+        start_byte_ack(net, I2C_TGT_VC, ack);
+        check_true(ack, "Peripheral did not ACK correct address");
+        while not is_empty(tx_data) loop
+            push_basic_stream(net, TX_DATA_SOURCE_VC, to_std_logic_vector(pop_byte(tx_data), 8));
+        end loop;
+    end procedure;
+
+end package body;

--- a/hdl/projects/cosmo_seq/spd_proxy/sims/spd_proxy_top_th.vhd
+++ b/hdl/projects/cosmo_seq/spd_proxy/sims/spd_proxy_top_th.vhd
@@ -1,0 +1,138 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+-- Copyright 2025 Oxide Computer Company
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library vunit_lib;
+    context vunit_lib.vunit_context;
+    context vunit_lib.com_context;
+    context vunit_lib.vc_context;
+
+use work.i2c_common_pkg.all;
+use work.tristate_if_pkg.all;
+use work.stream8_pkg;
+
+use work.spd_proxy_top_tb_pkg.all;
+
+entity spd_proxy_top_th is
+end entity;
+
+architecture th of spd_proxy_top_th is
+    constant CLK_PER_TIME : time := CLK_PER_NS * 1 ns;
+
+    signal clk   : std_logic := '0';
+    signal reset : std_logic := '1';
+
+    signal cpu_scl  : std_logic;
+    signal cpu_sda  : std_logic;
+    signal dimm_scl : std_logic;
+    signal dimm_sda : std_logic;
+
+    signal cpu_proxy_scl_if     : tristate;
+    signal cpu_proxy_sda_if     : tristate;
+    signal dimm_proxy_scl_if    : tristate;
+    signal dimm_proxy_sda_if    : tristate;
+
+    signal command          : cmd_t;
+    signal command_valid    : std_logic;
+    signal controller_ready : std_logic;
+    signal tx_data_stream   : stream8_pkg.data_channel;
+    signal rx_data_stream   : stream8_pkg.data_channel;
+begin
+
+    clk     <= not clk after CLK_PER_TIME / 2;
+    reset   <= '0' after 200 ns;
+
+    -- simulated CPU I2C controller
+    i2c_controller_vc_inst: entity work.i2c_controller_vc
+        generic map(
+            I2C_CTRL_VC => I2C_CTRL_VC,
+            MODE        => STANDARD
+        )
+        port map(
+            scl => cpu_scl,
+            sda => cpu_sda
+        );
+
+    -- simulated DIMM I2C target
+    i2c_target_vc_inst: entity work.i2c_target_vc
+        generic map(
+            I2C_TARGET_VC => I2C_TGT_VC
+        )
+        port map(
+            scl => dimm_scl,
+            sda => dimm_sda
+        );
+
+    -- DUT: the SPD proxy
+    spd_proxy_top_inst: entity work.spd_proxy_top
+        generic map(
+            CLK_PER_NS  => CLK_PER_NS,
+            I2C_MODE    => FAST_PLUS
+        )
+        port map(
+            clk                 => clk,
+            reset               => reset,
+            cpu_scl_if          => cpu_proxy_scl_if,
+            cpu_sda_if          => cpu_proxy_sda_if,
+            dimm_scl_if         => dimm_proxy_scl_if,
+            dimm_sda_if         => dimm_proxy_sda_if,
+            i2c_command         => command,
+            i2c_command_valid   => command_valid,
+            i2c_ctrlr_idle      => controller_ready,
+            i2c_tx_st_if        => tx_data_stream,
+            i2c_rx_st_if        => rx_data_stream
+        );
+
+    -- I2C simulation support infrastructure
+    i2c_cmd_vc_inst: entity work.i2c_cmd_vc
+        generic map (
+            I2C_CMD_VC => I2C_CMD_VC
+        )
+        port map (
+            cmd     => command,
+            valid   => command_valid,
+            abort   => open,
+            ready   => controller_ready
+        );
+
+    tx_source_vc : entity work.basic_source
+        generic map (
+            SOURCE  => TX_DATA_SOURCE_VC
+        )
+        port map (
+            clk     => clk,
+            valid   => tx_data_stream.valid,
+            ready   => tx_data_stream.ready,
+            data    => tx_data_stream.data
+        );
+
+    rx_sink_vc : entity work.basic_sink
+        generic map (
+            SINK    => RX_DATA_SINK_VC
+        )
+        port map (
+            clk     => clk,
+            valid   => rx_data_stream.valid,
+            ready   => rx_data_stream.ready,
+            data    => rx_data_stream.data
+        );
+
+    -- wire the CPU to the proxy DUT
+    cpu_scl <= cpu_proxy_scl_if.o when cpu_proxy_scl_if.oe else 'H';
+    cpu_sda <= cpu_proxy_sda_if.o when cpu_proxy_sda_if.oe else 'H';
+    cpu_proxy_scl_if.i  <= cpu_scl;
+    cpu_proxy_sda_if.i  <= cpu_sda;
+
+    -- wire the proxy DUT to the DIMMs
+    dimm_scl <= dimm_proxy_scl_if.o when dimm_proxy_scl_if.oe else 'H';
+    dimm_sda <= dimm_proxy_sda_if.o when dimm_proxy_sda_if.oe else 'H';
+    dimm_proxy_scl_if.i <= dimm_scl;
+    dimm_proxy_sda_if.i <= dimm_sda;
+
+end architecture;

--- a/hdl/projects/cosmo_seq/spd_proxy/spd_proxy_top.vhd
+++ b/hdl/projects/cosmo_seq/spd_proxy/spd_proxy_top.vhd
@@ -1,0 +1,203 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+-- Copyright 2025 Oxide Computer Company
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+use work.i2c_common_pkg.all;
+use work.stream8_pkg;
+use work.time_pkg.all;
+use work.tristate_if_pkg.all;
+
+entity spd_proxy_top is
+    generic (
+        CLK_PER_NS  : positive;
+        I2C_MODE    : mode_t;
+    );
+    port (
+        clk         : in std_logic;
+        reset       : in std_logic;
+
+        -- CPU <-> FPGA
+        cpu_scl_if  : view tristate_if;
+        cpu_sda_if  : view tristate_if;
+
+        -- FPGA <-> DIMMs
+        dimm_scl_if : view tristate_if;
+        dimm_sda_if : view tristate_if;
+
+        -- FPGA I2C Interface
+        i2c_command         : in cmd_t;
+        i2c_command_valid   : in std_logic;
+        i2c_ctrlr_idle      : out std_logic;
+        i2c_tx_st_if        : view stream8_pkg.st_sink_if;
+        i2c_rx_st_if        : view stream8_pkg.st_source_if;
+    );
+end entity;
+
+architecture rtl of spd_proxy_top is
+    constant CPU_I2C_TSP_CYCLES : integer :=
+        to_integer(calc_ns(get_i2c_settings(I2C_MODE).tsp_ns, CLK_PER_NS, 8));
+    signal cpu_scl_filt         : std_logic;
+    signal cpu_scl_fedge        : std_logic;
+    signal cpu_sda_fedge        : std_logic;
+    signal cpu_sda_redge        : std_logic;
+    signal cpu_start_detected   : std_logic;
+    signal cpu_stop_detected    : std_logic;
+    signal cpu_busy             : boolean;
+    signal cpu_has_mux          : boolean;
+
+    signal ctrlr_idle           : std_logic;
+    signal ctrlr_scl_if         : tristate;
+    signal ctrlr_sda_if         : tristate;
+    signal ctrlr_has_int_mux    : boolean;
+
+    signal fpga_scl_if  : tristate;
+    signal fpga_sda_if  : tristate;
+
+    constant CNTR_SIZE      : integer := 8;
+    -- use the FAST_PLUS hold time since we know the targets support it
+    constant START_HD_TICKS : std_logic_vector(CNTR_SIZE - 1 downto 0) :=
+        calc_ns(get_i2c_settings(FAST_PLUS).sta_su_hd_ns, CLK_PER_NS, CNTR_SIZE);
+    signal need_start       : boolean;
+    signal scl_sim          : std_logic;
+    signal sda_sim          : std_logic;
+    signal sda_sim_fedge    : std_logic;
+    signal start_simulated  : std_logic;
+begin
+    --
+    -- CPU bus monitoring
+    --
+    i2c_glitch_filter_inst: entity work.i2c_glitch_filter
+        generic map(
+            filter_cycles   => CPU_I2C_TSP_CYCLES
+        )
+        port map(
+            clk             => clk,
+            reset           => reset,
+            raw_scl         => cpu_scl_if.i,
+            raw_sda         => cpu_sda_if.i,
+            filtered_scl    => cpu_scl_filt,
+            scl_redge       => open,
+            scl_fedge       => cpu_scl_fedge,
+            filtered_sda    => open,
+            sda_redge       => cpu_sda_redge,
+            sda_fedge       => cpu_sda_fedge
+        );
+
+    -- on a START we need to request the controller abort any in-progress transaction
+    cpu_start_detected  <= '1' when cpu_scl_filt = '1' and cpu_sda_fedge = '1' else '0';
+    -- on a STOP we know the CPU is done and we can resume our work
+    cpu_stop_detected   <= '1' when cpu_scl_filt = '1' and cpu_sda_redge = '1' else '0';
+
+    bus_monitor: process(clk, reset)
+    begin
+        if reset then
+            cpu_busy    <= false;
+            need_start  <= false;
+        elsif rising_edge(clk) then
+            if cpu_start_detected then
+                cpu_busy    <= true;
+            elsif cpu_stop_detected then
+                cpu_busy    <= false;
+            end if;
+
+            -- The FPGA still owns the bus and the START hold time as elapsed. This means before
+            -- the mux is swapped we need to simulate a START condition .
+            if ctrlr_idle = '0' and cpu_scl_fedge = '1' then
+                need_start  <= true;
+            elsif start_simulated then
+                need_start  <= false;
+            end if;
+        end if;
+    end process;
+
+    start_generator: process(clk, reset)
+        variable sda_sim_next   : std_logic;
+    begin
+        if reset then
+            scl_sim         <= '1';
+            sda_sim         <= '1';
+            sda_sim_fedge   <= '1';
+            sda_sim_next    := '1';
+        elsif rising_edge(clk) then
+            -- Do we need to perhaps be smarter here around sending SCL low prior to handing the
+            -- bus back to the CPU? We may not need to worry about simulating a falling edge on SCL
+            -- since that will happen automatically when we cut over to the CPU bus where SCL is low
+            -- already, but we can't know the state of SDA. A hard cutover back to the CPU with SCL
+            -- going low and SDA going high the same cycle could theoretically cause a STOP glitch?
+            scl_sim <= '1';
+            if need_start and not ctrlr_has_int_mux and start_simulated = '0' then
+                -- create the artifical START condition
+                sda_sim_next    := '0';
+            else
+                sda_sim_next    := '1';
+            end if;
+
+            -- use the falling edge to load the simulated START hold time counter
+            sda_sim_fedge   <= '1' when sda_sim = '1' and sda_sim_next = '0' else '0';
+            sda_sim         <= sda_sim_next;
+        end if;
+    end process;
+
+    countdown_inst: entity work.countdown
+        generic map (
+            SIZE    => CNTR_SIZE
+        )
+        port map (
+            clk     => clk,
+            reset   => reset,
+            count   => START_HD_TICKS,
+            load    => sda_sim_fedge,
+            decr    => not sda_sim,
+            clear   => '0',
+            done    => start_simulated
+        );
+
+    -- FPGA I2C controller
+    i2c_ctrl_txn_layer_inst: entity work.i2c_ctrl_txn_layer
+        generic map(
+            CLK_PER_NS  => CLK_PER_NS,
+            MODE        => I2C_MODE
+        )
+        port map(
+            clk         => clk,
+            reset       => reset,
+            scl_if      => ctrlr_scl_if,
+            sda_if      => ctrlr_sda_if,
+            cmd         => i2c_command,
+            cmd_valid   => i2c_command_valid,
+            abort       => cpu_start_detected,
+            core_ready  => i2c_ctrlr_idle,
+            tx_st_if    => i2c_tx_st_if,
+            rx_st_if    => i2c_rx_st_if
+        );
+
+    -- This mux controls if the I2C controller or the simulated START generator control the
+    -- FPGA internal I2C bux.
+    ctrlr_has_int_mux   <= not need_start or i2c_ctrlr_idle = '0';
+    fpga_scl_if.o       <= ctrlr_scl_if.o when ctrlr_has_int_mux else scl_sim;
+    fpga_scl_if.oe      <= ctrlr_scl_if.oe when ctrlr_has_int_mux else not scl_sim;
+    fpga_sda_if.o       <= ctrlr_sda_if.o when ctrlr_has_int_mux else sda_sim;
+    fpga_sda_if.oe      <= ctrlr_sda_if.oe when ctrlr_has_int_mux else not sda_sim;
+
+    -- Break the controller input from the bus when it does not have this mux
+    ctrlr_scl_if.i      <= fpga_scl_if.i when ctrlr_has_int_mux else '1';
+    ctrlr_sda_if.i      <= fpga_sda_if.i when ctrlr_has_int_mux else '1';
+
+    -- This mux controls if the CPU or the FPGA control the bus out to the DIMMs
+    cpu_has_mux     <= cpu_busy and i2c_ctrlr_idle = '1' and not need_start;
+    dimm_scl_if.o   <= cpu_scl_if.i when cpu_has_mux else fpga_scl_if.o;
+    dimm_scl_if.oe  <= not cpu_scl_if.i when cpu_has_mux else fpga_scl_if.oe;
+    dimm_sda_if.o   <= cpu_sda_if.i when cpu_has_mux else fpga_sda_if.o;
+    dimm_sda_if.oe  <= not cpu_sda_if.i when cpu_has_mux else fpga_sda_if.oe;
+
+    -- Break the fpga input from the bus when it doesn't have the bus
+    fpga_scl_if.i  <= '1' when cpu_has_mux else dimm_scl_if.i;
+    fpga_sda_if.i  <= '1' when cpu_has_mux else dimm_sda_if.i;
+
+end architecture;


### PR DESCRIPTION
This commit adds the `spd_proxy_top` block whose intention is to house an I2C controller which will attempt to utilize the DIMM bus while a CPU is not using it. When the CPU begins using the bus the internal controller will wrap up what it is doing as quickly as possible and we will attempt to gracefully hand the bus over the CPU in a way that doesn't cause problems.