### PR TITLE
RDL naming convention enforcement and updates

### DIFF
--- a/hdl/ip/vhd/espi/BUCK
+++ b/hdl/ip/vhd/espi/BUCK
@@ -2,21 +2,21 @@ load("//tools:hdl.bzl", "vhdl_unit", "vunit_sim")
 load("//tools:rdl.bzl", "rdl_file")
 
 rdl_file(
-    name = "espi_spec_regs_pkg",
+    name = "espi_spec_regs_rdl",
     src = "espi_spec_regs.rdl",
     outputs = ["espi_spec_regs_pkg.vhd", "espi_spec_regs.html"],
     visibility = ['PUBLIC']
 )
 
 rdl_file(
-    name = "vwire_regs_pkg",
+    name = "vwire_regs_rdl",
     src = "vwire_channel/vwire_regs.rdl",
     outputs = ["vwire_regs_pkg.vhd", "vwire_regs.html"],
     visibility = ['PUBLIC']
 )
 
 rdl_file(
-    name = "espi_regs_pkg",
+    name = "espi_regs_rdl",
     src = "sys_regs/espi_regs.rdl",
     outputs = ["espi_regs_pkg.vhd", "espi_regs.html"],
     visibility = ['PUBLIC']
@@ -33,9 +33,9 @@ vhdl_unit(
         "vwire_channel/*.vhd",
         "*.vhd"]),
     deps = [
-        ":espi_spec_regs_pkg",
-        ":espi_regs_pkg",
-        ":vwire_regs_pkg",
+        ":espi_spec_regs_rdl",
+        ":espi_regs_rdl",
+        ":vwire_regs_rdl",
         "//hdl/ip/vhd/common:calc_pkg",
         "//hdl/ip/vhd/common:time_pkg",
         "//hdl/ip/vhd/synchronizers:meta_sync",

--- a/hdl/ip/vhd/espi/sys_regs/espi_regs.rdl
+++ b/hdl/ip/vhd/espi/sys_regs/espi_regs.rdl
@@ -2,7 +2,14 @@
 // This is SystemRDL description of the sw-accessible registers in the Gimlet
 // Sequencer FPGA.
 
+property addr_span_bytes {
+    type=number;
+    component=addrmap;
+    default=0x100;
+    };
+
 addrmap espi_regs {
+    
     name = "espi system registers";
     desc = "Registers accessible on the Axi bus for debug and testing of the espi target";
 

--- a/hdl/ip/vhd/i2c/controller/BUCK
+++ b/hdl/ip/vhd/i2c/controller/BUCK
@@ -2,7 +2,7 @@ load("//tools:hdl.bzl", "vhdl_unit", "vunit_sim")
 load("//tools:rdl.bzl", "rdl_file")
 
 rdl_file(
-    name = "i2c_ctrl_regs_pkg",
+    name = "i2c_ctrl_regs_rdl",
     src = "regs/i2c_ctrl_regs.rdl",
     outputs = ["i2c_ctrl_regs_pkg.vhd", "i2c_ctrl_regs.html"],
     visibility = ['PUBLIC']

--- a/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/BUCK
+++ b/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/BUCK
@@ -2,9 +2,9 @@ load("//tools:hdl.bzl", "vhdl_unit", "vunit_sim")
 load("//tools:rdl.bzl", "rdl_file")
 
 rdl_file(
-    name = "pca9506_regs_pkg",
+    name = "pca9506_regs_rdl",
     src = "pca9506_regs.rdl",
-    outputs = ["pca9506_regs_pkg.vhd", "pca9506_regs_pkg.html"],
+    outputs = ["pca9506_regs_pkg.vhd", "pca9506_regs.html"],
     visibility = ['PUBLIC']
 )
 
@@ -13,7 +13,7 @@ vhdl_unit(
     srcs = glob(["*.vhd"]),
     deps = [
         "//hdl/ip/vhd/i2c/target:i2c_target_phy",
-        ":pca9506_regs_pkg",
+        ":pca9506_regs_rdl",
     ],
     visibility = ['PUBLIC']
 )

--- a/hdl/ip/vhd/i2c/muxes/PCA9545ish/BUCK
+++ b/hdl/ip/vhd/i2c/muxes/PCA9545ish/BUCK
@@ -2,9 +2,9 @@ load("//tools:hdl.bzl", "vhdl_unit", "vunit_sim")
 load("//tools:rdl.bzl", "rdl_file")
 
 rdl_file(
-    name = "i2c_mux_regs_pkg",
+    name = "emulated_pca9545_regs_rdl",
     src = "emulated_pca9545_regs.rdl",
-    outputs = ["i2c_mux_regs_pkg.vhd", "i2c_mux_regs.html"],
+    outputs = ["emulated_pca9545_regs_pkg.vhd", "emulated_pca9545_regs.html"],
     visibility = ['PUBLIC']
 )
 
@@ -14,7 +14,7 @@ vhdl_unit(
     srcs = glob(["*.vhd"]),
     deps = [
         "//hdl/ip/vhd/i2c/target:i2c_target_phy",
-        ":i2c_mux_regs_pkg",
+        ":emulated_pca9545_regs_rdl",
     ],
     visibility = ['PUBLIC']
 )

--- a/hdl/ip/vhd/i2c/muxes/PCA9545ish/emulated_pca9545_regs.rdl
+++ b/hdl/ip/vhd/i2c/muxes/PCA9545ish/emulated_pca9545_regs.rdl
@@ -1,7 +1,7 @@
 // Copyright 2025 Oxide Computer Company
 // This is SystemRDL description of emulated i2c mux registers
 
-addrmap emulated_pca9545 {
+addrmap emulated_pca9545_regs {
     name = "pca9545 registers";
     desc = "Registers accessible on the i2c bus for controlling the emulated PCA9545 i2c mux";
 

--- a/hdl/ip/vhd/i2c/muxes/PCA9545ish/pca9545ish_function.vhd
+++ b/hdl/ip/vhd/i2c/muxes/PCA9545ish/pca9545ish_function.vhd
@@ -16,7 +16,7 @@ use ieee.numeric_std.all;
 use ieee.numeric_std_unsigned.all;
 
 use work.i2c_base_types_pkg.all;
-use work.i2c_mux_regs_pkg.all;
+use work.emulated_pca9545_regs_pkg.all;
 
 
 entity pca9545ish_function is

--- a/hdl/ip/vhd/info/BUCK
+++ b/hdl/ip/vhd/info/BUCK
@@ -2,7 +2,7 @@ load("//tools:hdl.bzl", "vhdl_unit", "vunit_sim")
 load("//tools:rdl.bzl", "rdl_file")
 
 rdl_file(
-    name = "info_regs_pkg",
+    name = "info_regs_rdl",
     src = "info_regs.rdl",
     outputs = ["info_regs_pkg.vhd", "info_regs.html"],
     visibility = ['PUBLIC']
@@ -32,7 +32,7 @@ vhdl_unit(
     srcs = ["info_2k8.vhd"],
     deps = [
         ":git_sha_pkg",
-        ":info_regs_pkg",
+        ":info_regs_rdl",
         ],
     standard = "2008",
     visibility = ['PUBLIC']

--- a/hdl/ip/vhd/spi_nor_controller/BUCK
+++ b/hdl/ip/vhd/spi_nor_controller/BUCK
@@ -2,12 +2,12 @@ load("//tools:hdl.bzl", "vhdl_unit", "vunit_sim")
 load("//tools:rdl.bzl", "rdl_file")
 
 rdl_file(
-    name = "spi_nor_rdl",
+    name = "spi_nor_regs_rdl",
     src = "spi_nor_regs.rdl",
     outputs = [
         "spi_nor_regs_pkg.vhd", 
-        "spi_nor_reg_map.html", 
-        "spi_nor_reg_map.json",
+        "spi_nor_regs.html", 
+        "spi_nor_regs.json",
     ],
     visibility = ["PUBLIC"],
 )
@@ -23,7 +23,7 @@ vhdl_unit(
     ]),
     standard = "2019",
     deps = [
-        ":spi_nor_rdl",
+        ":spi_nor_regs_rdl",
         "//hdl/ip/vhd/fifos:dcfifo_xpm",
         "//hdl/ip/vhd/axi_blocks:axilite_if_2k19_pkg",
         ],

--- a/hdl/ip/vhd/spi_nor_controller/spi_nor_regs.rdl
+++ b/hdl/ip/vhd/spi_nor_controller/spi_nor_regs.rdl
@@ -7,7 +7,7 @@
 // This is SystemRDL description of the sw-accesible registers in the
 // grapefruit dev board FPGA.
 
-addrmap nor_flash_regs {
+addrmap spi_nor_regs {
     name = "SPI/QSPI NOR flash controller";
     desc = "";
 

--- a/hdl/projects/grapefruit/BUCK
+++ b/hdl/projects/grapefruit/BUCK
@@ -3,37 +3,37 @@ load("//tools:rdl.bzl", "rdl_file")
 load("//tools:vivado.bzl", "vivado_bitstream")
 
 rdl_file(
-    name = "base_regs_map",
+    name = "gfruit_regs_rdl",
     src = "base_regs/gfruit_regs.rdl",
     outputs = [
-        "grapefruit_regs_pkg.vhd", 
-        "grapefruit_reg_map.html", 
-        "grapefruit_reg_map.json",
+        "gfruit_regs_pkg.vhd", 
+        "gfruit_regs.html", 
+        "gfruit_regs.json",
     ]
 )
 
 rdl_file(
-    name = "gfruit_sgpio_regs",
-    src = "sgpio/gfruit_sgpio.rdl",
+    name = "gfruit_sgpio_regs_rdl",
+    src = "sgpio/gfruit_sgpio_regs.rdl",
     outputs = [
-        "sgpio_regs_pkg.vhd", 
-        "sgpio_reg_map.html", 
-        "sgpio_reg_map.json",
+        "gfruit_sgpio_regs_pkg.vhd", 
+        "gfruit_sgpio_regs.html", 
+        "gfruit_sgpio_regs.json",
     ]
 )
 
 rdl_file(
-    name = "gfruit_top_regs",
+    name = "gfruit_top_rdl",
     src = "gfruit_top.rdl",
     deps = [
-        ":base_regs_map",
-        ":gfruit_sgpio_regs",
-        "//hdl/ip/vhd/spi_nor_controller:spi_nor_rdl",
-        "//hdl/ip/vhd/espi:espi_regs_pkg",
+        ":gfruit_regs_rdl",
+        ":gfruit_sgpio_regs_rdl",
+        "//hdl/ip/vhd/spi_nor_controller:spi_nor_regs_rdl",
+        "//hdl/ip/vhd/espi:espi_regs_rdl",
     ],
     outputs = [
-        "gfruit_top_map.html", 
-        "gfruit_top_map.json"
+        "gfruit_top.html", 
+        "gfruit_top.json"
     ]
 )
 
@@ -46,7 +46,7 @@ vhdl_unit (
     name = "base_regs",
     srcs = glob(["base_regs/*.vhd"]),
     deps = [
-        ":base_regs_map",
+        ":gfruit_regs_rdl",
         "//hdl/ip/vhd/axi_blocks:axilite_if_2k19_pkg",
         ],
     standard = "2019",
@@ -56,7 +56,7 @@ vhdl_unit (
     name = "gfruit_sgpio",
     srcs = glob(["sgpio/*.vhd"]),
     deps = [
-        ":gfruit_sgpio_regs",
+        ":gfruit_sgpio_regs_rdl",
         "//hdl/ip/vhd/axi_blocks:axilite_if_2k19_pkg",
         "//hdl/ip/vhd/sgpio:sgpio_top",
         ],
@@ -69,7 +69,7 @@ vhdl_unit(
     srcs = ["grapefruit_top.vhd"],
     deps = [
         ":base_regs",
-        ":gfruit_top_regs",
+        ":gfruit_top_rdl",
         ":gfruit_sgpio",
         ":gfruit_black_boxes",
         "//hdl/projects/cosmo_seq:reset_sync",

--- a/hdl/projects/grapefruit/base_regs/gfruit_regs.rdl
+++ b/hdl/projects/grapefruit/base_regs/gfruit_regs.rdl
@@ -7,7 +7,7 @@
 // This is SystemRDL description of the sw-accesible registers in the
 // grapefruit dev board FPGA.
 
-addrmap gfruit_base_regs {
+addrmap gfruit_regs {
     name = "Grapefruit FPGA";
     desc = "Register description of the Grapefruit FPGA";
 

--- a/hdl/projects/grapefruit/base_regs/registers.vhd
+++ b/hdl/projects/grapefruit/base_regs/registers.vhd
@@ -13,7 +13,7 @@ use ieee.numeric_std_unsigned.all;
 use work.axil_common_pkg.all;
 use work.axil8x32_pkg;
 
-use work.grapefruit_regs_pkg.all;
+use work.gfruit_regs_pkg.all;
 
 entity registers is 
     port (

--- a/hdl/projects/grapefruit/gfruit_top.rdl
+++ b/hdl/projects/grapefruit/gfruit_top.rdl
@@ -1,8 +1,8 @@
 addrmap top_level_map {
     default regwidth = 32;
     // Instantiate 2 to test nesting
-    gfruit_base_regs base @ 0x0;
-    nor_flash_regs spi_nor @ 0x0100;
+    gfruit_regs base @ 0x0;
+    spi_nor_regs spi_nor @ 0x0100;
     espi_regs espi @ 0x0200;
-    gfruit_sgpio sgpio @ 0x0300;
+    gfruit_sgpio_regs sgpio @ 0x0300;
 };

--- a/hdl/projects/grapefruit/sgpio/gfruit_sgpio.vhd
+++ b/hdl/projects/grapefruit/sgpio/gfruit_sgpio.vhd
@@ -18,7 +18,7 @@ use ieee.numeric_std_unsigned.all;
 
 use work.axil8x32_pkg.all;
 
-use work.sgpio_regs_pkg.all;
+use work.gfruit_sgpio_regs_pkg.all;
 
 entity gfruit_sgpio is
     port (

--- a/hdl/projects/grapefruit/sgpio/gfruit_sgpio_regs.rdl
+++ b/hdl/projects/grapefruit/sgpio/gfruit_sgpio_regs.rdl
@@ -1,0 +1,222 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright 2024 Oxide Computer Company
+//
+// This is SystemRDL description of the sw-accesible registers in the
+// grapefruit dev board FPGA.
+
+addrmap gfruit_sgpio_regs {
+    name = "Grapefruit FPGA";
+    desc = "Register description of the Grapefruit FPGA";
+
+    default regwidth = 32;
+    default sw = rw;
+    default hw = r;
+
+    reg {
+        name = "CH0 Outputs";
+        field {
+            desc = "HAWAII_HEARTBEAT";
+        } hbt[15:15] = 0;
+        field {
+            desc = "MB_SCM_HPM_STBY_RDY";
+        } stb_rdy[14:14] = 0;
+        field {
+            desc = "UNUSED_OUTS";
+        } unused[13:12] = 0;
+        field {
+            desc = "HPM_BMC_GPIOY3-??";
+        } y3[11:11] =  0;
+        field {
+            desc = "HPM_BMC_GPIOA5-MGMT_SMBUS_DATA";
+        } a5[10:10] =  1;
+        field {
+            desc = "HPM_BMC_GPIOA4-MGMT_SMBUS_CLK";
+        } a4[9:9] =  1;
+        field {
+            desc = "HPM_BMC_GPIOV7-GPIO_OUTPUT_9";
+        } v7[8:8] =  0;
+        field {
+            desc = "HPM_BMC_GPIOV6-GPIO_OUTPUT_8";
+        } v6[7:7] =  0;
+        field {
+            desc = "HPM_BMC_GPIOV5-GPIO_OUTPUT_7";
+        } v5[6:6] =  0;
+        field {
+            desc = "HPM_BMC_GPIOV3-GPIO_OUTPUT_6";
+        } v3[5:5] =  0;
+        field {
+            desc = "HPM_BMC_GPION7-BMC_READY";
+        } n7[4:4] =  1;
+        field {
+            desc = "HPM_BMC_GPIOL5-??";
+        } l5[3:3] =  1;
+        field {
+            desc = "HPM_BMC_GPIOL4-??";
+        } l4[2:2] =  0;
+        field {
+            desc = "HPM_BMC_GPIOH3-??";
+        } h3[1:1] =  0;
+        field {
+            desc = "HPM_BMC_GPIOH0-MGMT_ASSERT_LOCAL_LOCK";
+        } h0[0:0] =  0;
+
+    } OUT0;
+
+    reg {
+        name = "CH0 Inputs";
+
+        default sw = r;
+
+        field {
+            desc = "HPM_BMC_GPIOG7-BMC_SCM_FPGA_UART_RX";
+        } g7[15:15] =  0;
+        field {
+            desc = "HPM_BMC_GPIOP6-MGMT_SYS_MON_PWR_GOOD";
+        } p6[14:14] =  0;
+        field {
+            desc = "HPM_BMC_GPIOP4-MGMT_SYS_MON_NMI_BTN_L";
+        } p4[13:13] =  0;
+        field {
+            desc = "HPM_BMC_GPIOP2-MGMT_SYS_MON_PWR_BTN_L";
+        } p2[12:12] =  0;
+        field {
+            desc = "HPM_BMC_GPIOP0-MGMT_SYS_MON_RST_BTN_L";
+        } p0[11:11] =  0;
+        field {
+            desc = "HPM_BMC_GPION6-DEBUG_INPUT1";
+        } n6[10:10] =  0;
+        field {
+            desc = "HPM_BMC_GPION5-MGMT_AC_LOSS_L";
+        } n5[9:9] =  0;
+        field {
+            desc = "HPM_BMC_GPION4-MGMT_SYS_MON_ATX_PWR_OK";
+        } n4[8:8] =  0;
+        field {
+            desc = "HPM_BMC_GPION3-MGMT_SYS_MON_P1_THERMTRIP_L";
+        } n3[7:7] =  0;
+        field {
+            desc = "HPM_BMC_GPION2-MGMT_SYS_MON_P0_THERMTRIP_L";
+        } n2[6:6] =  0;
+        field {
+            desc = "HPM_BMC_GPION1-MGMT_SYS_MON_P1_PROCHOT_L";
+        } n1[5:5] =  0;
+        field {
+            desc = "HPM_BMC_GPION0-MGMT_SYS_MON_P0_PROCHOT_L";
+        } n0[4:4] =  0;
+        field {
+            desc = "HPM_BMC_GPIOI6-MGMT_SYS_MON_RESET_L";
+        } i6[3:3] =  0;
+        field {
+            desc = "HPM_BMC_GPIOB7-P1_PRESENT_L";
+        } b7[2:2] =  0;
+        field {
+            desc = "HPM_BMC_GPIOB5-P0_PRESENT_L";
+        } b5[1:1] =  0;
+        field {
+            desc = "HPM_BMC_GPIOB4-MGMT_SYS_MON_POST_COMPLETE";
+        } b4[0:0] =  0;
+
+    } IN0;
+
+    reg {
+        name = "CH1 Outputs";
+        
+        field {
+            desc = "HPM_BMC_GPIOG6-BMC_SCM_FPGA_UART_TX";
+        } g6[14:14] =  1;
+        field {
+            desc = "HPM_BMC_GPIOP5-MGMT_ASSERT_NMI_BTN_L";
+        } p5[13:13] =  1;
+        field {
+            desc = "HPM_BMC_GPIOP3-MGMT_ASSERT_PWR_BTN_L";
+        } p3[12:12] =  1;
+        field {
+            desc = "HPM_BMC_GPIOP1-MGMT_ASSERT_RST_BTN_L";
+        } p1[11:11] =  1;
+        field {
+            desc = "HPM_BMC_GPIOO5-JTAG_TRST_N";
+        } o5[10:10] =  1;
+        field {
+            desc = "HPM_BMC_GPIOO4-GPIO_OUTPUT_5";
+        } o4[9:9] =  0;
+        field {
+            desc = "HPM_BMC_GPIOO3-GPIO_OUTPUT_4";
+        } o3[8:8] =  0;
+        field {
+            desc = "HPM_BMC_GPIOO2-GPIO_OUTPUT_3";
+        } o2[7:7] =  0;
+        field {
+            desc = "HPM_BMC_GPIOO1-GPIO_OUTPUT_2";
+        } o1[6:6] =  0;
+        field {
+            desc = "HHPM_BMC_GPIOO0-GPIO_OUTPUT_1";
+        } o0[5:5] =  0;
+        field {
+            desc = "HPM_BMC_GPIOM2-MGMT_ASSERT_CLR_CMOS";
+        } m2[4:4] =  0;
+        field {
+            desc = "HPM_BMC_GPIOM1-MGMT_ASSERT_P1_PROCHOT";
+        } m1[3:3] =  0;
+        field {
+            desc = "HPM_BMC_GPIOM0-MGMT_ASSERT_P0_PROCHOT";
+        } m0[2:2] =  0;
+        field {
+            desc = "HPM_BMC_GPIOH2-MGMT_SOC_RESET_L";
+        } h2[1:1] =  1;
+        field {
+            desc = "HPM_BMC_GPIOH1-MGMT_ASERT_WARM_RST_BTN_L";
+        } h1[0:0] =  1;
+
+    } OUT1;
+
+    reg {
+        name = "CH1 Inputs";
+
+        default sw = r;
+        
+        field {
+            desc = "MGMT_SMBUS_ALERT_L";
+        } uu1[15:15] =  0;
+        field {
+            desc = "HPM_BMC_GPIOI7-??";
+        } i7[14:14] =  0;
+        field {
+            desc = "ESPI_BOOT_SEL";
+        } espi_sel[13:13] =  0;
+        field {
+            desc = "I2C_BMC_MB_ALERT_s";
+        } uu[12:9] =  0;
+        field {
+            desc = "HPM_BMC_GPIOS7-GPIO_INPUT_6";
+        } s7[8:8] =  0;
+        field {
+            desc = "HPM_BMC_GPIOS6-GPIO_INPUT_5";
+        } s6[7:7] =  0;
+        field {
+            desc = "HPM_BMC_GPIOS5-GPIO_INPUT_4";
+        } s5[6:6] =  0;
+        field {
+            desc = "HPM_BMC_GPIOS4-GPIO_INPUT_3";
+        } s4[5:5] =  0;
+        field {
+            desc = "HPM_BMC_GPIOQ4-GPIO_INPUT_2";
+        } q4[4:4] =  0;
+        field {
+            desc = "HPM_BMC_GPIOQ3-GPIO_INPUT_1";
+        } q3[3:3] =  0;
+        field {
+            desc = "HPM_BMC_GPIOM5-??";
+        } m5[2:2] =  0;
+        field {
+            desc = "HPM_BMC_GPIOM4-??";
+        } m4[1:1] =  0;
+        field {
+            desc = "HPM_BMC_GPIOM3-??";
+        } m3[0:0] =  0;
+
+    } IN1;
+    
+};

--- a/hdl/projects/grapefruit/sgpio/sgpio_regs.vhd
+++ b/hdl/projects/grapefruit/sgpio/sgpio_regs.vhd
@@ -13,7 +13,7 @@ use ieee.numeric_std_unsigned.all;
 use work.axil_common_pkg.all;
 use work.axil8x32_pkg.all;
 
-use work.sgpio_regs_pkg.all;
+use work.gfruit_sgpio_regs_pkg.all;
 
 entity sgpio_regs is 
     port (

--- a/tools/rdl.bzl
+++ b/tools/rdl.bzl
@@ -31,6 +31,20 @@ def _rdl_file_impl(ctx):
     # Add the deps to a TSet for these files
     deps_tset = [x[RDLFileInfo].set for x in ctx.attrs.deps]
 
+    # Let's enforce some naming conventions here
+    # by convention, and for easier human understand of buck files we prefer our
+    # RDL targets to end in _rdl
+    # We're particular about this since we want to enforce certain naming standards b/c
+    # some collateral is consumed programmatically down-stream by say sw generation tools
+    # We could provide a knob to relax this if needed
+    if not ctx.attrs.name.endswith("_rdl"):
+       fail("RDL target named {} should have an ending in '_rdl'".format(ctx.attrs.name))
+    
+    src_base_name = ctx.attrs.name[:-4] # Take off the _rdl
+    expected_src = src_base_name + ".rdl"
+    if not ctx.attrs.src.basename == expected_src:
+        fail("RDL file {} does not have an expected name {}".format(ctx.attrs.src.basename, expected_src))
+
     # Make the deps a child of the tset containing any sources
     top_tset = ctx.actions.tset(RDLTSet, value=ctx.attrs.src, children=deps_tset)
 
@@ -41,6 +55,23 @@ def _rdl_file_impl(ctx):
     )
 
     if ctx.attrs.outputs:
+        # Let's do some sanity checking on the naming of the outputs. Again, we're being particular
+        # about this because humans can specify but we want machines to be able to consume some of these
+        # In general, our convention is <src_base_name>.<file_extension> but we want "_pkg" to be appended
+        # in the vhdl case.
+        for out in ctx.attrs.outputs:
+            # Right now we allow .vhd, .json, and .html in buck
+            if out.endswith(".vhd"):
+                expected_name = src_base_name + "_pkg.vhd"
+            elif out.endswith(".json"):
+                expected_name = src_base_name + ".json"
+            elif out.endswith(".html"):
+                expected_name = src_base_name + ".html"
+            else:
+                fail("Output {} does not have an expected extension".format(out))
+
+            if out != expected_name:
+                fail("Output {} does match expected filename {}. Check for typos and follow our naming convention".format(out, expected_name))
         # Get the rdl python executable since we'll be using it for
         #  for generating our outputs
         rdl_gen_py = ctx.attrs._rdl_gen[RunInfo]

--- a/tools/site_cobble/rdl_pkg/json_dump.py
+++ b/tools/site_cobble/rdl_pkg/json_dump.py
@@ -129,13 +129,16 @@ def convert_addr_map_only(
 
     json_obj = dict()
     if isinstance(obj, AddrmapNode):
+
         json_obj["type"] = "addrmap"
+        json_obj["addr_span_bytes"] = obj.size
     elif isinstance(obj, RegfileNode):
         json_obj["type"] = "regfile"
     else:
         raise RuntimeError
 
     json_obj["inst_name"] = obj.inst_name
+    json_obj["orig_type_name"] = obj.orig_type_name
     json_obj["addr_offset"] = obj.address_offset
 
     json_obj["children"] = []
@@ -157,8 +160,10 @@ def convert_addrmap_or_regfile(
     json_obj = dict()
     if isinstance(obj, AddrmapNode):
         json_obj["type"] = "addrmap"
+        json_obj["addr_span_bytes"] = obj.size
     elif isinstance(obj, RegfileNode):
         json_obj["type"] = "regfile"
+        json_obj["addr_span_bytes"] = obj.size
     else:
         raise RuntimeError
 


### PR DESCRIPTION
Working with @mkeeter we're adding some improvements to the RDL generation and I've made some naming convention enforcement to help facilitate programatic consumption of the generated artifacts.

New Features:
- added "orig_type_name" to top level addrmap json so that the instance name can be linked with the actual hardware generated .json. Remember, we may have multiple copies of the same "hw" with different instance names.
- added "addr_span_bytes" to the top level addrmap json to give a hint to sw tool generation how many registers we have specified. Note that there's a missing feature from SystemRDL spec that would allow reserving undefined register space, so we're stuck telling sizes that are based only on what we've defined. From a hw implementation perspective, it's certainly safe to assume the peripheral owns up to the next power of 2 here, and possibly with a floor of 256byte addresses.

New Enforcement:
- To provide some naming consistency, we're now enforcing that buck2 rdl targets end with "_rdl" so that it's easier to reason about, and then enforce that output file names (which are user-specified) conform to the expected patterns for software consumption. There are more improvements to be made here https://github.com/oxidecomputer/quartz/issues/301 but this is a functional start.

The new enforcement regime required doing some updates to various things as seen in this PR as well.