### PR TITLE
Make SP-console the default UART

### DIFF
--- a/hdl/projects/cosmo_seq/BUCK
+++ b/hdl/projects/cosmo_seq/BUCK
@@ -6,6 +6,7 @@ rdl_file(
     name = "cosmo_seq_top_rdl",
     src = "cosmo_seq_top.rdl",
     deps = [
+        "//hdl/projects/cosmo_seq/debug_module:debug_regs_rdl",
         "//hdl/projects/cosmo_seq/dimms_subsystem:dimm_regs_rdl",
         "//hdl/ip/vhd/info:info_regs_rdl",
         "//hdl/projects/cosmo_seq/sp_i2c_subsystem:sp_i2c_regs_rdl",
@@ -60,6 +61,7 @@ vhdl_unit(
         "//hdl/projects/cosmo_seq/sp_i2c_subsystem:sp_i2c_subsystem",
         "//hdl/projects/cosmo_seq/sp5_hotplug_subsystem:sp5_hotplug_subsystem",
         "//hdl/projects/cosmo_seq/dimms_subsystem:dimms_subsystem_top",
+        "//hdl/projects/cosmo_seq/debug_module:debug_module_top",
     ],
     standard = "2019",
 )

--- a/hdl/projects/cosmo_seq/cosmo_seq_top.rdl
+++ b/hdl/projects/cosmo_seq/cosmo_seq_top.rdl
@@ -19,4 +19,5 @@ addrmap cosmo_seq_top {
     sp_i2c_regs sp_i2c @ 0x0400;
     pca9506_axi_regs fpga1_hotplug @ 0x0500;
     spd_proxy_regs spd_proxy @ 0x0600;
+    debug_regs debug_ctrl @ 0x0700;
 };

--- a/hdl/projects/cosmo_seq/debug_module/BUCK
+++ b/hdl/projects/cosmo_seq/debug_module/BUCK
@@ -1,0 +1,24 @@
+load("//tools:hdl.bzl", "vhdl_unit", "vunit_sim")
+load("//tools:rdl.bzl", "rdl_file")
+
+rdl_file(
+    name = "debug_regs_rdl",
+    src = "debug_regs.rdl",
+    outputs = [
+        "debug_regs_pkg.vhd", 
+        "debug_regs.html", 
+        "debug_regs.json",
+    ],
+    visibility = ["PUBLIC"],
+)
+
+vhdl_unit(
+    name = "debug_module_top",
+    srcs = glob(["*.vhd"]),
+    deps = [
+        ":debug_regs_rdl",
+        "//hdl/ip/vhd/axi_blocks:axilite_if_2k19",
+    ],
+    visibility = ["PUBLIC"],
+    standard = "2019",
+)

--- a/hdl/projects/cosmo_seq/debug_module/debug_module_top.vhd
+++ b/hdl/projects/cosmo_seq/debug_module/debug_module_top.vhd
@@ -1,0 +1,91 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+-- Copyright 2025 Oxide Computer Company
+
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use ieee.numeric_std_unsigned.all;
+
+use work.axil8x32_pkg.all;
+
+use work.debug_regs_pkg.all;
+
+entity debug_module_top is
+    port (
+        clk : in std_logic;
+        reset : in std_logic;
+
+        axi_if : view axil_target;
+
+        dbg_uart_control : out uart_control_type
+
+    );
+end entity;
+
+architecture rtl of debug_module_top is
+    signal rdata : std_logic_vector(31 downto 0);
+    signal active_read : std_logic;
+    signal active_write : std_logic;
+begin
+
+     axil_target_txn_inst: entity work.axil_target_txn
+     port map(
+        clk => clk,
+        reset => reset,
+        arvalid => axi_if.read_address.valid,
+        arready => axi_if.read_address.ready,
+        awvalid => axi_if.write_address.valid,
+        awready => axi_if.write_address.ready,
+        wvalid => axi_if.write_data.valid,
+        wready => axi_if.write_data.ready,
+        bvalid => axi_if.write_response.valid,
+        bready => axi_if.write_response.ready,
+        bresp => axi_if.write_response.resp,
+        rvalid => axi_if.read_data.valid,
+        rready => axi_if.read_data.ready,
+        rresp => axi_if.read_data.resp,
+        active_read => active_read,
+        active_write => active_write
+    );
+    axi_if.read_data.data <= rdata;
+
+    write_logic: process(clk, reset)
+    begin
+        if reset then
+            dbg_uart_control <= rec_reset;
+
+        elsif rising_edge(clk) then
+
+            if active_write then
+                case to_integer(axi_if.write_address.addr) is
+                    when UART_CONTROL_OFFSET => dbg_uart_control <= unpack(axi_if.write_data.data);
+                    when others => null;
+                end case;
+            end if;
+
+        end if;
+    end process;
+
+    
+
+    read_logic: process(clk, reset)
+    begin
+        if reset then
+            rdata <= (others => '0');
+        elsif rising_edge(clk) then
+            if active_read then
+                case to_integer(axi_if.read_address.addr) is
+                    when UART_CONTROL_OFFSET => rdata <= pack(dbg_uart_control);
+                    when others => rdata <= (others => '0');
+                end case;
+            end if;
+
+        end if;
+    end process;
+
+
+end rtl;

--- a/hdl/projects/cosmo_seq/debug_module/debug_regs.rdl
+++ b/hdl/projects/cosmo_seq/debug_module/debug_regs.rdl
@@ -1,0 +1,22 @@
+// Copyright 2025 Oxide Computer Company
+// This is SystemRDL description of the sw-accessible registers in the Cosmo
+// Debug Control FPGA block.
+
+addrmap debug_regs {
+    name = "Cosmo Debug Control block";
+    desc = "";
+
+    default regwidth = 32;
+    default sw = rw;
+    default hw = r;
+ 
+    reg {
+           name = "UART Debug Control";
+           field {
+               desc = "Set to 1 to send the SP5's console UART out the UART debug header. By default
+               this is muxed to the SP's console UART, setting this takes the data away from the SP and 
+               sends it out the debug header with flow control.";
+           } sp5_to_header[0:0] = 0;
+       } uart_control;
+
+};


### PR DESCRIPTION
Previously, we defaulted to shoving the SP5 uart data out the debug header. That presented challenges with the mfg stations where a uart dongle isn't necessarily connected leading to a wedge due to hardware-handshake.  This makes the default the  SP which will keep the buffer clear (like it does on gimlet) and we have a new memory mapped peripheral to flip the mux back to the debug headers if we need it.

This lays the groundwork for additional debug control of various things which we may want eventually also.

I booted this on my cosmo, and once booted I could use the `humility console-proxy attach` command to get proper uart coms. This verified that we don't wedge during boot and the the sp-console-proxy is working as expected.