### PR TITLE
Ndh/cosmo prebringup cleanup

### DIFF
--- a/hdl/projects/cosmo_seq/cosmo_seq_top.vhd
+++ b/hdl/projects/cosmo_seq/cosmo_seq_top.vhd
@@ -484,6 +484,7 @@ begin
      port map(
         clk => clk_125m,
         reset => reset_125m,
+        in_a0 => a0_ok,
         axi_if => responders(SP_I2C_RESP_IDX),
         sp_scl => i2c_sp_to_fpga1_scl,
         sp_scl_o => sp_scl_o,

--- a/hdl/projects/cosmo_seq/sequencer/nic_seq.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/nic_seq.vhd
@@ -22,6 +22,7 @@ entity nic_seq is
 
         sw_enable : in std_logic;
         upstream_ok : in std_logic;
+        nic_idle : out std_logic;
         debug_enables : in debug_enables_type;
         nic_overrides_reg : in nic_overrides_type;
 
@@ -66,6 +67,8 @@ architecture rtl of nic_seq is
     signal final_nic_outs : nic_overrides_type;
 
 begin
+
+    nic_idle <= '1' when nic_r.state = IDLE else '0';
 
     nic_sm:process(all)
         variable v : nic_r_t;

--- a/hdl/projects/cosmo_seq/sequencer/sims/sp5_sim.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sims/sp5_sim.vhd
@@ -29,10 +29,6 @@ begin
     -- this is the sunny day sequence
     sm: process
     begin
-        sp5_pins.thermtrip_l <= '0';
-        sp5_pins.reset_l <= '0';
-        sp5_pins.slp_s3_l <= '0';
-        sp5_pins.slp_s5_l <= '0';
 
         case state is
             when IDLE =>
@@ -40,6 +36,7 @@ begin
                 state <= RSM_RST;
 
             when RSM_RST =>
+                wait for 10 us;
                 state <= WAIT_FOR_PB;
 
             when WAIT_FOR_PB =>
@@ -64,6 +61,7 @@ begin
                     state <= IDLE;
                 end if;
         end case;
+        wait until rising_edge(clk);
     end process;
     -- power button fedge, max 360us to slp_sx_edges
 

--- a/hdl/projects/cosmo_seq/sequencer/sp5_sequencer.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sp5_sequencer.vhd
@@ -240,6 +240,7 @@ begin
      port map(
         clk => clk,
         reset => reset,
+        nic_idle => nic_idle,
         sw_enable => power_ctrl.a0_en,
         upstream_ok => a0_ok,
         nic_overrides_reg => nic_overrides,


### PR DESCRIPTION
Fixes #321, don't allow selecting of powered down mux segments.
Clean up sims around sequencing.