### PR TITLE
make SDA aribtration logic its own module

### DIFF
--- a/hdl/projects/cosmo_seq/spd_proxy/BUCK
+++ b/hdl/projects/cosmo_seq/spd_proxy/BUCK
@@ -1,16 +1,33 @@
 load("//tools:hdl.bzl", "vhdl_unit", "vunit_sim")
 
 vhdl_unit(
+    name = "sda_arbiter",
+    srcs = glob(["sda_arbiter/*.vhd"]),
+    deps = [],
+    visibility = ['PUBLIC'],
+)
+
+vhdl_unit(
     name = "spd_proxy_top",
     srcs = glob(["*.vhd"]),
     deps = [
+        ":sda_arbiter",
         "//hdl/ip/vhd/common:tristate_if_pkg",
         "//hdl/ip/vhd/i2c/common:i2c_common_pkg",
         "//hdl/ip/vhd/i2c/common:i2c_glitch_filter",
         "//hdl/ip/vhd/i2c/controller:i2c_ctrl_txn_layer",
     ],
     standard = "2019",
-    visibility = ['PUBLIC']
+    visibility = ['PUBLIC'],
+)
+
+vunit_sim(
+    name = "sda_arbiter_tb",
+    srcs = glob(["sda_arbiter/sims/*.vhd"]),
+    deps = [
+        ":sda_arbiter",
+    ],
+    visibility = ['PUBLIC'],
 )
 
 vunit_sim(

--- a/hdl/projects/cosmo_seq/spd_proxy/sda_arbiter/sda_arbiter.vhd
+++ b/hdl/projects/cosmo_seq/spd_proxy/sda_arbiter/sda_arbiter.vhd
@@ -1,0 +1,89 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+-- Copyright 2025 Oxide Computer Company
+--
+-- This block monitors two I2C SDA signals, `a` and `b`, with the intention thatt hey are
+-- essentially connected but proxied by the FPGA. It assumes the inactive state for the bus is high,
+-- and then monitors for `a` or `b` to pull the line low. It will then grant whichever side pulled
+-- the line low the bus until that side releases it, at which point after HYSTERESIS_CYCLES both
+-- sides will be resambled again.
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity sda_arbiter is
+    generic (
+        HYSTERESIS_CYCLES : integer
+    );
+    port (
+        clk     : in std_logic;
+        reset   : in std_logic;
+
+        a       : in std_logic;
+        b       : in std_logic;
+        enabled : in std_logic;
+        a_grant : out std_logic;
+        b_grant : out std_logic
+    );
+end entity;
+
+architecture rtl of sda_arbiter is
+    type sda_control_t is (
+        NONE,
+        GRANT_A,
+        GRANT_B
+    );
+    signal sda_state : sda_control_t;
+    signal hysteresis_cntr : natural;
+begin
+
+    a_grant <= '1' when sda_state = GRANT_A else '0';
+    b_grant <= '1' when sda_state = GRANT_B else '0';
+
+    arbitration : process(clk, reset)
+        variable sda_next : sda_control_t;
+    begin
+        if reset then
+            sda_state       <= NONE;
+        elsif rising_edge(clk) then
+            if enabled then
+                if hysteresis_cntr = HYSTERESIS_CYCLES then
+                    case sda_state is
+                        when NONE =>
+                            if a = '0' and b = '1' then
+                                sda_next    := GRANT_A;
+                            elsif a = '1' and b = '0' then
+                                sda_next    := GRANT_B;
+                            end if;
+
+                        when GRANT_A =>
+                            if a = '1' then
+                                sda_next    := NONE;
+                            end if;
+
+                        when GRANT_B =>
+                            if b = '1' then
+                                sda_next    := NONE;
+                            end if;
+                    end case;
+
+                    -- arbitration changed, enforce hysteresis
+                    if sda_next /= sda_state then
+                        hysteresis_cntr <= 0;
+                    end if;
+                else
+                    hysteresis_cntr <= hysteresis_cntr + 1;
+                end if;
+            else
+                sda_next        := NONE;
+                hysteresis_cntr <= 0;
+            end if;
+
+            sda_state <= sda_next;
+        end if;
+    end process;
+
+end architecture;

--- a/hdl/projects/cosmo_seq/spd_proxy/sda_arbiter/sda_arbiter.vhd
+++ b/hdl/projects/cosmo_seq/spd_proxy/sda_arbiter/sda_arbiter.vhd
@@ -8,7 +8,7 @@
 -- essentially connected but proxied by the FPGA. It assumes the inactive state for the bus is high,
 -- and then monitors for `a` or `b` to pull the line low. It will then grant whichever side pulled
 -- the line low the bus until that side releases it, at which point after HYSTERESIS_CYCLES both
--- sides will be resambled again.
+-- sides will be resampled again.
 
 library ieee;
 use ieee.std_logic_1164.all;
@@ -16,7 +16,7 @@ use ieee.numeric_std.all;
 
 entity sda_arbiter is
     generic (
-        HYSTERESIS_CYCLES : integer
+        HYSTERESIS_CYCLES : natural
     );
     port (
         clk     : in std_logic;
@@ -37,7 +37,7 @@ architecture rtl of sda_arbiter is
         GRANT_B
     );
     signal sda_state : sda_control_t;
-    signal hysteresis_cntr : natural;
+    signal hysteresis_cntr : natural range 0 to HYSTERESIS_CYCLES;
 begin
 
     a_grant <= '1' when sda_state = GRANT_A else '0';
@@ -48,6 +48,7 @@ begin
     begin
         if reset then
             sda_state       <= NONE;
+            hysteresis_cntr <= 0;
         elsif rising_edge(clk) then
             if enabled then
                 if hysteresis_cntr = HYSTERESIS_CYCLES then

--- a/hdl/projects/cosmo_seq/spd_proxy/sda_arbiter/sims/sda_arbiter_tb.gtkw
+++ b/hdl/projects/cosmo_seq/spd_proxy/sda_arbiter/sims/sda_arbiter_tb.gtkw
@@ -1,0 +1,31 @@
+[*]
+[*] GTKWave Analyzer v3.3.104 (w)1999-2020 BSI
+[*] Mon Mar 17 12:06:15 2025
+[*]
+[dumpfile] "/home/aaron/Oxide/git/quartz/vunit_out/test_output/lib.sda_arbiter_tb.hysteresis_fba39672ff868058b296cfd50da9181a1eabe178/nvc/sda_arbiter_tb.fst"
+[dumpfile_mtime] "Mon Mar 17 12:06:00 2025"
+[dumpfile_size] 767
+[savefile] "/home/aaron/Oxide/git/quartz/hdl/projects/cosmo_seq/spd_proxy/sda_arbiter/sims/sda_arbiter_tb.gtkw"
+[timestart] 0
+[size] 2528 1283
+[pos] 1138 -22
+*-25.222696 100000000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+[treeopen] sda_arbiter_tb.
+[sst_width] 221
+[signals_width] 313
+[sst_expanded] 1
+[sst_vpaned_height] 382
+@28
+sda_arbiter_tb.sda_arbiter_inst.clk
+sda_arbiter_tb.sda_arbiter_inst.reset
+sda_arbiter_tb.sda_arbiter_inst.enabled
+sda_arbiter_tb.sda_arbiter_inst.a
+sda_arbiter_tb.sda_arbiter_inst.b
+sda_arbiter_tb.sda_arbiter_inst.sda_state
+@25
+sda_arbiter_tb.sda_arbiter_inst.hysteresis_cntr
+@28
+sda_arbiter_tb.sda_arbiter_inst.a_grant
+sda_arbiter_tb.sda_arbiter_inst.b_grant
+[pattern_trace] 1
+[pattern_trace] 0

--- a/hdl/projects/cosmo_seq/spd_proxy/sda_arbiter/sims/sda_arbiter_tb.vhd
+++ b/hdl/projects/cosmo_seq/spd_proxy/sda_arbiter/sims/sda_arbiter_tb.vhd
@@ -1,0 +1,141 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+-- Copyright 2025 Oxide Computer Company
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std_unsigned.all;
+
+library vunit_lib;
+    context vunit_lib.com_context;
+    context vunit_lib.vunit_context;
+
+entity sda_arbiter_tb is
+    generic (
+        runner_cfg : string
+    );
+end entity;
+
+architecture tb of sda_arbiter_tb is
+    constant CLK_PER_TIME       : time      := 8 ns;
+    constant HYSTERESIS_CYCLES  : integer   := 10;
+
+    signal clk      : std_logic := '0';
+    signal reset    : std_logic := '1';
+    signal a        : std_logic := '1';
+    signal b        : std_logic := '1';
+    signal enabled  : std_logic := '1';
+    signal a_grant  : std_logic;
+    signal b_grant  : std_logic;
+begin
+
+    clk     <= not clk after CLK_PER_TIME / 2;
+    reset   <= '0' after 100 ns;
+
+    sda_arbiter_inst: entity work.sda_arbiter
+     generic map(
+        HYSTERESIS_CYCLES => HYSTERESIS_CYCLES
+    )
+     port map(
+        clk     => clk,
+        reset   => reset,
+        a       => a,
+        b       => b,
+        enabled => enabled,
+        a_grant => a_grant,
+        b_grant => b_grant
+    );
+
+    bench: process
+        variable cycle_counter : integer := 0;
+    begin
+        -- Always the first thing in the process, set up things for the VUnit test runner
+        test_runner_setup(runner, runner_cfg);
+
+        -- wait for reset to clear
+        wait until reset = '0';
+
+        while test_suite loop
+            if run("grant_a") then
+                -- assert A bus
+                b <= '1';
+                wait for 100 ns;
+                a <= '0';
+
+                check_true(a_grant = '0', "Bus A should not be granted the bus.");
+                check_true(b_grant = '0', "Bus B should not be granted the bus.");
+
+                -- arbitration grant is registered
+                wait for CLK_PER_TIME + 1 ns;
+
+                check_true(a_grant = '1', "Bus A should immediately be granted the bus.");
+                check_true(b_grant = '0', "Bus B should not be granted the bus.");
+            elsif run("grant_b") then
+                -- assert B bus
+                a <= '1';
+                wait for 100 ns;
+                b <= '0';
+
+                check_true(a_grant = '0', "Bus A should not be granted the bus.");
+                check_true(b_grant = '0', "Bus B should not be granted the bus.");
+
+                -- arbitration grant is registered
+                wait for CLK_PER_TIME + 1 ns;
+
+                check_true(a_grant = '0', "Bus A should not be granted the bus.");
+                check_true(b_grant = '1', "Bus B should immediately be granted the bus.");
+            elsif run("hysteresis") then
+                -- assert A bus
+                b <= '1';
+                wait for 100 ns;
+                a <= '0';
+                wait until a_grant = '1';
+
+                -- release A bus and assert B bus, expecting the arbitration not to change before
+                -- HYSTERESIS_CYCLES has passed
+                a <= '1';
+                b <= '0';
+
+                while cycle_counter <= HYSTERESIS_CYCLES loop
+                    wait for CLK_PER_TIME;
+                    check_true(a_grant = '1', "Bus A should be granted the bus.");
+                    check_true(b_grant = '0', "Bus B should not be granted the bus.");
+                    cycle_counter := cycle_counter + 1;
+                end loop;
+
+                -- after the initial hysteresis period, neither bus should be granted arbitration
+                cycle_counter := 0;
+                while cycle_counter <= HYSTERESIS_CYCLES loop
+                    wait for CLK_PER_TIME;
+                    check_true(a_grant = '0', "Bus A should not be granted the bus.");
+                    check_true(b_grant = '0', "Bus B should not be granted the bus.");
+                    cycle_counter := cycle_counter + 1;
+                end loop;
+
+                -- after the second hysteresis period, B should be granted the bus.
+                wait until rising_edge(clk);
+                check_true(a_grant = '0', "Bus A should not be granted the bus.");
+                check_true(b_grant = '1', "Bus B should be granted the bus.");
+            elsif run("disable") then
+                -- assert A bus
+                b <= '1';
+                wait for 100 ns;
+                a <= '0';
+                wait until a_grant = '1';
+
+                enabled <= '0';
+                wait for CLK_PER_TIME + 1 ns;
+                check_true(a_grant = '0', "Bus A should not be granted the bus.");
+                check_true(b_grant = '0', "Bus B should not be granted the bus.");
+            end if;
+        end loop;
+
+        wait for 1 us;
+        test_runner_cleanup(runner);
+        wait;
+    end process;
+
+    test_runner_watchdog(runner, 10 us);
+end architecture;


### PR DESCRIPTION
This could be parameterized further to be a more general way to arbitrate a shared bus where the FPGA is a proxy, but for now this is what it is.