### PR TITLE
fix I2C controller VC to drive SCL low during ACK transmit

### DIFF
--- a/hdl/ip/vhd/vunit_components/i2c_controller/i2c_ctrlr_vc.vhd
+++ b/hdl/ip/vhd/vunit_components/i2c_controller/i2c_ctrlr_vc.vhd
@@ -185,6 +185,7 @@ begin
                 scl <= 'Z';
                 wait until falling_edge(aligner_int);
                 sda <= 'Z';
+                scl <= '0';
             end procedure;
             procedure send_nack is
             begin


### PR DESCRIPTION
Without this we will miss a rising edge whenever the controller has to ACK (e.g., during a read from a target).