### PR TITLE
Add byte-enables to DPR

### DIFF
--- a/hdl/ip/vhd/common/utils/calc_pkg.vhd
+++ b/hdl/ip/vhd/common/utils/calc_pkg.vhd
@@ -67,7 +67,7 @@ package body calc_pkg is
             count         := count * 2;
             bits_required := bits_required + 1;
         end loop;
-        -- Beacuse 0 counts, as long as we have more than 1 bit required,
+        -- Because 0 counts, as long as we have more than 1 bit required,
         -- we need to subtract 1 from the number found above since 8 bits
         -- can represent 256 values
         if bits_required > 1 then

--- a/hdl/ip/vhd/memories/BUCK
+++ b/hdl/ip/vhd/memories/BUCK
@@ -10,11 +10,21 @@ vhdl_unit(
 )
 
 vhdl_unit(
+    name = "mixed_width_simple_dpr",
+    srcs = ["mixed_width_simple_dpr.vhd",],
+    deps = [
+        "//hdl/ip/vhd/common:calc_pkg",
+        ],
+    visibility = ["PUBLIC"],
+)
+
+vhdl_unit(
     name = "memories_tb",
     is_tb = True,
     srcs = glob(["sims/*.vhd"]),
     deps = [
         ":dual_clock_simple_dpr",
+        ":mixed_width_simple_dpr",
         "//hdl/ip/vhd/fifos:dcfifo_xpm",
         "//hdl/ip/vhd/vunit_components:sim_gpio"
     ],

--- a/hdl/ip/vhd/memories/mixed_width_simple_dpr.vhd
+++ b/hdl/ip/vhd/memories/mixed_width_simple_dpr.vhd
@@ -1,0 +1,132 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+-- Copyright 2025 Oxide Computer Company
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use ieee.numeric_std_unsigned.all;
+
+use work.calc_pkg.all;
+
+-- Simple dual port ram supporting dual clocks with symmetric read and
+-- write sizes. Addresses are in terms of `WIDTH` as a word
+-- `NUM_WORDS` is the depth of the FIFO again in terms of entries
+-- of `WIDTH` of the port
+-- Note: a read from an address that is undergoing a write will
+-- result in undefined behavior and needs to be avoided
+-- Note2: This is an attempt at making a ram that can be inferred
+-- by vivado wihout using shared variables. All of Xilinx's inferrence
+-- examples use shared variables who's functionality was deprecated
+-- technically by VHDL-2002, and a protected variable would be a more
+-- proper model of it at this point but it is unclear if those would
+-- compile or be recognized as and implemented in RAM.
+-- You are limited to aspect ratios supported by the device/software:
+-- Generally read:write ratios of 1:32, 1:16, 1:8, 1:4, 1:2, 1:1, 2:1, 
+--   4:1, 8:1, 16:1, or 32:1
+-- are supported, with no width being larger than 4096 bits
+
+entity mixed_width_simple_dpr is
+    generic (
+        write_width : integer;
+        read_width  : integer;
+        write_num_words  : integer;
+        reg_output : boolean := false
+    );
+    port (
+        -- Write-side interface clock
+        wclk : in    std_logic;
+        -- Write address, sync'd to wclk domain
+        waddr : in    std_logic_vector(log2ceil(write_num_words) - 1 downto 0);
+        -- Write data, sync'd to wclk domain
+        wdata : in    std_logic_vector(write_width - 1 downto 0);
+        -- Write enable, sync'd to wclk domain
+        wren : in    std_logic; -- wclk domain
+        -- Read-side interface clock
+        rclk : in    std_logic;
+        -- read addrss size is going to be calculated based on the aspect ratio of the two sides
+        raddr : in    std_logic_vector(log2ceil(write_num_words * write_width / read_width) - 1  downto 0);
+        -- Read data, sync'd to rclk domain
+        rdata : out   std_logic_vector(read_width - 1 downto 0)
+    );
+end entity;
+
+architecture ram of mixed_width_simple_dpr is
+    constant write_side_is_bigger : boolean := write_width > read_width;
+    constant min_width : integer := minimum(write_width, read_width);
+    constant max_width : integer := maximum(write_width, read_width);
+    constant ratio : integer := max_width / min_width;
+    -- the max size is going to be the biggest number of words we can have on either side
+    constant max_size : integer := maximum(write_num_words, write_num_words * write_width / read_width);
+
+    type ram_t is array (0 to max_size - 1) of std_logic_vector(min_width - 1 downto 0);
+    signal ram : ram_t := (others => (others => '0'));
+    signal rdata_int : std_logic_vector(rdata'range);
+
+    begin
+
+
+    write_bigger_gen: if write_side_is_bigger generate
+        -- The unrolling works differently depending on which side is larger
+        -- The write side is wider so we decode the read side as the native width and
+        -- the write side address is expanded to get proper address.
+        wbig_write_proc:process(wclk)
+            variable addr: integer := 0;
+        begin
+            if rising_edge(wclk) then
+                for i in 0 to RATIO - 1 loop
+                    -- Set up the address by concatenating the ratio bits to the end since we're accessing
+                    -- by min-width sizes.
+                    addr := to_integer(waddr & to_std_logic_vector(i, log2ceil(RATIO)));
+    
+                    if wren = '1' then
+                        ram(addr) <= wdata((i + 1) * min_width - 1 downto i * min_width);
+                    end if;
+                end loop;
+            end if;
+        end process;
+    
+        rdata_int <= ram(to_integer(raddr));
+    else generate
+        -- Write side is smaller so the decodes flip from above, write side writes to ram array natively
+        -- and the read side has to expand the data out.
+
+        wsmaller_write_proc:process(wclk)
+        begin
+            if rising_edge(wclk) then
+                for i in 0 to RATIO - 1 loop
+                    -- No address adjustment since this is the min-width side
+                    if wren = '1' then
+                        ram(to_integer(waddr)) <= wdata;
+                    end if;
+                end loop;
+            end if;
+        end process;
+
+        rd_proc:process(all)
+            variable addr: integer := 0;
+        begin
+            for i in 0 to RATIO - 1 loop
+                -- Set up the address by concatenating the ratio bits to the end since we're accessing
+                -- by min-width sizes.
+                addr := to_integer(raddr & to_std_logic_vector(i, log2ceil(RATIO)));
+                rdata_int((i + 1) * min_width - 1 downto i * min_width) <= ram(addr);
+            end loop;
+        end process;
+    end generate;
+
+    out_reg_gen: if reg_output generate
+        out_reg: process(rclk)
+        begin
+            if rising_edge(rclk) then
+                rdata <= rdata_int;
+            end if;
+        end process;
+    else generate
+        rdata <= rdata_int;
+    end generate;
+
+
+end ram;

--- a/hdl/ip/vhd/memories/sims/memories_sim_pkg.vhd
+++ b/hdl/ip/vhd/memories/sims/memories_sim_pkg.vhd
@@ -2,7 +2,7 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
+-- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;
@@ -18,13 +18,15 @@ package memories_sim_pkg is
     procedure write_dpr (
         signal net    : inout network_t;
         variable addr : in std_logic_vector(3 downto 0);
-        variable data : in std_logic_vector(7 downto 0)
+        variable data : in std_logic_vector(15 downto 0);
+        constant actor : actor_t
     );
 
     procedure read_dpr (
         signal net    : inout network_t;
         variable addr : in  std_logic_vector(3 downto 0);
-        variable data : out std_logic_vector(7 downto 0)
+        variable data : out std_logic_vector(15 downto 0);
+        constant actor : actor_t
     );
 
 end package;
@@ -34,36 +36,38 @@ package body memories_sim_pkg is
     procedure write_dpr (
         signal net    : inout network_t;
         variable addr : in std_logic_vector(3 downto 0);
-        variable data : in std_logic_vector(7 downto 0)
+        variable data : in std_logic_vector(15 downto 0);
+        constant actor : actor_t
     ) is
 
-        variable msg_target : actor_t;
+        variable msg_target : actor_t := actor;
         variable send_data  : std_logic_vector(31 downto 0) := (others => '0');
+        variable write_idx : integer := addr'length + data'length;
 
     begin
-        msg_target             := find("dpr_write_side");
-        send_data(12 downto 0) := "1" & addr & data;
+        send_data(addr'length + data'length-1 downto 0) := addr & data;
+        send_data(write_idx) := '1';
         set_gpio(net, msg_target, send_data);
-        send_data(12)          := '0';
+        send_data(write_idx) := '1';
         set_gpio(net, msg_target, send_data);
     end;
 
     procedure read_dpr (
         signal net    : inout network_t;
         variable addr : in  std_logic_vector(3 downto 0);
-        variable data : out std_logic_vector(7 downto 0)
+        variable data : out std_logic_vector(15 downto 0);
+        constant actor : actor_t
     ) is
 
-        variable msg_target : actor_t;
+        variable msg_target : actor_t := actor;
         variable send_data  : std_logic_vector(31 downto 0) := (others => '0');
         variable get_data   : std_logic_vector(31 downto 0) := (others => '0');
 
     begin
-        msg_target            := find("dpr_read_side");
         send_data(3 downto 0) := addr;
         set_gpio(net, msg_target, send_data);
         get_gpio(net, msg_target, get_data);
-        data                  := get_data(7 downto 0);
+        data                  := get_data(data'range);
     end;
 
 end package body;

--- a/hdl/ip/vhd/memories/sims/memories_tb.vhd
+++ b/hdl/ip/vhd/memories/sims/memories_tb.vhd
@@ -2,7 +2,7 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
+-- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;
@@ -34,9 +34,11 @@ begin
         alias reset_a is << signal th.reset_a : std_logic >>;
         alias reset_b is << signal th.reset_b : std_logic >>;
 
-        variable write_data : std_logic_vector(7 downto 0);
-        variable read_data  : std_logic_vector(7 downto 0);
+        variable write_data : std_logic_vector(15 downto 0);
+        variable read_data  : std_logic_vector(15 downto 0);
         variable dpr_addr   : std_logic_vector(3 downto 0);
+        variable wactor      : actor_t := null_actor;
+        variable ractor      : actor_t := null_actor;
     begin
         -- Always the first thing in the process, set up things for the VUnit test runner
         test_runner_setup(runner, runner_cfg);
@@ -48,23 +50,46 @@ begin
 
         while test_suite loop
             if run("basic_dpr_test") then
+                wactor := find("dpr_write_side");
+                ractor := find("dpr_read_side");
                 -- load fifo with data
-                write_data := X"AA";
-                dpr_addr   := X"0";
-                write_dpr(net, dpr_addr, write_data);
-                write_data := X"55";
-                dpr_addr   := X"1";
-                write_dpr(net, dpr_addr, write_data);
+                write_data := 16x"AAAA";
+                dpr_addr   := 4x"0";
+                write_dpr(net, dpr_addr, write_data, wactor);
                 wait for 1 us;
-                read_dpr(net, dpr_addr, read_data);
-                -- check read-side data
-                check_equal(read_data, write_data, "Mismatch detected");
+                read_dpr(net, dpr_addr, read_data, ractor);
 
-                write_data := X"AA";
-                dpr_addr   := X"0";
-                read_dpr(net, dpr_addr, read_data);
                 -- check read-side data
-                check_equal(read_data, write_data, "Mismatch detected");
+                check_equal(read_data, write_data, "Addr0: Mismatch detected");
+
+                write_data := 16x"55";
+                dpr_addr   := 4x"1";
+                write_dpr(net, dpr_addr, write_data, wactor);
+                wait for 1 us;
+                read_dpr(net, dpr_addr, read_data, ractor);
+                -- check read-side data
+                check_equal(read_data, write_data, "Addr1: Mismatch detected");
+            elsif run("mixed_width_dpr_test") then
+                wactor := find("mixed_dpr_write_side");
+                ractor := find("mixed_dpr_read_side");
+                -- load an 8bit write-side with 55 at address 0
+                write_data := 16x"55";
+                dpr_addr   := 4x"0";
+                write_dpr(net, dpr_addr, write_data, wactor);
+                wait for 1 us;
+                -- load an 8bit write-side with AA at address 1
+                write_data := 16x"AA";
+                dpr_addr   := 4x"1";
+                write_dpr(net, dpr_addr, write_data, wactor);
+                wait for 1 us;
+                -- get 16bit read-side expected AA55 at address 0
+                dpr_addr   := 4x"0";
+                read_dpr(net, dpr_addr, read_data, ractor);
+
+                -- check read-side data
+                check_equal(read_data, std_logic_vector'(16x"AA55"), "Addr0: Mismatch detected");
+
+                
             end if;
         end loop;
         wait for 1 us;


### PR DESCRIPTION
I have a use-case that wants byte-enables on a dual-port ram so I'm adding them and an associated testcase here.
@Aaron-Hartwig: Ready to review