### PR TITLE
Fix helper function encoded bit order

### DIFF
--- a/hdl/ip/vhd/8b10b/BUCK
+++ b/hdl/ip/vhd/8b10b/BUCK
@@ -5,6 +5,7 @@ vhdl_unit(
     srcs = glob(["helper_8b10b_pkg.vhd"]),
     deps = [
         "//hdl/ip/vhd/common:calc_pkg",
+        "//hdl/ip/vhd/common:transforms_pkg",
     ],
     standard = "2008",
     visibility = ['PUBLIC'],


### PR DESCRIPTION
Due to how the 8b10b algo works, most tables show the input (8b) in octal or hex with MSB 1st (HGF EDCBA) but show the encoded 10b version in LSB1st (abcdei fghj). Flipping the bit-order in the constants makes it more difficult to compare to tables for correctness, so I have left things in the encoded order, but changed the names and added comments to reflect that and then reversed the bit order before it's consumed.

Problems like this are extremely annoying to notice/debug so it's best to give ourselves the easiest time possible.

This also adds a helper function that will figure out control or non-control character encoding.