### PR TITLE
minibar: move HCV register to after the ident fields

### DIFF
--- a/hdl/projects/minibar/minibar_controller.rdl
+++ b/hdl/projects/minibar/minibar_controller.rdl
@@ -53,18 +53,6 @@ addrmap minibar_controller {
     } ID3;
 
     //
-    // Hardware Compatibility Version
-    // See RFD 438
-    //
-    reg {
-        name = "Hardware Compatibility Version Code";
-        default sw = r;
-        field {
-            desc = "HCV Code";
-        } data[7:0] = 0;
-    } HCV;
-
-    //
     // Checksum utilized by the SP
     //
     reg {
@@ -165,6 +153,18 @@ addrmap minibar_controller {
             desc = "sha[7..0]";
         } data[7:0] = 0;
     } SHA3;
+
+    //
+    // Hardware Compatibility Version
+    // See RFD 438
+    //
+    reg {
+        name = "Hardware Compatibility Version Code";
+        default sw = r;
+        field {
+            desc = "HCV Code";
+        } data[7:0] = 0;
+    } HCV;
 
     reg {
         name = "Scratchpad";


### PR DESCRIPTION
I previously had it smack dab in the middle of a range we expect for an identifying data structure in hubris (https://github.com/oxidecomputer/hubris/blob/a31b6acf6900c04978302b5a1dcc017e9b35e1fc/drv/fpga-api/src/lib.rs#L269)