### PR TITLE
Add control of ignition flash and creset to sequencer

### DIFF
--- a/hdl/projects/cosmo_seq/cosmo_seq_top.vhd
+++ b/hdl/projects/cosmo_seq/cosmo_seq_top.vhd
@@ -410,8 +410,6 @@ begin
     -- misc things tied:
     fpga1_to_fpga2_io <= (others => 'Z');
     fpga1_to_sp5_sys_reset_l <= 'Z';  -- We don't use this in product, external PU.
-    fpga1_to_ign_trgt_fpga_creset <= '0';  -- Disabled until we decide what to do with it
-    fpga1_to_sp_mux_ign_mux_sel <= '0';  -- Default until we decide what to do with it
     fpga1_to_sp_irq_l <= (others => '1');
     -- Enable various buffers when we're in A0:
     fpga1_espi0_cs_l_buff_oe_en_l <= '0' when sp5_seq_pins.pwr_good else 'Z';
@@ -654,7 +652,9 @@ begin
         nic_rails_pins => nic_rails,
         nic_seq_pins => nic_seq_pins,
         sp5_t6_power_en => sp5_t6_power_en,
-        sp5_t6_perst_l => sp5_t6_perst_l
+        sp5_t6_perst_l => sp5_t6_perst_l,
+        ignition_mux_sel => fpga1_to_sp_mux_ign_mux_sel,
+        ignition_creset => fpga1_to_ign_trgt_fpga_creset
     );
 
     -- early power related pins

--- a/hdl/projects/cosmo_seq/sequencer/sequencer_regs.rdl
+++ b/hdl/projects/cosmo_seq/sequencer/sequencer_regs.rdl
@@ -382,6 +382,17 @@ addrmap sequencer_regs {
             desc = "nic_pcie_clk_buff_oe_l live status, note: only valid when SP5 rails are up (From FPGA to buffer)";
         } nic_pcie_clk_buff_oe_l[1] = 1;
     } nic_overrides;
+
+     reg {
+        name = "ignition flash and reconfig control";
+        desc = "For debugging purposes, allows the sequencer to write to the ignition flash and reconfigure it. Turning this mux on isolates the front FPGA my muxing away from it";
+        field {
+            desc = "Ignition reconfigure trigger. This latches on once set since ignition should powercycle the IBC. Setting this bit results in an SP power-cycle";
+        } ignition_creset[1:1] = 0;
+        field {
+            desc = "Set to 1 to isolate front FPGA and be connected to ignition flash instead";
+        } mux_to_ignition[0:0] = 0;
+    } ignition_control;
     
 
 };

--- a/hdl/projects/cosmo_seq/sequencer/sp5_sequencer.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sp5_sequencer.vhd
@@ -52,6 +52,9 @@ entity sp5_sequencer is
         sp5_t6_power_en : in std_logic;
         sp5_t6_perst_l : in std_logic;
 
+        ignition_mux_sel : out std_logic;
+        ignition_creset : out std_logic;
+
 
     );
 end entity;
@@ -70,7 +73,6 @@ architecture rtl of sp5_sequencer is
     -- power ok means we're up and happy
     -- power idle means we're down and idle
     -- power not idle could mean we're in the middle of a sequence up or down
-    signal nic_ok : std_logic;
     signal nic_idle : std_logic;
     signal therm_trip : std_logic;
     signal early_power : early_power_t;
@@ -134,7 +136,9 @@ begin
         rails_en_rdbk => rails_en_rdbk,
         rails_pg_rdbk => rails_pg_rdbk,
         sp5_readbacks => sp5_readbacks,
-        nic_readbacks => nic_readbacks
+        nic_readbacks => nic_readbacks,
+        ignition_mux_sel => ignition_mux_sel,
+        ignition_creset => ignition_creset
     );
 
     -- control from hubris


### PR DESCRIPTION
Wire out control of flash mux and the ignition creset into the sequencer block for board functional verification.