### PR TITLE
Fix up lsp generation to set 3rd party on osvvm and vunit.

### DIFF
--- a/tools/multitool/multitool_cli.py
+++ b/tools/multitool/multitool_cli.py
@@ -77,7 +77,22 @@ def vunit_files():
     ret = {}
     ret["vunit_lib"] = []
     ret["osvvm"] = []
-    for file in vunit_vhdl.rglob("*.vhd"):
+    excludes = [
+        "tb_com_codec.vhd",
+        "93",
+        "2002",
+        "MemoryPkg_c",
+        "ScoreboardPkg_int_c",
+        "ScoreboardPkg_slv_c",
+        "MemoryPkg_orig",
+        "VendorCovApiPkg_Aldec",
+        "location_pkg-body-2019"
+        
+    ]
+    vunit_vhdl_files = vunit_vhdl.rglob("*.vhd")
+    # filter out exclusions
+    vunit_vhdl_files = [f for f in vunit_vhdl_files if not any(ex in str(f) for ex in excludes)]
+    for file in vunit_vhdl_files:
         if "osvvm" in str(file):
             lib = "osvvm"
         else:
@@ -119,7 +134,9 @@ def vhdl_ls_toml_gen(args):
 
     # Now combine these with the vunit and osvvm files we just found
     vunit["vunit_lib"]["files"].extend(our_vunit_files)
+    vunit["vunit_lib"]["is_third_party"] = True
     osvvm["osvvm"]["files"].extend(our_osvvm_files)
+    osvvm["osvvm"]["is_third_party"] = True
 
     # Update the running structure with these new libraries
     vhdl_lsp_dict["libraries"].update(vunit)
@@ -181,7 +198,7 @@ format_parser.add_argument(
     "--no-fix", 
     action="store_true", 
     default=False,
-    help="Don't fix files, just print erros and warnings to stdout"
+    help="Don't fix files, just print errors and warnings to stdout"
 )
 
 # create the parser for the "lsp-toml" command

--- a/tools/vhdl-ls.bxl
+++ b/tools/vhdl-ls.bxl
@@ -102,7 +102,7 @@ def vhdl_toml_gen(ctx):
     # party since vhdl-ls only supports is_third_party at the library level. For now, we're going
     # to special case xpm if it exits in the worklib and set is_third_party to true
     if files_by_library_name.get("xpm", []):
-        files_by_library_name.update({"xpm": {"is_third_party": True}})
+        files_by_library_name['xpm']['is_third_party'] = True
     # Now load the vhdl from RDL files into worklib
     worklib_files = files_by_library_name.get("worklib", {"files": []}).get("files")
     worklib_files.extend(gen_vhdl)

--- a/tools/vhdl-ls.bxl
+++ b/tools/vhdl-ls.bxl
@@ -83,7 +83,7 @@ def vhdl_toml_gen(ctx):
             #ctx.output.print("No sources found for {}".format(file))
             continue
         lib_name = attrs.library.value()
-        # We allow empty library names, but need to dump them into a defaul
+        # We allow empty library names, but need to dump them into a default
         # library, and it can't be named "work" due to continued confusion
         # around 'work' not being an *actual* library name see
         # https://insights.sigasi.com/tech/work-not-vhdl-library/
@@ -97,6 +97,12 @@ def vhdl_toml_gen(ctx):
         files.extend(srcs)
         files_by_library_name.update({"{}".format(lib_name): {"files": files}})
     
+    # I'd like to find a better way of passing is_third_party in through the tooling, but it's 
+    # complicated by the fact that I'd need to figure out if all the files in a library are third
+    # party since vhdl-ls only supports is_third_party at the library level. For now, we're going
+    # to special case xpm if it exits in the worklib and set is_third_party to true
+    if files_by_library_name.get("xpm", []):
+        files_by_library_name.update({"xpm": {"is_third_party": True}})
     # Now load the vhdl from RDL files into worklib
     worklib_files = files_by_library_name.get("worklib", {"files": []}).get("files")
     worklib_files.extend(gen_vhdl)


### PR DESCRIPTION
Was getting annoyed at the number of errors reported in vscode since we were pulling in too many of the VUnit and OSVVM files and there were conflicts.  This cleans that up a bit and sets the is_third_party on these files to hide lints also.