### PR TITLE
make I2C controller push-pull

### DIFF
--- a/hdl/ip/vhd/i2c/controller/txn_layer/i2c_ctrl_txn_layer.vhd
+++ b/hdl/ip/vhd/i2c/controller/txn_layer/i2c_ctrl_txn_layer.vhd
@@ -139,7 +139,7 @@ begin
 
             -- watch for a new command to arrive then kick off a START
             when IDLE =>
-                if cmd_valid = '1' and ll_ready = '1' then
+                if cmd_valid = '1' and ll_ready = '1' and abort = '0' then
                     v.state     := START;
                     v.cmd       := cmd;
                 end if;

--- a/hdl/ip/vhd/i2c/controller/txn_layer/i2c_ctrl_txn_layer.vhd
+++ b/hdl/ip/vhd/i2c/controller/txn_layer/i2c_ctrl_txn_layer.vhd
@@ -74,19 +74,23 @@ architecture rtl of i2c_ctrl_txn_layer is
         tx_byte         : std_logic_vector(7 downto 0);
         tx_byte_valid   : std_logic;
         next_valid      : std_logic;
+        txd             : std_logic_vector(7 downto 0);
+        txd_valid       : std_logic;
     end record;
 
     constant SM_REG_RESET : sm_reg_t := (
-        IDLE,           -- state
-        CMD_RESET,      -- cmd
-        false,          -- in_random_read
-        (others => '0'),-- bytes_done
-        '0',            -- do_start
-        '0',            -- do_ack
-        '0',            -- do_stop
-        (others => '0'),-- tx_byte
-        '0',            -- tx_byte_valid
-        '0'             -- next_valid
+        state => IDLE,
+        cmd => CMD_RESET,
+        in_random_read => false,
+        bytes_done => (others => '0'),
+        do_start => '0',
+        do_ack => '0',
+        do_stop => '0',
+        tx_byte => (others => '0'),
+        tx_byte_valid => '0',
+        next_valid => '0',
+        txd => (others => '0'),
+        txd_valid => '0'
     );
 
     signal sm_reg, sm_reg_next    : sm_reg_t;
@@ -125,15 +129,13 @@ begin
     reg_sm_next: process(all)
         variable v          : sm_reg_t;
         variable is_read    : std_logic;
-        variable txd        : std_logic_vector(7 downto 0);
-        variable txd_valid  : std_logic;
     begin
         v           := sm_reg;
         is_read     := '1' when sm_reg.cmd.op = READ or sm_reg.in_random_read else '0';
 
         -- single cycle pulses
         v.next_valid    := '0';
-        txd_valid       := '0';
+        v.txd_valid     := '0';
 
         case sm_reg.state is
 
@@ -150,8 +152,8 @@ begin
 
             -- wait for link layer to finish START sequence and load up the address byte
             when WAIT_START =>
-                txd       := sm_reg.cmd.addr & is_read;
-                txd_valid := '1';
+                v.txd       := sm_reg.cmd.addr & is_read;
+                v.txd_valid := '1';
                 if ll_ready then
                     v.next_valid    := '1';
                     v.state         := WAIT_ADDR_ACK;
@@ -170,8 +172,8 @@ begin
                         else
                             v.state     := WAIT_WRITE_ACK;
                             -- load up the register address
-                            txd         := sm_reg.cmd.reg;
-                            txd_valid   := '1';
+                            v.txd       := sm_reg.cmd.reg;
+                            v.txd_valid := '1';
                         end if;
                     else
                         -- TODO: address nack error
@@ -244,9 +246,9 @@ begin
         v.do_start  := '1' when v.state = START else '0';
         v.do_stop   := '1' when v.state = STOP else '0';
 
-        v.tx_byte       := txd when sm_reg.state = WAIT_START or sm_reg.state = WAIT_ADDR_ACK
+        v.tx_byte       := v.txd when sm_reg.state = WAIT_START or sm_reg.state = WAIT_ADDR_ACK
                             else tx_st_if.data;
-        v.tx_byte_valid := txd_valid when sm_reg.state = WAIT_START or sm_reg.state = WAIT_ADDR_ACK
+        v.tx_byte_valid := v.txd_valid when sm_reg.state = WAIT_START or sm_reg.state = WAIT_ADDR_ACK
                             else tx_st_if.valid;
 
         sm_reg_next <= v;

--- a/hdl/ip/vhd/i2c/controller/txn_layer/sims/i2c_ctrl_txn_layer_tb.gtkw
+++ b/hdl/ip/vhd/i2c/controller/txn_layer/sims/i2c_ctrl_txn_layer_tb.gtkw
@@ -1,15 +1,15 @@
 [*]
 [*] GTKWave Analyzer v3.3.104 (w)1999-2020 BSI
-[*] Fri Feb  7 21:04:37 2025
+[*] Wed Mar 12 14:09:08 2025
 [*]
-[dumpfile] "/home/aaron/Oxide/git/quartz/vunit_out/test_output/lib.i2c_ctrl_txn_layer_tb.abort_transaction_5030992a55fd175f5a816e54580c7a725cf50715/nvc/i2c_ctrl_txn_layer_tb.fst"
-[dumpfile_mtime] "Fri Feb  7 16:35:44 2025"
-[dumpfile_size] 5828
+[dumpfile] "/home/aaron/Oxide/git/quartz/vunit_out/test_output/lib.i2c_ctrl_txn_layer_tb.write_and_read_one_byte_344489395475d58724aafb4fc63c500bd501b62f/nvc/i2c_ctrl_txn_layer_tb.fst"
+[dumpfile_mtime] "Wed Mar 12 14:04:36 2025"
+[dumpfile_size] 4352
 [savefile] "/home/aaron/Oxide/git/quartz/hdl/ip/vhd/i2c/controller/txn_layer/sims/i2c_ctrl_txn_layer_tb.gtkw"
 [timestart] 0
-[size] 1344 1283
-[pos] 2559 23
-*-34.710972 86100000000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+[size] 1376 1283
+[pos] 2514 -22
+*-32.845215 8124000000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
 [treeopen] i2c_ctrl_txn_layer_tb.
 [treeopen] i2c_ctrl_txn_layer_tb.th.
 [treeopen] i2c_ctrl_txn_layer_tb.th.dut.
@@ -47,11 +47,13 @@ i2c_ctrl_txn_layer_tb.th.dut.abort
 -SCL
 @28
 i2c_ctrl_txn_layer_tb.th.dut.scl_if.i
+i2c_ctrl_txn_layer_tb.th.dut.scl_if.o
 i2c_ctrl_txn_layer_tb.th.dut.scl_if.oe
 @200
 -SDA
 @28
 i2c_ctrl_txn_layer_tb.th.dut.sda_if.i
+i2c_ctrl_txn_layer_tb.th.dut.sda_if.o
 i2c_ctrl_txn_layer_tb.th.dut.sda_if.oe
 @200
 -State
@@ -106,6 +108,7 @@ i2c_ctrl_txn_layer_tb.th.dut.i2c_ctrl_link_layer_inst.sm_countdown.counter[7:0]
 @28
 i2c_ctrl_txn_layer_tb.th.dut.i2c_ctrl_link_layer_inst.sm_countdown.decr
 i2c_ctrl_txn_layer_tb.th.dut.i2c_ctrl_link_layer_inst.sm_countdown.load
+@29
 i2c_ctrl_txn_layer_tb.th.dut.i2c_ctrl_link_layer_inst.sm_countdown.done
 @200
 -
@@ -127,15 +130,12 @@ i2c_ctrl_txn_layer_tb.th.tx_source_vc.data[7:0]
 -target Model
 -SCL
 @28
-i2c_ctrl_txn_layer_tb.th.target.scl_if.i
-i2c_ctrl_txn_layer_tb.th.target.scl_if.o
-i2c_ctrl_txn_layer_tb.th.target.scl_if.oe
+i2c_ctrl_txn_layer_tb.th.scl
 @200
 -SDA
 @28
-i2c_ctrl_txn_layer_tb.th.target.sda_if.i
-i2c_ctrl_txn_layer_tb.th.target.sda_if.o
-i2c_ctrl_txn_layer_tb.th.target.sda_if.oe
+i2c_ctrl_txn_layer_tb.th.sda
+i2c_ctrl_txn_layer_tb.th.target.sda_oe
 i2c_ctrl_txn_layer_tb.th.target.state
 i2c_ctrl_txn_layer_tb.th.target.start_condition
 i2c_ctrl_txn_layer_tb.th.target.stop_condition

--- a/hdl/ip/vhd/i2c/controller/txn_layer/sims/i2c_ctrl_txn_layer_th.vhd
+++ b/hdl/ip/vhd/i2c/controller/txn_layer/sims/i2c_ctrl_txn_layer_th.vhd
@@ -122,9 +122,10 @@ begin
             data    => rx_data_stream.data
         );
 
-    -- wire the bus to the controller's tristate ports
-    scl <= ctrl_scl_tristate.o when ctrl_scl_tristate.oe else 'H';
-    sda <= ctrl_sda_tristate.o when ctrl_sda_tristate.oe else 'H';
+    -- wire the bus to the controller's tristate ports, the controller is push-pull so we make it
+    -- open-drain here
+    scl <= '0' when (ctrl_scl_tristate.oe = '1' and ctrl_scl_tristate.o = '0') else 'H';
+    sda <= '0' when (ctrl_sda_tristate.oe = '1' and ctrl_sda_tristate.o = '0') else 'H';
     ctrl_scl_tristate.i     <= scl;
     ctrl_sda_tristate.i     <= sda;
 


### PR DESCRIPTION
As discussed, the controller logic will now operate as a push-pull driver. This gives flexibility since if that is desired it will be the default, and adapting a push-pull driver to be open-drain is simple when accompanying tristate logic is still present.

This change also changes the target VC to utilize the `*_int` signals for rising/falling edge triggers since those are adapted to '0' or '1' from the std_logic inout pins.