### PR TITLE
Add 8b10b encoders/decoders 

### DIFF
--- a/hdl/ip/vhd/8b10b/BUCK
+++ b/hdl/ip/vhd/8b10b/BUCK
@@ -1,0 +1,25 @@
+load("//tools:hdl.bzl", "vhdl_unit")
+
+vhdl_unit(
+    name = "helper_8b10b_pkg",
+    srcs = glob(["helper_8b10b_pkg.vhd"]),
+    deps = [
+        "//hdl/ip/vhd/common:calc_pkg",
+    ],
+    standard = "2008",
+    visibility = ['PUBLIC'],
+)
+
+vhdl_unit(
+    name = "encode_8b10b",
+    srcs = glob(["encode_8b10b.vhd"]),
+    standard = "2008",
+    visibility = ['PUBLIC'],
+)
+
+vhdl_unit(
+    name = "decode_8b10b",
+    srcs = glob(["decode_8b10b.vhd"]),
+    standard = "2008",
+    visibility = ['PUBLIC'],
+)

--- a/hdl/ip/vhd/8b10b/decode_8b10b.vhd
+++ b/hdl/ip/vhd/8b10b/decode_8b10b.vhd
@@ -56,7 +56,7 @@ architecture rtl of decode_8b10b is
 
     signal disp6b : std_logic;
 
-    -- The 5B/6B decoding special cases where ABCDE !       : std_logic; abcde
+    -- The 5B/6B decoding special cases where ABCDE != abcde
 
     signal p22bceeqi   : std_logic;
     signal p22bncneeqi : std_logic;

--- a/hdl/ip/vhd/8b10b/decode_8b10b.vhd
+++ b/hdl/ip/vhd/8b10b/decode_8b10b.vhd
@@ -1,0 +1,219 @@
+-- Adapted by Oxide from Verilog code by Chuck Benz,
+-- with the following license from https://asics.chuckbenz.com/decode.v:
+-- Chuck Benz, Hollis, NH   Copyright (c)2002
+--
+-- The information and description contained herein is the
+-- property of Chuck Benz.
+--
+-- Permission is granted for any reuse of this information
+-- and description as long as this copyright notice is
+-- preserved.  Modifications may be made as long as this
+-- notice is preserved.
+
+-- per Widmer and Franaszek
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity decode_8b10b is
+    port(
+        datain   : in  std_logic_vector(9 downto 0);
+        dispin   : in  std_logic;
+
+        dataout  : out std_logic_vector(8 downto 0);
+        dispout  : out std_logic;
+
+        code_err : out std_logic;
+        disp_err : out std_logic
+    );
+end decode_8b10b;
+
+architecture rtl of decode_8b10b is
+    alias ai is datain(0);
+    alias bi is datain(1);
+    alias ci is datain(2);
+    alias di is datain(3);
+    alias ei is datain(4);
+    alias ii is datain(5);
+    alias fi is datain(6);
+    alias gi is datain(7);
+    alias hi is datain(8);
+    alias ji is datain(9);
+
+    signal aeqb : std_logic;
+    signal ceqd : std_logic;
+    signal p22  : std_logic;
+    signal p13  : std_logic;
+    signal p31  : std_logic;
+
+    signal p40 : std_logic;
+    signal p04 : std_logic;
+
+    signal disp6a  : std_logic;
+    signal disp6a2 : std_logic;
+    signal disp6a0 : std_logic;
+
+    signal disp6b : std_logic;
+
+    -- The 5B/6B decoding special cases where ABCDE !       : std_logic; abcde
+
+    signal p22bceeqi   : std_logic;
+    signal p22bncneeqi : std_logic;
+    signal p13in       : std_logic;
+    signal p31i        : std_logic;
+    signal p13dei      : std_logic;
+    signal p22aceeqi   : std_logic;
+    signal p22ancneeqi : std_logic;
+    signal p13en       : std_logic;
+    signal anbnenin    : std_logic;
+    signal abei        : std_logic;
+    signal cndnenin    : std_logic;
+
+    signal compa : std_logic;
+    signal compb : std_logic;
+    signal compc : std_logic;
+    signal compd : std_logic;
+    signal compe : std_logic;
+
+    alias ao is dataout(0);
+    alias bo is dataout(1);
+    alias co is dataout(2);
+    alias d_o is dataout(3);
+    alias eo is dataout(4);
+    alias fo is dataout(5);
+    alias go is dataout(6);
+    alias ho is dataout(7);
+    alias ko is dataout(8);
+
+    signal feqg    : std_logic;
+    signal heqj    : std_logic;
+    signal fghj22  : std_logic;
+    signal fghjp13 : std_logic;
+    signal fghjp31 : std_logic;
+   
+    signal k28p : std_logic;
+
+    signal disp6p : std_logic;
+    signal disp6n : std_logic;
+    signal disp4p : std_logic;
+    signal disp4n : std_logic;
+
+    signal ei_eq_ii : std_logic;
+
+begin
+
+    aeqb <= (ai and bi) or ((not ai) and (not bi));
+    ceqd <= (ci and di) or ((not ci) and (not di));
+    p22  <= (ai and bi and (not ci) and (not di)) or 
+            (ci and di and (not ai) and (not bi)) or 
+            ((not aeqb) and (not ceqd));
+    p13  <= ((not aeqb) and (not ci) and (not di)) or 
+            ((not ceqd) and (not ai) and (not bi));
+    p31  <= ((not aeqb) and ci and di) or 
+            ((not ceqd) and ai and bi);
+    p40  <= (ai and bi and ci and di);
+    p04  <= (not ai) and (not bi) and (not ci) and (not di);
+
+    disp6a  <= p31 or (p22 and dispin); -- pos disp if p22 and was pos, or p31.
+    disp6a2 <= p31 and dispin; -- disp is ++ after 4 bits
+    disp6a0 <= p13 and (not dispin); -- -- disp after 4 bits
+
+    disp6b <= (((ei and ii and (not disp6a0)) or (disp6a and (ei or ii)) or disp6a2 or 
+                (ei and ii and di)) and (ei or ii or di));
+
+    -- The 5B/6B decoding special cases where ABCDE (NOT <= '1' when (  abcde
+    ei_eq_ii <= '1' when ei = ii else '0';  -- hold this partial for use below
+
+    p22bceeqi   <= p22 and bi and ci and ei_eq_ii;
+    p22bncneeqi <= p22 and (not bi) and (not ci) and ei_eq_ii;
+    p13in       <= p13 and (not ii);
+    p31i        <= p31 and ii;
+    p13dei      <= p13 and di and ei and ii;
+    p22aceeqi   <= p22 and ai and ci and ei_eq_ii;
+    p22ancneeqi <= p22 and (not ai) and (not ci) and ei_eq_ii;
+    p13en       <= p13 and (not ei);
+    anbnenin    <= (not ai) and (not bi) and (not ei) and (not ii);
+    abei        <= ai and bi and ei and ii;
+    cndnenin    <= (not ci) and (not di) and (not ei) and (not ii);
+
+    compa <= p22bncneeqi or p31i or p13dei or p22ancneeqi or 
+             p13en or abei or cndnenin;
+    compb <= p22bceeqi or p31i or p13dei or p22aceeqi or 
+             p13en or abei or cndnenin;
+    compc <= p22bceeqi or p31i or p13dei or p22ancneeqi or 
+             p13en or anbnenin or cndnenin;
+    compd <= p22bncneeqi or p31i or p13dei or p22aceeqi or 
+             p13en or abei or cndnenin;
+    compe <= p22bncneeqi or p13in or p13dei or p22ancneeqi or 
+             p13en or anbnenin or cndnenin;
+
+    ao  <= ai xor compa;
+    bo  <= bi xor compb;
+    co  <= ci xor compc;
+    d_o <= di xor compd;
+    eo  <= ei xor compe;
+
+    feqg    <= (fi and gi) or ((not fi) and (not gi));
+    heqj    <= (hi and ji) or ((not hi) and (not ji));
+    fghj22  <= (fi and gi and (not hi) and (not ji)) or 
+               ((not fi) and (not gi) and hi and ji) or 
+               ((not feqg) and (not heqj));
+    fghjp13 <= ((not feqg) and (not hi) and (not ji)) or 
+               ((not heqj) and (not fi) and (not gi));
+    fghjp31 <= (((not feqg)) and hi and ji) or 
+               ((not heqj) and fi and gi);
+
+    dispout <= (fghjp31 or (disp6b and fghj22) or (hi and ji)) and (hi or ji);
+
+    ko <= ((ci and di and ei and ii) or ((not ci) and (not di) and (not ei) and (not ii)) or 
+           (p13 and (not ei) and ii and gi and hi and ji) or 
+           (p31 and ei and (not ii) and (not gi) and (not hi) and (not ji)));
+
+    -- k28 with positive disp into fghi - .1, .2, .5, and .6 special cases
+    k28p <= not (ci or di or ei or ii);
+    fo   <= (ji and (not fi) and (hi or (not gi) or k28p)) or 
+            (fi and (not ji) and ((not hi) or gi or (not k28p))) or 
+            (k28p and gi and hi) or 
+            ((not k28p) and (not gi) and (not hi));
+    go   <= (ji and (not fi) and (hi or (not gi) or (not k28p))) or 
+            (fi and (not ji) and ((not hi) or gi or k28p)) or 
+            ((not k28p) and gi and hi) or 
+            (k28p and (not gi) and (not hi));
+    ho   <= ((ji xor hi) and (not (((not fi) and gi and (not hi) and ji and (not k28p)) or ((not fi) and gi and hi and (not ji) and k28p) or 
+                                   (fi and (not gi) and (not hi) and ji and (not k28p)) or (fi and (not gi) and hi and (not ji) and k28p)))) or 
+            ((not fi) and gi and hi and ji) or (fi and (not gi) and (not hi) and (not ji));
+
+    disp6p <= (p31 and (ei or ii)) or (p22 and ei and ii);
+    disp6n <= (p13 and (not (ei and ii))) or (p22 and (not ei) and (not ii));
+    disp4p <= fghjp31;
+    disp4n <= fghjp13;
+
+    code_err <= p40 or p04 or (fi and gi and hi and ji) or ((not fi) and (not gi) and (not hi) and (not ji)) or 
+                (p13 and (not ei) and (not ii)) or (p31 and ei and ii) or 
+                (ei and ii and fi and gi and hi) or ((not ei) and (not ii) and (not fi) and (not gi) and (not hi)) or 
+                (ei and (not ii) and gi and hi and ji) or ((not ei) and ii and (not gi) and (not hi) and (not ji)) or 
+                ((not p31) and ei and (not ii) and (not gi) and (not hi) and (not ji)) or 
+                ((not p13) and (not ei) and ii and gi and hi and ji) or
+                (((ei and ii and (not gi) and (not hi) and (not ji)) or 
+                  ((not ei) and (not ii) and gi and hi and ji)) and 
+                   (not ((ci and di and ei) or ((not ci) and (not di) and (not ei))))) or 
+                (disp6p and disp4p) or (disp6n and disp4n) or 
+                (ai and bi and ci and (not ei) and (not ii) and (((not fi) and (not gi)) or fghjp13)) or 
+                ((not ai) and (not bi) and (not ci) and ei and ii and ((fi and gi) or fghjp31)) or 
+                (fi and gi and (not hi) and (not ji) and disp6p) or 
+                ((not fi) and (not gi) and hi and ji and disp6n) or 
+                (ci and di and ei and ii and (not fi) and (not gi) and (not hi)) or 
+                ((not ci) and (not di) and (not ei) and (not ii) and fi and gi and hi);
+
+    -- my disp err fires for any legal codes that violate disparity, may fire for illegal codes
+    disp_err <= ((dispin and disp6p) or (disp6n and (not dispin)) or 
+                 (dispin and (not disp6n) and fi and gi) or 
+                 (dispin and ai and bi and ci) or 
+                 (dispin and (not disp6n) and disp4p) or 
+                 ((not dispin) and (not disp6p) and (not fi) and (not gi)) or 
+                 ((not dispin) and (not ai) and (not bi) and (not ci)) or 
+                 ((not dispin) and (not disp6p) and disp4n) or 
+                 (disp6p and disp4p) or (disp6n and disp4n));
+
+end rtl;

--- a/hdl/ip/vhd/8b10b/encode_8b10b.vhd
+++ b/hdl/ip/vhd/8b10b/encode_8b10b.vhd
@@ -1,0 +1,172 @@
+-- Adapted by Oxide from Verilog code by Chuck Benz,
+-- with the following license from https://asics.chuckbenz.com/encode.v:
+-- Chuck Benz, Hollis, NH   Copyright (c)2002
+--
+-- The information and description contained herein is the
+-- property of Chuck Benz.
+--
+-- Permission is granted for any reuse of this information
+-- and description as long as this copyright notice is
+-- preserved.  Modifications may be made as long as this
+-- notice is preserved.
+
+-- per Widmer and Franaszek
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity encode_8b10b is
+    port(
+        datain  : in  std_logic_vector(8 downto 0);
+        dispin  : in  std_logic;  -- 0 = neg disp, 1 = pos disp
+
+        dataout : out std_logic_vector(9 downto 0);
+        dispout : out std_logic
+    );
+end encode_8b10b;
+
+architecture rtl of encode_8b10b is
+    alias ai is datain(0);
+    alias bi is datain(1);
+    alias ci is datain(2);
+    alias di is datain(3);
+    alias ei is datain(4);
+    alias fi is datain(5);
+    alias gi is datain(6);
+    alias hi is datain(7);
+    alias ki is datain(8);
+
+    signal ao  : std_logic;
+    signal bo  : std_logic;
+    signal co  : std_logic;
+    signal d_o : std_logic;
+    signal eo  : std_logic;
+    signal fo  : std_logic;
+    signal go  : std_logic;
+    signal ho  : std_logic;
+    signal io  : std_logic;
+    signal jo  : std_logic;
+
+    signal aeqb  : std_logic;
+    signal ceqd  : std_logic;
+    signal ndos6 : std_logic;
+    signal pdos6 : std_logic;
+    signal ndos4 : std_logic;
+    signal pdos4 : std_logic;
+
+    signal l22 : std_logic;
+    signal l40 : std_logic;
+    signal l04 : std_logic;
+    signal l13 : std_logic;
+    signal l31 : std_logic;
+
+    signal nd1s4 : std_logic;
+    signal pd1s4 : std_logic;
+    signal pd1s6 : std_logic;
+    signal nd1s6 : std_logic;
+    signal alt7  : std_logic;
+
+    signal alt7partial : std_logic;
+    signal illegalk : std_logic;
+
+    signal compls6  : std_logic;
+    signal compls4  : std_logic;
+
+    signal disp6 : std_logic;
+
+begin
+
+    aeqb <= (ai and bi) or ((not ai) and (not bi));
+    ceqd <= (ci and di) or ((not ci) and (not di));
+    l22  <= (ai and bi and (not ci) and (not di)) or 
+            (ci and di and (not ai) and (not bi)) or 
+            ((not aeqb) and (not ceqd));
+    l40  <= ai and bi and ci and di;
+    l04  <= (not ai) and (not bi) and (not ci) and (not di);
+    l13  <= ((not aeqb) and (not ci) and (not di)) or 
+            ((not ceqd) and (not ai) and (not bi));
+    l31  <= ((not aeqb) and ci and di) or 
+            ((not ceqd) and ai and bi);
+
+    -- the 5b/6b encoding
+    ao  <= ai;
+    bo  <= (bi and (not l40)) or l04;
+    co  <= l04 or ci or (ei and di and (not ci) and (not bi) and (not ai));
+    d_o <= di and (not (ai and bi and ci));  -- note: "do" is a reserved word in vhdl
+    eo  <= (ei or l13) and (not (ei and di and (not ci) and (not bi) and (not ai)));
+    io  <= (l22 and (not ei)) or 
+           (ei and (not di) and (not ci) and (not (ai and bi))) or -- D16, D17, D18
+           (ei and l40) or 
+           (ki and ei and di and ci and (not bi) and (not ai)) or -- K.28
+           (ei and (not di) and ci and (not bi) and (not ai));
+
+    -- pds16 indicates cases where d-1 is assumed + to get our encoded value
+    pd1s6 <= (ei and di and (not ci) and (not bi) and (not ai)) or ((not ei) and (not l22) and (not l31));
+    -- nds16 indicates cases where d-1 is assumed - to get our encoded value
+    nd1s6 <= (ki or (ei and (not l22) and (not l13)) or ((not ei) and (not di) and ci and bi and ai));
+
+    -- ndos6 is pds16 cases where d-1 is + yields - disp out - all of them
+    ndos6 <= pd1s6;
+    -- pdos6 is nds16 cases where d-1 is - yields + disp out - all but one
+    pdos6 <= ki or (ei and (not l22) and (not l13));
+
+    -- some Dx.7 and all Kx.7 cases result in run length of 5 case unless
+    -- an alternate coding is used (referred to as Dx.A7, normal is Dx.P7)
+    -- specifically, D11, D13, D14, D17, D18, D19.
+    alt7partial <= (not ei) and di and l31 when dispin = '1' else (ei and (not di) and l13);
+
+    alt7 <= fi and gi and hi and (ki or alt7partial);
+
+    fo <= fi and (not alt7);
+    go <= gi or ((not fi) and (not gi) and (not hi));
+    ho <= hi;
+    jo <= ((not hi) and (gi xor fi)) or alt7;
+
+    -- nd1s4 is cases where d-1 is assumed - to get our encoded value
+    nd1s4 <= fi and gi;
+    -- pd1s4 is cases where d-1 is assumed + to get our encoded value
+    pd1s4 <= ((not fi) and (not gi)) or (ki and ((fi and (not gi)) or ((not fi) and gi)));
+
+    -- ndos4 is pd1s4 cases where d-1 is + yields - disp out - just some
+    ndos4 <= ((not fi) and (not gi));
+    -- pdos4 is nd1s4 cases where d-1 is - yields + disp out
+    pdos4 <= fi and gi and hi;
+
+    -- only legal K codes are K28.0->.7, K23/27/29/30.7
+    --  K28.0->7 is ei=di=ci=1,bi=ai=0
+    --  K23 is 10111
+    --  K27 is 11011
+    --  K29 is 11101
+    --  K30 is 11110 - so K23/27/29/30 are ei & l31
+    -- not used in design but may be fished out for sim??
+    illegalk <= ki and
+                (ai or bi or (not ci) or (not di) or (not ei)) and -- not K28.0->7
+                ((not fi) or (not gi) or (not hi) or (not ei) or (not l31)); -- not K23/27/29/30.7
+
+    -- now determine whether to do the complementing
+    -- complement if prev disp is - and pd1s6 is set, or + and nd1s6 is set
+    compls6 <= (pd1s6 and (not dispin)) or (nd1s6 and dispin);
+
+    -- disparity out of 5b6b is disp in with pdso6 and ndso6
+    -- pds16 indicates cases where d-1 is assumed + to get our encoded value
+    -- ndos6 is cases where d-1 is + yields - disp out
+    -- nds16 indicates cases where d-1 is assumed - to get our encoded value
+    -- pdos6 is cases where d-1 is - yields + disp out
+    -- disp toggles in all ndis16 cases, and all but that 1 nds16 case
+    disp6 <= dispin xor (ndos6 or pdos6);
+
+    compls4 <= (pd1s4 and (not disp6)) or (nd1s4 and disp6);
+    dispout <= disp6 xor (ndos4 or pdos4);
+
+    dataout(9) <= jo xor compls4;
+    dataout(8) <= ho xor compls4;
+    dataout(7) <= go xor compls4;
+    dataout(6) <= fo xor compls4;
+    dataout(5) <= io xor compls6;
+    dataout(4) <= eo xor compls6;
+    dataout(3) <= d_o xor compls6;
+    dataout(2) <= co xor compls6;
+    dataout(1) <= bo xor compls6;
+    dataout(0) <= ao xor compls6;
+end rtl;

--- a/hdl/ip/vhd/8b10b/helper_8b10b_pkg.vhd
+++ b/hdl/ip/vhd/8b10b/helper_8b10b_pkg.vhd
@@ -1,0 +1,195 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+-- Copyright 2025 Oxide Computer Company
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use ieee.numeric_std_unsigned.all;
+
+use work.calc_pkg.all;
+
+package helper_8b10b_pkg is
+
+-- 8b10b encoding constants in decoded form
+constant K28_0                  : std_logic_vector(7 downto 0) := X"1C";
+constant K28_1                  : std_logic_vector(7 downto 0) := X"3C";
+constant K28_2                  : std_logic_vector(7 downto 0) := X"5C";
+constant K28_3                  : std_logic_vector(7 downto 0) := X"7C";
+constant K28_4                  : std_logic_vector(7 downto 0) := X"9C";
+constant K28_5                  : std_logic_vector(7 downto 0) := X"BC";
+constant K28_6                  : std_logic_vector(7 downto 0) := X"DC";
+constant K28_7                  : std_logic_vector(7 downto 0) := X"FC";
+constant K23_7                  : std_logic_vector(7 downto 0) := X"F7";
+constant K27_7                  : std_logic_vector(7 downto 0) := X"FB";
+constant K29_7                  : std_logic_vector(7 downto 0) := X"FD";
+constant K30_7                  : std_logic_vector(7 downto 0) := X"FE";
+constant KERR                   : std_logic_vector(7 downto 0) := X"FF";
+
+type encoded_8b10b_t is record
+    data : std_logic_vector(9 downto 0);
+    disparity : std_logic;
+end record;
+
+type encode_lkup_table_t is array(0 to 255) of std_logic_vector(9 downto 0);
+
+
+-- a CAM table for 8b10b encoding. This likely should not be used in hw
+-- but is useful for verification
+-- This is to be used when you're running a negative disparity
+-- in abcdeifghj
+constant RD_MINUS : encode_lkup_table_t := (
+    10x"274", 10x"1d4", 10x"2d4", 10x"31b", 10x"354", 10x"29b", 10x"19b", 10x"38b",
+    10x"394", 10x"25b", 10x"15b", 10x"34b", 10x"0db", 10x"2cb", 10x"1cb", 10x"174",
+    10x"1b4", 10x"23b", 10x"13b", 10x"32b", 10x"0bb", 10x"2ab", 10x"1ab", 10x"3a4",
+    10x"334", 10x"26b", 10x"16b", 10x"364", 10x"0eb", 10x"2e4", 10x"1e4", 10x"2b4",
+    10x"279", 10x"1d9", 10x"2d9", 10x"319", 10x"359", 10x"299", 10x"199", 10x"389",
+    10x"399", 10x"259", 10x"159", 10x"349", 10x"0d9", 10x"2c9", 10x"1c9", 10x"179",
+    10x"1b9", 10x"239", 10x"139", 10x"329", 10x"0b9", 10x"2a9", 10x"1a9", 10x"3a9",
+    10x"339", 10x"269", 10x"169", 10x"369", 10x"0e9", 10x"2e9", 10x"1e9", 10x"2b9",
+    10x"275", 10x"1d5", 10x"2d5", 10x"315", 10x"355", 10x"295", 10x"195", 10x"385",
+    10x"395", 10x"255", 10x"155", 10x"345", 10x"0d5", 10x"2c5", 10x"1c5", 10x"175",
+    10x"1b5", 10x"235", 10x"135", 10x"325", 10x"0b5", 10x"2a5", 10x"1a5", 10x"3a5",
+    10x"335", 10x"265", 10x"165", 10x"365", 10x"0e5", 10x"2e5", 10x"1e5", 10x"2b5",
+    10x"273", 10x"1d3", 10x"2d3", 10x"31c", 10x"353", 10x"29c", 10x"19c", 10x"38c",
+    10x"393", 10x"25c", 10x"15c", 10x"34c", 10x"0dc", 10x"2cc", 10x"1cc", 10x"173",
+    10x"1b3", 10x"23c", 10x"13c", 10x"32c", 10x"0bc", 10x"2ac", 10x"1ac", 10x"3a3",
+    10x"333", 10x"26c", 10x"16c", 10x"363", 10x"0ec", 10x"2e3", 10x"1e3", 10x"2b3",
+    10x"272", 10x"1d2", 10x"2d2", 10x"31d", 10x"352", 10x"29d", 10x"19d", 10x"38d",
+    10x"392", 10x"25d", 10x"15d", 10x"34d", 10x"0dd", 10x"2cd", 10x"1cd", 10x"172",
+    10x"1b2", 10x"23d", 10x"13d", 10x"32d", 10x"0bd", 10x"2ad", 10x"1ad", 10x"3a2",
+    10x"332", 10x"26d", 10x"16d", 10x"362", 10x"0ed", 10x"2e2", 10x"1e2", 10x"2b2",
+    10x"27a", 10x"1da", 10x"2da", 10x"31a", 10x"35a", 10x"29a", 10x"19a", 10x"38a",
+    10x"39a", 10x"25a", 10x"15a", 10x"34a", 10x"0da", 10x"2ca", 10x"1ca", 10x"17a",
+    10x"1ba", 10x"23a", 10x"13a", 10x"32a", 10x"0ba", 10x"2aa", 10x"1aa", 10x"3aa",
+    10x"33a", 10x"26a", 10x"16a", 10x"36a", 10x"0ea", 10x"2ea", 10x"1ea", 10x"2ba",
+    10x"276", 10x"1d6", 10x"2d6", 10x"316", 10x"356", 10x"296", 10x"196", 10x"386",
+    10x"396", 10x"256", 10x"156", 10x"346", 10x"0d6", 10x"2c6", 10x"1c6", 10x"176",
+    10x"1b6", 10x"236", 10x"136", 10x"326", 10x"0b6", 10x"2a6", 10x"1a6", 10x"3a6",
+    10x"336", 10x"266", 10x"166", 10x"366", 10x"0e6", 10x"2e6", 10x"1e6", 10x"2b6",
+    10x"271", 10x"1d1", 10x"2d1", 10x"31e", 10x"351", 10x"29e", 10x"19e", 10x"38e",
+    10x"391", 10x"25e", 10x"15e", 10x"34e", 10x"0de", 10x"2ce", 10x"1ce", 10x"171",
+    10x"1b1", 10x"237", 10x"137", 10x"32e", 10x"0b7", 10x"2ae", 10x"1ae", 10x"3a1",
+    10x"331", 10x"26e", 10x"16e", 10x"361", 10x"0ee", 10x"2e1", 10x"1e1", 10x"2b1");
+
+constant RD_PLUS : encode_lkup_table_t := (
+    10x"18b", 10x"22b", 10x"12b", 10x"314", 10x"0ab", 10x"294", 10x"194", 10x"074",
+    10x"06b", 10x"254", 10x"154", 10x"344", 10x"0d4", 10x"2c4", 10x"1c4", 10x"28b",
+    10x"24b", 10x"234", 10x"134", 10x"324", 10x"0b4", 10x"2a4", 10x"1a4", 10x"05b",
+    10x"0cb", 10x"264", 10x"164", 10x"09b", 10x"0e4", 10x"11b", 10x"21b", 10x"14b",
+    10x"189", 10x"229", 10x"129", 10x"319", 10x"0a9", 10x"299", 10x"199", 10x"079",
+    10x"069", 10x"259", 10x"159", 10x"349", 10x"0d9", 10x"2c9", 10x"1c9", 10x"289",
+    10x"249", 10x"239", 10x"139", 10x"329", 10x"0b9", 10x"2a9", 10x"1a9", 10x"059",
+    10x"0c9", 10x"269", 10x"169", 10x"099", 10x"0e9", 10x"119", 10x"219", 10x"149",
+    10x"185", 10x"225", 10x"125", 10x"315", 10x"0a5", 10x"295", 10x"195", 10x"075",
+    10x"065", 10x"255", 10x"155", 10x"345", 10x"0d5", 10x"2c5", 10x"1c5", 10x"285",
+    10x"245", 10x"235", 10x"135", 10x"325", 10x"0b5", 10x"2a5", 10x"1a5", 10x"055",
+    10x"0c5", 10x"265", 10x"165", 10x"095", 10x"0e5", 10x"115", 10x"215", 10x"145",
+    10x"18c", 10x"22c", 10x"12c", 10x"313", 10x"0ac", 10x"293", 10x"193", 10x"073",
+    10x"06c", 10x"253", 10x"153", 10x"343", 10x"0d3", 10x"2c3", 10x"1c3", 10x"28c",
+    10x"24c", 10x"233", 10x"133", 10x"323", 10x"0b3", 10x"2a3", 10x"1a3", 10x"05c",
+    10x"0cc", 10x"263", 10x"163", 10x"09c", 10x"0e3", 10x"11c", 10x"21c", 10x"14c",
+    10x"18d", 10x"22d", 10x"12d", 10x"312", 10x"0ad", 10x"292", 10x"192", 10x"072",
+    10x"06d", 10x"252", 10x"152", 10x"342", 10x"0d2", 10x"2c2", 10x"1c2", 10x"28d",
+    10x"24d", 10x"232", 10x"132", 10x"322", 10x"0b2", 10x"2a2", 10x"1a2", 10x"05d",
+    10x"0cd", 10x"262", 10x"162", 10x"09d", 10x"0e2", 10x"11d", 10x"21d", 10x"14d",
+    10x"18a", 10x"22a", 10x"12a", 10x"31a", 10x"0aa", 10x"29a", 10x"19a", 10x"07a",
+    10x"06a", 10x"25a", 10x"15a", 10x"34a", 10x"0da", 10x"2ca", 10x"1ca", 10x"28a",
+    10x"24a", 10x"23a", 10x"13a", 10x"32a", 10x"0ba", 10x"2aa", 10x"1aa", 10x"05a",
+    10x"0ca", 10x"26a", 10x"16a", 10x"09a", 10x"0ea", 10x"11a", 10x"21a", 10x"14a",
+    10x"186", 10x"226", 10x"126", 10x"316", 10x"0a6", 10x"296", 10x"196", 10x"076",
+    10x"066", 10x"256", 10x"156", 10x"346", 10x"0d6", 10x"2c6", 10x"1c6", 10x"286",
+    10x"246", 10x"236", 10x"136", 10x"326", 10x"0b6", 10x"2a6", 10x"1a6", 10x"056",
+    10x"0c6", 10x"266", 10x"166", 10x"096", 10x"0e6", 10x"116", 10x"216", 10x"146",
+    10x"18e", 10x"22e", 10x"12e", 10x"311", 10x"0ae", 10x"291", 10x"191", 10x"071",
+    10x"06e", 10x"251", 10x"151", 10x"348", 10x"0d1", 10x"2c8", 10x"1c8", 10x"28e",
+    10x"24e", 10x"231", 10x"131", 10x"321", 10x"0b1", 10x"2a1", 10x"1a1", 10x"05e",
+    10x"0ce", 10x"261", 10x"161", 10x"09e", 10x"0e1", 10x"11e", 10x"21e", 10x"14e");
+-- Note: this is only useful for simulation/test.  Use proper hardware 8b10b encoders
+-- for logic designs.  This function uses both the lookup arrays above and count_ones
+-- and count_zeros functions to determine the new disparity, and is not intended to be
+-- efficiently synthesized.
+function encode_data(
+    data_in : std_logic_vector(7 downto 0);
+    running_disparity : std_logic
+) return encoded_8b10b_t;
+
+function encode_k(
+    data_in : std_logic_vector(7 downto 0);
+    running_disparity : std_logic
+) return encoded_8b10b_t;
+
+end package;
+
+package body helper_8b10b_pkg is
+
+    function encode_data(
+        data_in : std_logic_vector(7 downto 0);
+        running_disparity : std_logic
+    ) return encoded_8b10b_t is
+        variable encoded : encoded_8b10b_t;
+        variable encoded_val : std_logic_vector(9 downto 0);
+    begin
+        if running_disparity = '0' then
+            encoded_val := RD_MINUS(to_integer(data_in));
+        else
+            encoded_val := RD_MINUS(to_integer(data_in));
+        end if;
+
+        encoded.data := encoded_val;
+        -- Now figure out the new disparity based on our chosen word
+        if count_ones(encoded_val) = count_zeros(encoded_val) then
+            encoded.disparity := running_disparity;  -- hold the same
+        else
+            encoded.disparity := not running_disparity;  -- flip
+        end if;
+        return encoded;
+    end function;
+
+    function encode_k(
+    data_in : std_logic_vector(7 downto 0);
+    running_disparity : std_logic
+) return encoded_8b10b_t is
+    variable encoded : encoded_8b10b_t;
+begin
+    encoded.disparity := running_disparity;  -- default to hold
+    case data_in is
+        when K28_0 =>
+            encoded.data := 10x"0f4" when running_disparity = '0' else 10x"30b";
+        when K28_1 =>
+            encoded.data := 10x"0f9" when running_disparity = '0' else 10x"306";
+            encoded.disparity := not encoded.disparity;
+        when K28_2 =>
+            encoded.data := 10x"0f5" when running_disparity = '0' else 10x"30a";
+            encoded.disparity := not encoded.disparity;
+        when K28_3 =>
+            encoded.data := 10x"0f3" when running_disparity = '0' else 10x"30c";
+            encoded.disparity := not encoded.disparity;
+        when K28_4 =>
+            encoded.data := 10x"0f2" when running_disparity = '0' else 10x"30d";
+        when K28_5 =>
+            encoded.data := 10x"0fa" when running_disparity = '0' else 10x"305";
+            encoded.disparity := not encoded.disparity;
+        when K28_6 =>
+            encoded.data := 10x"0f6" when running_disparity = '0' else 10x"309";
+            encoded.disparity := not encoded.disparity;
+        when K28_7 =>
+            encoded.data := 10x"0f8" when running_disparity = '0' else 10x"307";
+        when K23_7 =>
+            encoded.data := 10x"3a8" when running_disparity = '0' else 10x"057";
+        when K27_7 =>
+            encoded.data := 10x"368" when running_disparity = '0' else 10x"97";
+        when K29_7 =>
+            encoded.data := 10x"2e8" when running_disparity = '0' else 10x"117";
+        when K30_7 =>
+            encoded.data := 10x"1e8" when running_disparity = '0' else 10x"217";
+        when others =>
+            encoded.data := (others => '1');
+            assert false report "Can't encode invalid K character" severity error;
+    end case;
+    return encoded;
+end function;
+
+end package body;


### PR DESCRIPTION
based on chuck benz verilog example.

Added some helper functions which are expected to be useful for ignition simulations where this will be properly exercised, but this unit felt stand-alone enough to be it's own foundational PR.

Rather than build out a bunch of simulations for these blocks  (which are effectively just math functions) I'd  rather focus on integrating this stuff into a more useful ignition simulation and use those test  vehicles to be the ongoing tests of these modules.