### PR TITLE
Add crc8astar and some utility functions used by ignition

### DIFF
--- a/hdl/ip/vhd/common/utils/calc_pkg.vhd
+++ b/hdl/ip/vhd/common/utils/calc_pkg.vhd
@@ -49,9 +49,19 @@ package calc_pkg is
         byte_depth : natural
     ) return natural;
 
+    function num_bits_needed(value : natural) return positive;
+
+    function count_ones(value : std_logic_vector) return natural;
+    function count_zeros(value : std_logic_vector) return natural;
+
 end package;
 
 package body calc_pkg is
+
+    function num_bits_needed(value : natural) return positive is
+    begin
+        return log2ceil(value);
+    end function;
 
     function log2ceil (
         n : natural
@@ -112,5 +122,26 @@ package body calc_pkg is
     begin
         return log2ceil(byte_depth / (bit_width * 8));
     end;
+
+    function count_ones(value : std_logic_vector) return natural is
+        variable count : natural := 0;
+    begin
+        for i in value'range loop
+            if value(i) = '1' then
+                count := count + 1;
+            end if;
+        end loop;
+        return count;
+    end function;
+    function count_zeros(value : std_logic_vector) return natural is
+        variable count : natural := 0;
+    begin 
+        for i in value'range loop
+            if value(i) = '0' then
+                count := count + 1;
+            end if;
+        end loop;
+        return count;
+    end function;
 
 end package body;

--- a/hdl/ip/vhd/crc/BUCK
+++ b/hdl/ip/vhd/crc/BUCK
@@ -5,3 +5,9 @@ vhdl_unit(
     srcs = ["crc8atm_8wide.vhd"],
     visibility = ['PUBLIC']
 )
+
+vhdl_unit(
+    name = "crc8astar_8wide",
+    srcs = ["crc8astar_8wide.vhd"],
+    visibility = ['PUBLIC']
+)

--- a/hdl/ip/vhd/crc/BUCK
+++ b/hdl/ip/vhd/crc/BUCK
@@ -7,7 +7,7 @@ vhdl_unit(
 )
 
 vhdl_unit(
-    name = "crc8astar_8wide",
-    srcs = ["crc8astar_8wide.vhd"],
+    name = "crc8autostar_8wide",
+    srcs = ["crc8autostar_8wide.vhd"],
     visibility = ['PUBLIC']
 )

--- a/hdl/ip/vhd/crc/crc8astar_8wide.vhd
+++ b/hdl/ip/vhd/crc/crc8astar_8wide.vhd
@@ -1,0 +1,65 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+-- Copyright 2025 Oxide Computer Company
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use ieee.numeric_std_unsigned.all;
+
+-- An 8-wide parallel CRC LFSR implementation for the
+-- CRC8 ASTAR 0x2F CRC algorithm.
+-- The polynomial represented here is x^8+x^5+x^3+x^2+x+1 with
+-- a 1's seed value.
+
+entity crc8astar_8wide is
+    port (
+        clk     : in    std_logic;
+        reset   : in    std_logic;
+        data_in : in    std_logic_vector(7 downto 0);
+        enable  : in    std_logic;
+        clear   : in    std_logic;
+        crc_out : out   std_logic_vector(7 downto 0)
+    );
+end entity;
+
+architecture rtl of crc8astar_8wide is
+
+begin
+
+    crc_reg: process(clk, reset)
+    begin
+        if reset then
+            crc_out <= (others => '1');
+        elsif rising_edge(clk) then
+            -- This logic may run on a faster clock cycle than our shifter
+            -- so we allow the external logic to clock faster and use the
+            -- enable and clear to control when we do the shifts.
+            if clear then
+                crc_out <= (others => '1');
+            elsif enable then
+                -- This equation is created by unrolling 8 shifts of the
+                -- LFSR.
+                crc_out(0) <= crc_out(0) xor crc_out(3) xor crc_out(5) xor crc_out(7) xor 
+                              data_in(0) xor data_in(3) xor data_in(5) xor data_in(7);
+                crc_out(1) <= crc_out(0) xor crc_out(1) xor crc_out(3) xor crc_out(4) xor crc_out(5) xor crc_out(6) xor crc_out(7) xor
+                              data_in(0) xor data_in(1) xor data_in(3) xor data_in(4) xor data_in(5) xor data_in(6) xor data_in(7);
+                crc_out(2) <= crc_out(0) xor crc_out(1) xor crc_out(2) xor crc_out(3) xor crc_out(4) xor crc_out(6) xor
+                              data_in(0) xor data_in(1) xor data_in(2) xor data_in(3) xor data_in(4) xor data_in(6);
+                crc_out(3) <= crc_out(0) xor crc_out(1) xor crc_out(2) xor crc_out(4) xor 
+                              data_in(0) xor data_in(1) xor data_in(2) xor data_in(4) xor data_in(5);
+                crc_out(4) <= crc_out(1) xor crc_out(2) xor crc_out(3) xor crc_out(5) xor 
+                              data_in(1) xor data_in(2) xor data_in(3) xor data_in(5); 
+                crc_out(5) <= crc_out(0) xor crc_out(2) xor crc_out(4) xor crc_out(5) xor crc_out(6) xor crc_out(7) xor 
+                              data_in(0) xor data_in(2) xor data_in(4) xor data_in(5) xor data_in(6) xor data_in(7);
+                crc_out(6) <= crc_out(1) xor crc_out(3) xor crc_out(5) xor crc_out(6) xor crc_out(7) xor 
+                              data_in(1) xor data_in(3) xor data_in(5) xor data_in(6) xor data_in(7);
+                crc_out(7) <= crc_out(2) xor crc_out(4) xor crc_out(6) xor crc_out(7) xor 
+                              data_in(2) xor data_in(4) xor data_in(6) xor data_in(7);
+            end if;
+        end if;
+    end process;
+
+end rtl;

--- a/hdl/ip/vhd/crc/crc8autostar_8wide.vhd
+++ b/hdl/ip/vhd/crc/crc8autostar_8wide.vhd
@@ -10,11 +10,11 @@ use ieee.numeric_std.all;
 use ieee.numeric_std_unsigned.all;
 
 -- An 8-wide parallel CRC LFSR implementation for the
--- CRC8 ASTAR 0x2F CRC algorithm.
+-- CRC8 AUTOSTAR 0x2F CRC algorithm.
 -- The polynomial represented here is x^8+x^5+x^3+x^2+x+1 with
 -- a 1's seed value.
 
-entity crc8astar_8wide is
+entity crc8autostar_8wide is
     port (
         clk     : in    std_logic;
         reset   : in    std_logic;
@@ -25,7 +25,7 @@ entity crc8astar_8wide is
     );
 end entity;
 
-architecture rtl of crc8astar_8wide is
+architecture rtl of crc8autostar_8wide is
 
 begin
 

--- a/tools/yosys.bzl
+++ b/tools/yosys.bzl
@@ -106,6 +106,8 @@ def ice40_nextpnr(ctx, yoys_providers):
     cmd.add("--json", yosys_json)
     cmd.add("--asc", asc.as_output())
     cmd.add("--log", next_pnr_log.as_output())
+    for nextpnr_arg in ctx.attrs.nextpnr_args:
+        cmd.add(nextpnr_arg)
 
     ctx.actions.run(cmd, category="next_pnr")
 
@@ -139,6 +141,10 @@ ice40_bitstream = rule(
         "family": attrs.string(doc="FPGA family"),
         "package": attrs.string(doc="Supported FPGA package"),
         "pinmap": attrs.source(doc="Pin constraints file *.pcf"),
+        "nextpnr_args": attrs.list(
+            attrs.string(doc="Nextpnr arguments"),
+            default=[],
+        ),
         "_yosys_gen": attrs.exec_dep(
                 doc="Generate a Vivado tcl for this project",
                 default="root//tools/yosys_gen:yosys_gen",


### PR DESCRIPTION
A couple  more mathy blocks that felt separate enough to PR to help prevent massive walls of PRs for ignition. This stuff will all eventually be integrated into ignition and tested there.

A minor update to the yosys/pnr BUCK interface to allow passing in arguments so that I can do sizing builds in yosys + friends w/o needing full pinout constraints. This is useful for testing synth designs to understand logic utilization.