### PR TITLE
pre-bringup cosmo tasks

### DIFF
--- a/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/pca9506_regs.vhd
+++ b/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/pca9506_regs.vhd
@@ -25,6 +25,7 @@ entity pca9506_regs is
 
         -- io interface
         output_disable: in std_logic;
+        inband_reset : in std_logic; -- inband reset, can be used to reset the I/O expander
         io : in pca9506_pin_t;
         io_oe : out pca9506_pin_t;
         io_o : out pca9506_pin_t;
@@ -219,6 +220,34 @@ begin
                     when others =>
                         null;
                 end case;
+            end if;
+
+            if inband_reset then
+                ip0_reg  <= reset_0s;
+                ip1_reg  <= reset_0s;
+                ip2_reg  <= reset_0s;
+                ip3_reg  <= reset_0s;
+                ip4_reg  <= reset_0s;
+                op0_reg  <= reset_0s;
+                op1_reg  <= reset_0s;
+                op2_reg  <= reset_0s;
+                op3_reg  <= reset_0s;
+                op4_reg  <= reset_0s;
+                pi0_reg  <= reset_0s;
+                pi1_reg  <= reset_0s;
+                pi2_reg  <= reset_0s;
+                pi3_reg  <= reset_0s;
+                pi4_reg  <= reset_0s;
+                ioc0_reg <= reset_1s;
+                ioc1_reg <= reset_1s;
+                ioc2_reg <= reset_1s;
+                ioc3_reg <= reset_1s;
+                ioc4_reg <= reset_1s;  
+                msk0_reg <= reset_1s;
+                msk1_reg <= reset_1s;
+                msk2_reg <= reset_1s;
+                msk3_reg <= reset_1s;
+                msk4_reg <= reset_1s;
             end if;
 
         end if;

--- a/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/pca9506_top.vhd
+++ b/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/pca9506_top.vhd
@@ -25,6 +25,11 @@ entity pca9506_top is
         clk : in std_logic;
         reset : in std_logic;
 
+        -- optional inband reset, can be used to reset the I/O expander
+        -- this can be used if you need to "emulate" power-down behavior of the PCA9506
+        -- but we don't actually power down.
+        inband_reset : in std_logic := '0';
+
         -- I2C bus mux endpoint for control
         -- Does not support clock-stretching
         scl : in std_logic;
@@ -130,6 +135,7 @@ begin
         data_in => write_data,
         data_out => read_data,
         output_disable => '0',
+        inband_reset => inband_reset, -- allow inband reset to reset the registers
         io => io,
         io_oe => io_oe,
         io_o => io_o,

--- a/hdl/projects/cosmo_seq/sp5_hotplug_subsystem/BUCK
+++ b/hdl/projects/cosmo_seq/sp5_hotplug_subsystem/BUCK
@@ -2,10 +2,20 @@ load("//tools:hdl.bzl", "vhdl_unit", "vunit_sim")
 load("//tools:rdl.bzl", "rdl_file")
 
 vhdl_unit(
+    name = "perst_oneshot",
+    srcs = ["perst_oneshot.vhd"],
+    deps = [
+        "//hdl/ip/vhd/common:calc_pkg",
+    ],
+    visibility = ["PUBLIC"],
+)
+
+vhdl_unit(
     name = "sp5_hotplug_subsystem",
     srcs = ["sp5_hotplug_subsystem.vhd",
     ],
     deps = [
+        ":perst_oneshot",
         "//hdl/ip/vhd/synchronizers:meta_sync",
         "//hdl/ip/vhd/i2c/io_expanders/PCA9506ish:pca9506_top",
     ],

--- a/hdl/projects/cosmo_seq/sp5_hotplug_subsystem/perst_oneshot.vhd
+++ b/hdl/projects/cosmo_seq/sp5_hotplug_subsystem/perst_oneshot.vhd
@@ -1,0 +1,56 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+-- Copyright 2025 Oxide Computer Company
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+use work.calc_pkg.all; 
+
+entity perst_oneshot is
+    generic(
+        PERST_CNTS : integer
+    );
+    port (
+        clk : in std_logic;
+        reset : in std_logic;
+
+        power_en : in std_logic; -- active high input from the pin
+        perst_l : out std_logic
+    ); 
+end entity;
+
+architecture rtl of perst_oneshot is
+    signal cntr : unsigned(log2ceil(PERST_CNTS)-1 downto 0) := (others => '0');
+    
+    
+begin
+
+    sm:process(clk, reset)
+    begin
+        if reset then
+            cntr <= (others => '0'); -- reset the counter
+            perst_l <= '0'; 
+
+        elsif rising_edge(clk) then
+            if power_en = '1' and cntr <= (PERST_CNTS-1) then
+                -- increment the counter if power_en is high and we haven't reached the max count
+                cntr <= cntr + 1;
+                perst_l <= '0'; 
+            elsif  power_en then
+                perst_l <= '1'; -- once we reach the max count, assert perst_l
+            else
+                -- if power_en is low, reset the counter and deassert perst_l
+                cntr <= (others => '0'); 
+                perst_l <= '0'; 
+            end if;
+
+        end if;
+    end process;
+
+
+
+end rtl;


### PR DESCRIPTION
Adds some missing functionality for perst_l oneshots and resetting of pca9506 devices when not in a0 for a hopefully final pre-bringup submission here.

This finishes a couple of the remaining issues in #305 