### PR TITLE
Refactor axi lite transactions blocks into a common entity

### DIFF
--- a/hdl/ip/vhd/axi_blocks/BUCK
+++ b/hdl/ip/vhd/axi_blocks/BUCK
@@ -8,15 +8,40 @@ vhdl_unit(
 )
 
 vhdl_unit(
-    name = "axilite_if_2k8_pkg",
+    name = "axil_target_txn",
+    srcs = glob(["axil_target_txn.vhd"]),
+    deps = [
+        ":axilite_common_pkg",
+    ],
+    standard = "2008"
+)
+
+vhdl_unit(
+    name = "axilite_if_2k8",
     srcs = glob(["axilite*2k8_pkg.vhd"]),
+    # This stuff isn't *strictly* a dependency, but this provides
+    # a convenient way for downstream blocks to pull in one
+    # dep and get all the things they need for implementing an
+    # AXI-Lite interface.
+    deps = [
+        ":axil_target_txn",
+        ":axilite_common_pkg"
+    ],
     standard = "2008",
     visibility = ['PUBLIC'],
 )
 
 vhdl_unit(
-    name = "axilite_if_2k19_pkg",
+    name = "axilite_if_2k19",
     srcs = glob(["axilite*2k19_pkg.vhd"]),
+     # This stuff isn't *strictly* a dependency, but this provides
+    # a convenient way for downstream blocks to pull in one
+    # dep and get all the things they need for implementing an
+    # AXI-Lite interface.
+    deps = [
+        ":axil_target_txn",
+        ":axilite_common_pkg"
+    ],
     standard = "2019",
     visibility = ['PUBLIC'],
 )
@@ -25,8 +50,7 @@ vhdl_unit(
     name = "axil_interconnect",
     srcs = glob(["axil_interconnect.vhd"]),
     deps = [
-        ":axilite_common_pkg",
-        ":axilite_if_2k19_pkg",
+        ":axilite_if_2k19",
         ":axil_interconnect_2k8",
     ],
     standard = "2019",
@@ -37,8 +61,7 @@ vhdl_unit(
     name = "axil_interconnect_2k8",
     srcs = glob(["axil_interconnect_2k8.vhd"]),
     deps = [
-        ":axilite_common_pkg",
-        ":axilite_if_2k8_pkg",
+        ":axilite_if_2k8",
     ],
     standard = "2008",
     visibility = ['PUBLIC'],

--- a/hdl/ip/vhd/axi_blocks/axil_target_txn.vhd
+++ b/hdl/ip/vhd/axi_blocks/axil_target_txn.vhd
@@ -1,0 +1,82 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+-- Copyright 2025 Oxide Computer Company 
+ 
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+use work.axil_common_pkg.all;
+
+entity axil_target_txn is
+    port (
+        clk : in std_logic;
+        reset : in std_logic;
+
+        -- axi transaction signals
+        arvalid : in std_logic;
+        arready : out std_logic;
+        awvalid : in std_logic;
+        awready : out std_logic;
+        wready : out std_logic;
+        wvalid : in std_logic;
+        bvalid : out std_logic;
+        bready : in std_logic;
+        bresp : out std_logic_vector(1 downto 0);
+        rvalid : out std_logic;
+        rready : in std_logic;
+        rresp : out std_logic_vector(1 downto 0);
+        -- Helper signals
+        active_read : out std_logic;
+        active_write : out std_logic
+    );
+end entity;
+architecture rtl of axil_target_txn is
+
+begin
+
+    bresp  <= OKAY;
+    rresp  <= OKAY;
+
+    wready  <= awready;
+    arready <= not rvalid;
+
+    active_read <=  arvalid and arready;
+    active_write <= awready;
+
+
+    -- axi transaction mgmt
+    -- Common block for axi transaction management
+    axi_txn: process(clk, reset)
+    begin
+        if reset then
+            awready <= '0';
+            bvalid <= '0';
+            rvalid <= '0';
+        elsif rising_edge(clk) then
+            -- bvalid set on every write,
+            -- cleared after bvalid && bready
+            if awready then
+                bvalid <= '1';
+            elsif bready then
+                bvalid <= '0';
+            end if;
+    
+            if active_read then
+                rvalid <= '1';
+            elsif rready then
+                rvalid <= '0';
+            end if;
+    
+            -- can accept a new write if we're not
+            -- responding to write already or
+            -- the write is not in progress
+            awready <= not awready and
+                       (awvalid and wvalid) and
+                       (not bvalid or bready);
+        end if;
+    end process;
+
+end rtl;

--- a/hdl/ip/vhd/espi/BUCK
+++ b/hdl/ip/vhd/espi/BUCK
@@ -43,7 +43,7 @@ vhdl_unit(
         "//hdl/ip/vhd/crc:crc8atm_8wide",
         "//hdl/ip/vhd/fifos:dcfifo_xpm",
         "//hdl/ip/vhd/fifos:dcfifo_mixed_xpm",
-        "//hdl/ip/vhd/axi_blocks:axilite_if_2k19_pkg",
+        "//hdl/ip/vhd/axi_blocks:axilite_if_2k19",
         "//hdl/ip/vhd/memories:dual_clock_simple_dpr",
         "//hdl/ip/vhd/uart:axi_fifo_uart",
         ],

--- a/hdl/ip/vhd/espi/sys_regs/espi_regs.vhd
+++ b/hdl/ip/vhd/espi/sys_regs/espi_regs.vhd
@@ -30,20 +30,14 @@ end entity;
 
 architecture rtl of espi_regs is
 
-    constant OKAY               : std_logic_vector(1 downto 0) := "00";
-    signal   axi_int_read_ready : std_logic;
-    signal   awready            : std_logic;
-    signal   wready             : std_logic;
-    signal   bvalid             : std_logic;
-    signal   bready             : std_logic;
-    signal   arready            : std_logic;
-    signal   rvalid             : std_logic;
     signal   rdata              : std_logic_vector(31 downto 0);
     signal   control_reg        : control_type;
     signal   status_reg         : status_type;
     signal   fifo_status_reg    : fifo_status_type;
     signal   flags_reg          : flags_type;
     signal   resp_fifo_ack      : std_logic;
+    signal active_read        : std_logic;
+    signal active_write       : std_logic;
 
 begin
     fifo_status_reg.cmd_used_wds <= dbg_chan.wstatus.usedwds;
@@ -52,55 +46,27 @@ begin
     flags_reg.alert <= dbg_chan.alert_pending;
     msg_en <= control_reg.msg_en;
 
-    -- unpack the record
-    axi_if.write_response.resp  <= OKAY;
-    axi_if.write_response.valid <= bvalid;
-    axi_if.read_data.resp       <= OKAY;
-    axi_if.write_data.ready     <= wready;
-    axi_if.write_address.ready  <= awready;
-    axi_if.read_address.ready   <= arready;
-    axi_if.read_data.data       <= rdata;
-    axi_if.read_data.valid      <= rvalid;
-    bready                      <= axi_if.write_response.ready;
+    axi_if.read_data.data <= rdata;
 
-    wready  <= awready;
-    arready <= not rvalid;
-
-    axi_int_read_ready <= axi_if.read_address.valid and arready;
-
-    -- axi transaction mgmt
-    axi_txn: process(clk, reset)
-    begin
-        if reset then
-            awready <= '0';
-            bvalid <= '0';
-            rvalid <= '0';
-        elsif rising_edge(clk) then
-            -- bvalid set on every write,
-            -- The tranfer occurs when bvalid && bready
-            -- but we can simplify the clearing logic to only
-            -- look at bready since we don't care if we set bvalid to 0
-            -- if it was already a 0
-            if awready then
-                bvalid <= '1';
-            elsif bready then
-                bvalid <= '0';
-            end if;
-
-            if axi_int_read_ready then
-                rvalid <= '1';
-            elsif axi_if.read_data.ready then
-                rvalid <= '0';
-            end if;
-
-            -- can accept a new write if we're not
-            -- responding to write already or
-            -- the write is not in progress
-            awready <= not awready and
-                       (axi_if.write_address.valid and axi_if.write_data.valid) and
-                       (not bvalid or bready);
-        end if;
-    end process;
+    axil_target_txn_inst: entity work.axil_target_txn
+     port map(
+        clk => clk,
+        reset => reset,
+        arvalid => axi_if.read_address.valid,
+        arready => axi_if.read_address.ready,
+        awvalid => axi_if.write_address.valid,
+        awready => axi_if.write_address.ready,
+        wvalid => axi_if.write_data.valid,
+        wready => axi_if.write_data.ready,
+        bvalid => axi_if.write_response.valid,
+        bready => axi_if.write_response.ready,
+        bresp => axi_if.write_response.resp,
+        rvalid => axi_if.read_data.valid,
+        rready => axi_if.read_data.ready,
+        rresp => axi_if.read_data.resp,
+        active_read => active_read,
+        active_write => active_write
+    );
 
     write_logic: process(clk, reset)
     begin
@@ -110,7 +76,7 @@ begin
             control_reg.cmd_fifo_reset <= '0';  -- self clearing
             control_reg.cmd_size_fifo_reset <= '0';  -- self clearing
             control_reg.resp_fifo_reset <= '0';  -- self clearing
-            if wready then
+            if  axi_if.write_address.ready then
                 case to_integer(axi_if.write_address.addr) is
                     when CONTROL_OFFSET => control_reg <= unpack(axi_if.write_data.data);
                     when others => null;
@@ -120,11 +86,11 @@ begin
     end process;
 
     dbg_chan.wr.data <= axi_if.write_data.data;
-    dbg_chan.wr.write <= '1' when wready = '1' and to_integer(axi_if.write_address.addr) = CMD_FIFO_WDATA_OFFSET else '0';
+    dbg_chan.wr.write <= '1' when axi_if.write_address.ready = '1' and to_integer(axi_if.write_address.addr) = CMD_FIFO_WDATA_OFFSET else '0';
     dbg_chan.size.data <= axi_if.write_data.data;
-    dbg_chan.size.write <= '1' when wready = '1' and to_integer(axi_if.write_address.addr) = CMD_SIZE_FIFO_WDATA_OFFSET else '0';
+    dbg_chan.size.write <= '1' when axi_if.write_address.ready = '1' and to_integer(axi_if.write_address.addr) = CMD_SIZE_FIFO_WDATA_OFFSET else '0';
 
-    dbg_chan.rd.rdack <= '1' when axi_if.read_data.ready = '1' and rvalid = '1' and resp_fifo_ack = '1' else '0';
+    dbg_chan.rd.rdack <= '1' when axi_if.read_data.ready = '1' and axi_if.read_data.valid = '1' and resp_fifo_ack = '1' else '0';
 
     read_logic: process(clk, reset)
     begin
@@ -132,7 +98,7 @@ begin
             rdata <= (others => '0');
         elsif rising_edge(clk) then
             resp_fifo_ack <= '0';
-            if axi_int_read_ready then
+            if active_read then
                 case to_integer(axi_if.read_address.addr) is
                     when FLAGS_OFFSET => rdata <= pack(flags_reg);
                     when CONTROL_OFFSET => rdata <= pack(control_reg);

--- a/hdl/ip/vhd/fmc_if/BUCK
+++ b/hdl/ip/vhd/fmc_if/BUCK
@@ -12,7 +12,7 @@ vhdl_unit(
     srcs = glob(["stm32h7*.vhd"]),
     deps = [
         "//hdl/ip/vhd/fifos:dcfifo_xpm",
-        "//hdl/ip/vhd/axi_blocks:axilite_if_2k19_pkg"
+        "//hdl/ip/vhd/axi_blocks:axilite_if_2k19"
         ],
     standard = "2019",
     visibility = ["PUBLIC"],

--- a/hdl/ip/vhd/info/BUCK
+++ b/hdl/ip/vhd/info/BUCK
@@ -34,6 +34,7 @@ vhdl_unit(
     deps = [
         ":git_sha_pkg",
         ":info_regs_rdl",
+        "//hdl/ip/vhd/axi_blocks:axilite_if_2k8",
         ],
     standard = "2008",
     visibility = ['PUBLIC']
@@ -46,7 +47,7 @@ vhdl_unit(
     srcs = ["info.vhd"],
     deps = [
         ":info_2k8",
-        "//hdl/ip/vhd/axi_blocks:axilite_if_2k19_pkg",
+        "//hdl/ip/vhd/axi_blocks:axilite_if_2k19",
         ],
     standard = "2019",
     visibility = ['PUBLIC']

--- a/hdl/ip/vhd/info/info_2k8.vhd
+++ b/hdl/ip/vhd/info/info_2k8.vhd
@@ -53,8 +53,6 @@ entity info_2k8 is
 end entity;
 
 architecture rtl of info_2k8 is
-    constant OKAY               : std_logic_vector(1 downto 0) := "00";
-    signal   axi_int_read_ready : std_logic;
 
     constant identity : identity_type := rec_reset;
     constant version : version_type := rec_reset;
@@ -62,46 +60,32 @@ architecture rtl of info_2k8 is
     signal checksum : fpga_checksum_type := rec_reset;
     signal scratchpad : scratchpad_type := rec_reset;
     signal hubris_compat: hubris_compat_type := rec_reset;
+    signal active_read: std_logic;
+    signal active_write: std_logic;
 
 begin
-    bresp  <= OKAY;
-    rresp      <= OKAY;
 
-    wready  <= awready;
-    arready <= not rvalid;
+    axil_target_txn_inst: entity work.axil_target_txn
+    port map(
+       clk => clk,
+       reset => reset,
+       arvalid => arvalid,
+       arready => arready,
+       awvalid => awvalid,
+       awready =>awready,
+       wvalid => wvalid,
+       wready => wready,
+       bvalid => bvalid,
+       bready => bready,
+       bresp => bresp,
+       rvalid => rvalid,
+       rready => rready,
+       rresp =>rresp,
+       active_read => active_read,
+       active_write => active_write
+   );
 
-    axi_int_read_ready <= arvalid and arready;
 
-    -- axi transaction mgmt
-    axi_txn: process(clk, reset)
-    begin
-        if reset then
-            awready <= '0';
-            bvalid <= '0';
-            rvalid <= '0';
-        elsif rising_edge(clk) then
-            -- bvalid set on every write,
-            -- cleared after bvalid && bready
-            if awready then
-                bvalid <= '1';
-            elsif bready then
-                bvalid <= '0';
-            end if;
-
-            if axi_int_read_ready then
-                rvalid <= '1';
-            elsif rready then
-                rvalid <= '0';
-            end if;
-
-            -- can accept a new write if we're not
-            -- responding to write already or
-            -- the write is not in progress
-            awready <= not awready and
-                       (awvalid and wvalid) and
-                       (not bvalid or bready);
-        end if;
-    end process;
 
     write_logic: process(clk, reset)
     begin
@@ -113,7 +97,7 @@ begin
             -- changing.  Since we're not using this in decision logic, this should
             -- suffice for synchronization.
             hubris_compat <= unpack(resize(hubris_compat_pins, 32));
-            if wready then
+            if active_write then
                 case to_integer(awaddr) is
                     when FPGA_CHECKSUM_OFFSET => checksum <= write_byte_enable(checksum, wdata, wstrb);
                     when SCRATCHPAD_OFFSET => scratchpad <= write_byte_enable(scratchpad, wdata, wstrb);
@@ -128,7 +112,7 @@ begin
         if reset then
             rdata <= (others => '0');
         elsif rising_edge(clk) then
-            if axi_int_read_ready then
+            if active_read then
                 case to_integer(araddr) is
                     when IDENTITY_OFFSET => rdata <= pack(identity);
                     when HUBRIS_COMPAT_OFFSET => rdata <= pack(hubris_compat);

--- a/hdl/ip/vhd/spi_nor_controller/BUCK
+++ b/hdl/ip/vhd/spi_nor_controller/BUCK
@@ -25,7 +25,7 @@ vhdl_unit(
     deps = [
         ":spi_nor_regs_rdl",
         "//hdl/ip/vhd/fifos:dcfifo_xpm",
-        "//hdl/ip/vhd/axi_blocks:axilite_if_2k19_pkg",
+        "//hdl/ip/vhd/axi_blocks:axilite_if_2k19",
         ],
     visibility = ["PUBLIC"],
 )

--- a/hdl/projects/cosmo_seq/sequencer/sequencer_regs.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sequencer_regs.vhd
@@ -66,13 +66,10 @@ architecture rtl of sequencer_regs is
 
     signal rails_pg_max : rails_type;
    
-    signal axi_int_read_ready : std_logic;
-    signal awready : std_logic;
-    signal bvalid : std_logic;
-    alias bready is axi_if.write_response.ready;
-    signal arready : std_logic;
-    signal rvalid : std_logic;
+
     signal rdata : std_logic_vector(31 downto 0);
+    signal active_read : std_logic;
+    signal active_write : std_logic;
 
 begin
 
@@ -140,59 +137,30 @@ begin
     a0_en_redge <= power_ctrl.a0_en and (not a0_en_last);
     amd_reset_l_fedge <= not sp5_readbacks.reset_l and amd_reset_l_last;
     amd_pwrok_fedge <= not sp5_readbacks.pwr_ok and amd_pwrok_last;
-    
-    -- Assign outputs to the record here
-    -- write_address channel
-    axi_if.write_address.ready <= awready;
-    -- write_data channel
-    axi_if.write_data.ready <= awready;
 
-    -- write_response channel
-    axi_if.write_response.resp <= OKAY;
-    axi_if.write_response.valid <= bvalid;
-
-    -- read_address channel
-    axi_if.read_address.ready <= arready;
-    -- read_data channel
-    axi_if.read_data.resp <= OKAY;
+    axil_target_txn_inst: entity work.axil_target_txn
+     port map(
+        clk => clk,
+        reset => reset,
+        arvalid => axi_if.read_address.valid,
+        arready => axi_if.read_address.ready,
+        awvalid => axi_if.write_address.valid,
+        awready => axi_if.write_address.ready,
+        wvalid => axi_if.write_data.valid,
+        wready => axi_if.write_data.ready,
+        bvalid => axi_if.write_response.valid,
+        bready => axi_if.write_response.ready,
+        bresp => axi_if.write_response.resp,
+        rvalid => axi_if.read_data.valid,
+        rready => axi_if.read_data.ready,
+        rresp => axi_if.read_data.resp,
+        active_read => active_read,
+        active_write => active_write
+    );
     axi_if.read_data.data <= rdata;
-    axi_if.read_data.valid <= rvalid;
-
-    arready <= not rvalid;
+    
 
 
-    axi_int_read_ready <=  axi_if.read_address.valid and arready;
-
-    -- axi transaction mgmt
-    axi_txn: process(clk, reset)
-    begin
-        if reset then
-            awready <= '0';
-            bvalid <= '0';
-            rvalid <= '0';
-        elsif rising_edge(clk) then
-            -- bvalid set on every write,
-            -- cleared after bvalid && bready
-            if awready then
-                bvalid <= '1';
-            elsif bready then
-                bvalid <= '0';
-            end if;
-
-            if axi_int_read_ready then
-                rvalid <= '1';
-            elsif axi_if.read_data.ready then
-                rvalid <= '0';
-            end if;
-
-            -- can accept a new write if we're not
-            -- responding to write already or
-            -- the write is not in progress
-            awready <= not awready and
-                       (axi_if.write_address.valid and axi_if.write_data.valid) and
-                       (not bvalid or bready);
-        end if;
-    end process;
 
     write_logic: process(clk, reset)
     begin
@@ -205,7 +173,7 @@ begin
             nic_overrides <= rec_reset;
 
         elsif rising_edge(clk) then
-            if axi_if.write_data.ready then
+            if active_write then
                 case to_integer(axi_if.write_address.addr) is
                     when IFR_OFFSET => ifr <= ifr and (not axi_if.write_data.data);
                     when IER_OFFSET => ier <= unpack(axi_if.write_data.data);
@@ -228,7 +196,7 @@ begin
         if reset then
             rdata <= (others => '0');
         elsif rising_edge(clk) then
-            if axi_int_read_ready then
+            if active_read then
                 case to_integer(axi_if.read_address.addr) is
                     when IFR_OFFSET => rdata <= pack(ifr);
                     when IER_OFFSET => rdata <= pack(ier);

--- a/hdl/projects/cosmo_seq/sp_i2c_subsystem/BUCK
+++ b/hdl/projects/cosmo_seq/sp_i2c_subsystem/BUCK
@@ -7,7 +7,6 @@ vhdl_unit(
     ],
     deps = [
         "//hdl/ip/vhd/axi_blocks:axist_if_2k19_pkg",
-        "//hdl/ip/vhd/axi_blocks:axil_interconnect",
         "//hdl/ip/vhd/i2c/muxes/PCA9545ish:pca9545ish_top",
         "//hdl/ip/vhd/i2c/target:i2c_phy_consolidator",
     ],

--- a/hdl/projects/cosmo_seq/sp_i2c_subsystem/sp_i2c_subsystem.vhd
+++ b/hdl/projects/cosmo_seq/sp_i2c_subsystem/sp_i2c_subsystem.vhd
@@ -10,6 +10,7 @@ library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
+use work.axil8x32_pkg;
 use work.pca9545_pkg.all;
 
 entity sp_i2c_subsystem is

--- a/hdl/projects/cosmo_seq/sp_i2c_subsystem/sp_i2c_subsystem_regs.vhd
+++ b/hdl/projects/cosmo_seq/sp_i2c_subsystem/sp_i2c_subsystem_regs.vhd
@@ -1,0 +1,24 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+-- Copyright 2025 Oxide Computer Company
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+
+entity sp_i2c_subsystem_regs is
+    port(
+        clk : in std_logic;
+        reset : in std_logic;
+
+        axi_if : view axil8x32_pkg.axil_target
+    );
+end entity;
+architecture rtl of sp_i2c_subsystem_regs is
+
+begin
+
+end rtl;

--- a/hdl/projects/grapefruit/BUCK
+++ b/hdl/projects/grapefruit/BUCK
@@ -47,7 +47,7 @@ vhdl_unit (
     srcs = glob(["base_regs/*.vhd"]),
     deps = [
         ":gfruit_regs_rdl",
-        "//hdl/ip/vhd/axi_blocks:axilite_if_2k19_pkg",
+        "//hdl/ip/vhd/axi_blocks:axilite_if_2k19",
         ],
     standard = "2019",
 )
@@ -57,7 +57,7 @@ vhdl_unit (
     srcs = glob(["sgpio/*.vhd"]),
     deps = [
         ":gfruit_sgpio_regs_rdl",
-        "//hdl/ip/vhd/axi_blocks:axilite_if_2k19_pkg",
+        "//hdl/ip/vhd/axi_blocks:axilite_if_2k19",
         "//hdl/ip/vhd/sgpio:sgpio_top",
         ],
     standard = "2019",

--- a/hdl/projects/grapefruit/base_regs/registers.vhd
+++ b/hdl/projects/grapefruit/base_regs/registers.vhd
@@ -33,68 +33,32 @@ architecture rtl of registers is
     signal checksum : cs_type;
     signal scratchpad : scratchpad_type;
     signal passthu : passthru_type;
-    signal axi_int_read_ready : std_logic;
-    signal awready : std_logic;
-    signal bvalid : std_logic;
-    alias bready is axi_if.write_response.ready;
-    signal arready : std_logic;
-    signal rvalid : std_logic;
+    signal active_read : std_logic;
+    signal active_write : std_logic;
     signal rdata : std_logic_vector(31 downto 0);
 
 begin
 
-    -- Assign outputs to the record here
-    -- write_address channel
-    axi_if.write_address.ready <= awready;
-    -- write_data channel
-    axi_if.write_data.ready <= awready;
-
-    -- write_response channel
-    axi_if.write_response.resp <= OKAY;
-    axi_if.write_response.valid <= bvalid;
-
-    -- read_address channel
-    axi_if.read_address.ready <= arready;
-    -- read_data channel
-    axi_if.read_data.resp <= OKAY;
+    axil_target_txn_inst: entity work.axil_target_txn
+     port map(
+        clk => clk,
+        reset => reset,
+        arvalid => axi_if.read_address.valid,
+        arready => axi_if.read_address.ready,
+        awvalid => axi_if.write_address.valid,
+        awready => axi_if.write_address.ready,
+        wvalid => axi_if.write_data.valid,
+        wready => axi_if.write_data.ready,
+        bvalid => axi_if.write_response.valid,
+        bready => axi_if.write_response.ready,
+        bresp => axi_if.write_response.resp,
+        rvalid => axi_if.read_data.valid,
+        rready => axi_if.read_data.ready,
+        rresp => axi_if.read_data.resp,
+        active_read => active_read,
+        active_write => active_write
+    );
     axi_if.read_data.data <= rdata;
-    axi_if.read_data.valid <= rvalid;
-
-    arready <= not rvalid;
-
-
-    axi_int_read_ready <=  axi_if.read_address.valid and arready;
-
-    -- axi transaction mgmt
-    axi_txn: process(clk, reset)
-    begin
-        if reset then
-            awready <= '0';
-            bvalid <= '0';
-            rvalid <= '0';
-        elsif rising_edge(clk) then
-            -- bvalid set on every write,
-            -- cleared after bvalid && bready
-            if awready then
-                bvalid <= '1';
-            elsif bready then
-                bvalid <= '0';
-            end if;
-
-            if axi_int_read_ready then
-                rvalid <= '1';
-            elsif axi_if.read_data.ready then
-                rvalid <= '0';
-            end if;
-
-            -- can accept a new write if we're not
-            -- responding to write already or
-            -- the write is not in progress
-            awready <= not awready and
-                       (axi_if.write_address.valid and axi_if.write_data.valid) and
-                       (not bvalid or bready);
-        end if;
-    end process;
 
     write_logic: process(clk, reset)
     begin
@@ -102,7 +66,7 @@ begin
             checksum <= rec_reset;
             scratchpad <= rec_reset;
         elsif rising_edge(clk) then
-            if axi_if.write_data.ready then
+            if active_write then
                 case to_integer(axi_if.write_address.addr) is
                     when ID_OFFSET => null;  -- ID is read-only
                     when SHA_OFFSET => null;  -- SHA is read-only
@@ -122,7 +86,7 @@ begin
         if reset then
             rdata <= (others => '0');
         elsif rising_edge(clk) then
-            if axi_int_read_ready then
+            if active_read then
                 case to_integer(axi_if.read_address.addr) is
                     when ID_OFFSET => rdata <= pack(id);
                     when SHA_OFFSET => rdata <= pack(sha);

--- a/hdl/projects/grapefruit/sgpio/sgpio_regs.vhd
+++ b/hdl/projects/grapefruit/sgpio/sgpio_regs.vhd
@@ -31,70 +31,32 @@ entity sgpio_regs is
 end entity;
 
 architecture rtl of sgpio_regs is
-
-    signal axi_int_read_ready : std_logic;
-    signal awready : std_logic;
-    signal wready : std_logic;
-    signal bvalid : std_logic;
-    alias bready is axi_if.write_response.ready;
-    signal arready : std_logic;
-    signal rvalid : std_logic;
     signal rdata : std_logic_vector(31 downto 0);
+    signal active_read : std_logic;
+    signal active_write : std_logic;
 
 begin
 
-    -- Assign outputs to the record here
-    -- write_address channel
-    axi_if.write_address.ready <= awready;
-    -- write_data channel
-    axi_if.write_data.ready <= awready;
-
-    -- write_response channel
-    axi_if.write_response.resp <= OKAY;
-    axi_if.write_response.valid <= bvalid;
-
-    -- read_address channel
-    axi_if.read_address.ready <= arready;
-    -- read_data channel
-    axi_if.read_data.resp <= OKAY;
+    axil_target_txn_inst: entity work.axil_target_txn
+    port map(
+       clk => clk,
+       reset => reset,
+       arvalid => axi_if.read_address.valid,
+       arready => axi_if.read_address.ready,
+       awvalid => axi_if.write_address.valid,
+       awready => axi_if.write_address.ready,
+       wvalid => axi_if.write_data.valid,
+       wready => axi_if.write_data.ready,
+       bvalid => axi_if.write_response.valid,
+       bready => axi_if.write_response.ready,
+       bresp => axi_if.write_response.resp,
+       rvalid => axi_if.read_data.valid,
+       rready => axi_if.read_data.ready,
+       rresp => axi_if.read_data.resp,
+       active_read => active_read,
+       active_write => active_write
+   );
     axi_if.read_data.data <= rdata;
-    axi_if.read_data.valid <= rvalid;
-
-    arready <= not rvalid;
-
-
-    axi_int_read_ready <=  axi_if.read_address.valid and arready;
-
-    -- axi transaction mgmt
-    axi_txn: process(clk, reset)
-    begin
-        if reset then
-            awready <= '0';
-            bvalid <= '0';
-            rvalid <= '0';
-        elsif rising_edge(clk) then
-            -- bvalid set on every write,
-            -- cleared after bvalid && bready
-            if awready then
-                bvalid <= '1';
-            elsif bready then
-                bvalid <= '0';
-            end if;
-
-            if axi_int_read_ready then
-                rvalid <= '1';
-            elsif axi_if.read_data.ready then
-                rvalid <= '0';
-            end if;
-
-            -- can accept a new write if we're not
-            -- responding to write already or
-            -- the write is not in progress
-            awready <= not awready and
-                       (axi_if.write_address.valid and axi_if.write_data.valid) and
-                       (not bvalid or bready);
-        end if;
-    end process;
 
     write_logic: process(clk, reset)
     begin
@@ -102,7 +64,7 @@ begin
             out0 <= rec_reset;
             out1 <= rec_reset;
         elsif rising_edge(clk) then
-            if axi_if.write_data.ready then
+            if active_write then
                 case to_integer(axi_if.write_address.addr) is
                     when OUT0_OFFSET => out0 <= unpack(axi_if.write_data.data);
                     when OUT1_OFFSET => out1 <= unpack(axi_if.write_data.data);
@@ -119,7 +81,7 @@ begin
         if reset then
             rdata <= (others => '0');
         elsif rising_edge(clk) then
-            if axi_int_read_ready then
+            if active_read then
                 case to_integer(axi_if.read_address.addr) is
                     when OUT0_OFFSET => rdata <= pack(out0);
                     when OUT1_OFFSET => rdata <= pack(out1);


### PR DESCRIPTION
This allows us to share the logic that was currently duplicated in every axi target block.  We were startign to have too much copied code in every axi target block and any future fixing or maintenance was going to get out of hand quickly.

Additionally I slightly re-structured the BUCK files so that rather than importing a package, we import more stuff when bringing in axi-lite stuff so the downstream blocks have fewer common axi-lite parts to manage.