### PR TITLE
add register to allow hubris to control whether we emit backplane PCIE clock when something is connected.

### DIFF
--- a/hdl/ip/vhd/uart/fifo_uart/axi_fifo_st_uart.vhd
+++ b/hdl/ip/vhd/uart/fifo_uart/axi_fifo_st_uart.vhd
@@ -26,11 +26,25 @@ entity axi_fifo_st_uart is
     reset : in std_logic;
 
     -- UART interface
+    -- We have a couple of special cases here to deal with various power states and muxes.
+    -- We have a case where we'd like to disallow rx of data *and* deassert rts to indicate this.
+    --  Example: SP <-> SP5 console UART, we should not be ready to RX data until in the A0 domain for example.
+    -- We also have a case where we want to drop rx data silently, but not deassert rts.
+    --  Example: SP <-> SP5 console UART, but UART is muxed away from the SP and to a debug header.
+    --  In this case, we don't want to pool data in the FIFO from the SP or the SP5, but we also don't 
+    --  want to backpressure the SP here.
+    drop_silently : in std_logic := '0'; -- If set, the UART will drop rx data but not deassert rts
     allow_rx : in std_logic := '1'; -- Some configurations may want to not rx data until ready
     rx_pin : in std_logic;
     tx_pin : out std_logic;
     rts_pin : out std_logic;
     cts_pin : in std_logic;
+
+    -- Sideband signals
+    uart_to_axi_fifo_usedwds : out std_logic_vector(log2ceil(fifo_depth) downto 0);
+    axi_to_uart_fifo_usedwds : out std_logic_vector(log2ceil(fifo_depth) downto 0);
+    uart_rts_pin_copy : out std_logic; -- copy of the rts pin, for debug purposes
+    uart_cts_pin_copy : out std_logic; -- copy of the cts pin, for debug purposes
 
     -- AXI streaming interface
     axi_clk : in std_logic;
@@ -67,8 +81,8 @@ begin
     async_input => cts_pin,
     clk => clk,
     sycnd_output => cts_pin_syncd
-); 
-
+);
+uart_cts_pin_copy <= cts_pin_syncd;
 
   -- Actual UART serdes block
   axi_st_uart_inst: entity work.axi_st_uart
@@ -81,7 +95,7 @@ begin
       reset => reset,
       rx_pin => rx_pin,
       tx_pin => tx_pin,
-      allowed_to_sample => allow_rx,
+      allowed_to_sample => allow_rx and (not drop_silently),
       rx_data => pre_fifo_rx_data,
       rx_valid => pre_fifo_rx_valid,
       tx_data => tx_fifo_rdata,
@@ -111,6 +125,8 @@ begin
       rempty => rx_fifo_rempty,
       rusedwds => open
   );
+  uart_to_axi_fifo_usedwds <= std_logic_vector(rx_wusedwds);
+  uart_rts_pin_copy <= rts_pin;
   rx_valid <= not rx_fifo_rempty;
   -- hw handshake, de-assert when we run low on rx fifo space or when we're not allowing rx
   rts_pin <= '0' when (rx_wusedwds < full_threshold) and allow_rx = '1' else '1';
@@ -138,7 +154,7 @@ begin
       rdata => tx_fifo_rdata,
       rdreq => uart_tx_valid and uart_tx_ready,
       rempty => tx_fifo_rempty,
-      rusedwds => open
+      rusedwds => axi_to_uart_fifo_usedwds
   );
 
   tx_ready <= not tx_fifo_wfull;

--- a/hdl/projects/cosmo_seq/cosmo_seq_top.vhd
+++ b/hdl/projects/cosmo_seq/cosmo_seq_top.vhd
@@ -389,6 +389,7 @@ architecture rtl of cosmo_seq_top is
     signal fpga2_hp_irq_n : std_logic;
     alias a0_ok_to_fpga2 : std_logic is fpga1_to_fpga2_io(2);
     signal uart_dbg_if : uart_dbg_t;
+    signal allow_backplane_pcie_clk : std_logic;
 
 begin
 
@@ -584,6 +585,7 @@ begin
         clk => clk_125m,
         reset => reset_125m,
         axi_if => responders(SP5_HP_RESP_IDX),
+        allow_backplane_pcie_clk => allow_backplane_pcie_clk,
         sp5_i2c_sda => i2c_sp5_to_fpgax_hp_sda,
         sp5_i2c_sda_o => sp5_sda_o,
         sp5_i2c_sda_oe => sp5_sda_oe,
@@ -637,6 +639,7 @@ begin
         axi_if => responders(SEQ_RESP_IDX),
         a0_ok => a0_ok,
         a0_idle => a0_idle,
+        allow_backplane_pcie_clk => allow_backplane_pcie_clk,
         early_power_pins => early_power,
         ddr_bulk_pins => ddr_bulk,
         group_a_pins => sp5_group_a,

--- a/hdl/projects/cosmo_seq/cosmo_seq_top.vhd
+++ b/hdl/projects/cosmo_seq/cosmo_seq_top.vhd
@@ -21,7 +21,7 @@ use work.time_pkg.all;
 use work.tristate_if_pkg.all;
 
 use work.sequencer_io_pkg.all;
-use work.debug_regs_pkg.all;
+use work.sp5_uart_subsystem_pkg.all;
 
 entity cosmo_seq_top is
     port (
@@ -388,7 +388,7 @@ architecture rtl of cosmo_seq_top is
     alias fpga2_hp_irq_n_unsyncd : std_logic is fpga2_to_fpga1_io(2);
     signal fpga2_hp_irq_n : std_logic;
     alias a0_ok_to_fpga2 : std_logic is fpga1_to_fpga2_io(2);
-    signal dbg_uart_control : uart_control_type;
+    signal uart_dbg_if : uart_dbg_t;
 
 begin
 
@@ -425,19 +425,6 @@ begin
     uart1_fpga1_to_sp5_dat_buff <= '1';  -- Make this idle generally, buffer protects from cross-drive
     i3c_sp5_to_fpga1_oe_l <= '0' when  sp5_seq_pins.pwr_good else '1';
     i3c_fpga1_to_dimm_oe_l <= '0' when  sp5_seq_pins.pwr_good else '1';
-
-    -- hdt_fpga1_to_mux_en_l <= 'Z';
-    -- hdt_fpga1_to_mux_sel <= '0';
-
-    -- hdt_conn_to_mux_testen <= '0';
-    -- hdt_fpga1_to_mux_dat <= '1' when sp5_group_a.v1p8_sp5_a1.enable = '1' else '0';
-    -- hdt_fpga1_to_mux_dbreq_l <= '1' when sp5_group_a.v1p8_sp5_a1.enable = '1' else '0';
-    -- hdt_fpga1_to_mux_tck <= sp5_group_a.v1p8_sp5_a1.enable;
-    -- hdt_fpga1_to_mux_tms <= '1' when sp5_group_a.v1p8_sp5_a1.enable = '1' else '0';
-    -- hdt_fpga1_to_mux_trst_l <= '1' when sp5_group_a.v1p8_sp5_a1.enable = '1' else '0';
-    -- hdt_fpga1_to_mux_xtrig5_l  <= 'Z';
-    -- hdt_fpga1_to_mux_xtrig6_l <= 'Z';
-    -- hdt_fpga1_to_mux_xtrig7_l  <= 'Z';
 
     ---------------------------------------------
     -- FMC to AXI Interface from the SP
@@ -536,7 +523,7 @@ begin
      port map(
         clk => clk_125m,
         reset => reset_125m,
-        dbg_uart_control => dbg_uart_control,
+        dbg_if => uart_dbg_if,
         in_a0 => a0_ok,
         -- UART pins
         -- IPCC SP side
@@ -788,7 +775,7 @@ begin
         clk => clk_125m,
         reset => reset_125m,
         axi_if => responders(DBG_CTRL_RESP_IDX),
-        dbg_uart_control => dbg_uart_control
+        uart_dbg_if => uart_dbg_if
     );
 
 

--- a/hdl/projects/cosmo_seq/cosmo_seq_top.vhd
+++ b/hdl/projects/cosmo_seq/cosmo_seq_top.vhd
@@ -775,6 +775,8 @@ begin
         clk => clk_125m,
         reset => reset_125m,
         axi_if => responders(DBG_CTRL_RESP_IDX),
+        in_a0 => a0_ok,
+        sp5_debug2_pin => sp5_to_fpga1_debug2,
         uart_dbg_if => uart_dbg_if
     );
 

--- a/hdl/projects/cosmo_seq/debug_module/BUCK
+++ b/hdl/projects/cosmo_seq/debug_module/BUCK
@@ -18,6 +18,7 @@ vhdl_unit(
     deps = [
         ":debug_regs_rdl",
         "//hdl/ip/vhd/axi_blocks:axilite_if_2k19",
+        "//hdl/projects/cosmo_seq/sp5_uart_subsystem:sp5_uart_subsystem",
     ],
     visibility = ["PUBLIC"],
     standard = "2019",

--- a/hdl/projects/cosmo_seq/debug_module/debug_module_top.vhd
+++ b/hdl/projects/cosmo_seq/debug_module/debug_module_top.vhd
@@ -13,6 +13,7 @@ use ieee.numeric_std_unsigned.all;
 use work.axil8x32_pkg.all;
 
 use work.debug_regs_pkg.all;
+use work.sp5_uart_subsystem_pkg.all;
 
 entity debug_module_top is
     port (
@@ -21,7 +22,7 @@ entity debug_module_top is
 
         axi_if : view axil_target;
 
-        dbg_uart_control : out uart_control_type
+        uart_dbg_if : view uart_dbg_dbg_if
 
     );
 end entity;
@@ -30,7 +31,18 @@ architecture rtl of debug_module_top is
     signal rdata : std_logic_vector(31 downto 0);
     signal active_read : std_logic;
     signal active_write : std_logic;
+    signal dbg_uart_control : uart_control_type;
+    signal uart_pin_status: uart_pin_status_type;
 begin
+
+    -- Assign the output(s):
+    uart_dbg_if.sp5_console_uart_to_header <= dbg_uart_control.sp5_to_header;
+    uart_pin_status.ipcc_sp_cts_l <= uart_dbg_if.sp_uart1.uart_cts_pin_copy; -- (to SP pins, output from FPGA)
+    uart_pin_status.ipcc_sp_rts_l <= uart_dbg_if.sp_uart1.uart_rts_pin_copy; -- (from SP pins, input to FPGA)
+    uart_pin_status.console_sp_rts_l <= uart_dbg_if.sp_uart0.uart_rts_pin_copy; -- (from SP pins, input to FPGA)
+    uart_pin_status.console_sp_cts_l <= uart_dbg_if.sp_uart0.uart_cts_pin_copy; -- (to SP pins, output from FPGA);
+    uart_pin_status.console_sp5_rts_l <= uart_dbg_if.host_uart0.uart_rts_pin_copy; -- (from SP5 pins, input to FPGA)
+    uart_pin_status.console_sp5_cts_l <= uart_dbg_if.host_uart0.uart_cts_pin_copy; -- (to SP5 pins, output from FPGA)
 
      axil_target_txn_inst: entity work.axil_target_txn
      port map(
@@ -80,6 +92,13 @@ begin
             if active_read then
                 case to_integer(axi_if.read_address.addr) is
                     when UART_CONTROL_OFFSET => rdata <= pack(dbg_uart_control);
+                    when SP_AXI_TO_CONSOLE_UART_USEDWDS_OFFSET => rdata <= resize(uart_dbg_if.sp_uart0.axi_to_uart_fifo_usedwds, 32);
+                    when SP_CONSOLE_UART_TO_AXI_USEDWDS_OFFSET => rdata <= resize(uart_dbg_if.sp_uart0.uart_to_axi_fifo_usedwds, 32);
+                    when SP5_AXI_TO_CONSOLE_UART_USEDWDS_OFFSET => rdata <= resize(uart_dbg_if.host_uart0.axi_to_uart_fifo_usedwds, 32);
+                    when SP5_CONSOLE_UART_TO_AXI_USEDWDS_OFFSET => rdata <= resize(uart_dbg_if.host_uart0.uart_to_axi_fifo_usedwds, 32);
+                    when SP5_AXI_TO_IPCC_UART_USEDWDS_OFFSET => rdata <= resize(uart_dbg_if.sp_uart1.axi_to_uart_fifo_usedwds, 32);
+                    when SP5_IPCC_UART_TO_AXI_USEDWDS_OFFSET => rdata <= resize(uart_dbg_if.sp_uart1.uart_to_axi_fifo_usedwds, 32);
+                    --when CONSOLE_UART_PIN_STATUS_OFFSET : integer := 20;
                     when others => rdata <= (others => '0');
                 end case;
             end if;

--- a/hdl/projects/cosmo_seq/debug_module/debug_regs.rdl
+++ b/hdl/projects/cosmo_seq/debug_module/debug_regs.rdl
@@ -95,4 +95,16 @@ addrmap debug_regs {
           } usedwds[7:0] = 0;
       } sp5_ipcc_uart_to_axi_usedwds;
 
+    reg {
+        name = "SP5 DBG2 toggle counter";
+        field {
+            desc = "Saturating u32 counter that counts the number of times the SP5 DBG2 pin has toggled in this a0 power cycle. ";
+        } cnts[31:0] = 0;
+    } sp5_dbg2_toggle_counter;
+    reg {
+        name = "SP5 DBG2 toggle timer";
+        field {
+            desc = "Saturating u32 counter that counts the number 8ns clock cycles since last SP5 DBG2 pin toggle in this a0 power cycle.";
+        } cnts[31:0] = 0;
+    } sp5_dbg2_toggle_timer;
 };

--- a/hdl/projects/cosmo_seq/debug_module/debug_regs.rdl
+++ b/hdl/projects/cosmo_seq/debug_module/debug_regs.rdl
@@ -3,7 +3,7 @@
 // Debug Control FPGA block.
 
 addrmap debug_regs {
-    name = "Cosmo Debug Control block";
+    name = "Cosmo Debug Control/Status block";
     desc = "";
 
     default regwidth = 32;
@@ -18,5 +18,81 @@ addrmap debug_regs {
                sends it out the debug header with flow control.";
            } sp5_to_header[0:0] = 0;
        } uart_control;
+
+    reg {
+           name = "SP Console UART (AXI->UART) FIFO USEDWDS Status";
+           field {
+               desc = "Number of FIFO bytes pending transmit *to* the SP, should stay near 0 when the SP is
+               receiving bytes at a reasonable rate. This is effectively 1/2 the buffer in this flow as the
+               UART to the SP5 also has a FIFO.";
+           } usedwds[7:0] = 0;
+       } sp_axi_to_console_uart_usedwds;
+    
+    reg {
+          name = "SP Console UART (UART->AXI) FIFO USEDWDS Status";
+          field {
+              desc = "Number of FIFO bytes pending transmit *to* the SP5, should stay near 0 when the SP5 is
+              receiving bytes at a reasonable rate. This is effectively 1/2 the buffer in this flow as the
+              UART to the SP5 also has a FIFO.";
+          } usedwds[7:0] = 0;
+      } sp_console_uart_to_axi_usedwds;
+
+    reg {
+           name = "SP5 Console UART (AXI->UART) FIFO USEDWDS Status";
+           field {
+               desc = "Number of FIFO bytes pending transmit *to* the SP5, should stay near 0 when the SP5 is
+               receiving bytes at a reasonable rate. This is effectively 1/2 the buffer in this flow as the
+               UART to the SP also has a FIFO.";
+           } usedwds[7:0] = 0;
+       } sp5_axi_to_console_uart_usedwds;
+    
+    reg {
+          name = "SP5 Console UART (UART->AXI) FIFO USEDWDS Status";
+          field {
+              desc = "Number of FIFO bytes pending transmit *to* the SP, should stay near 0 when the SP is
+              receiving bytes at a reasonable rate. This is effectively 1/2 the buffer in this flow as the
+              UART to the SP also has a FIFO.";
+          } usedwds[7:0] = 0;
+      } sp5_console_uart_to_axi_usedwds;
+    
+    reg {
+        name = "Live status of the various hw handshake signals for the respective UART:";
+
+        field {
+            desc = "SP ipcc UART RTS_L (from SP pins, input to FPGA)";
+        } ipcc_sp_rts_l[9:9] = 0;
+        field {
+            desc = "SP ipcc UART CTS_L (from SP pins, input to FPGA)";
+        } ipcc_sp_cts_l[8:8] = 0;
+        field {
+            desc = "SP console UART RTS_L (from SP pins, input to FPGA)";
+        } console_sp_rts_l[5:5] = 0;
+        field {
+            desc = "SP console UART CTS_L (to SP5 pins, output from FPGA)";
+        } console_sp_cts_l[4:4] = 0;
+        field {
+            desc = "SP5 console UART RTS_L (from SP5 pins, input to FPGA)";
+        } console_sp5_rts_l[1:1] = 0;
+        field {
+            desc = "SP5 console UART CTS_L (to SP5 pins, output from FPGA)";
+        } console_sp5_cts_l[0:0] = 0;
+
+    } uart_pin_status;
+
+    reg {
+           name = "SP IPCC UART (AXI->UART) FIFO USEDWDS Status";
+           field {
+               desc = "Number of FIFO bytes pending transmit *to* the SP, should stay near 0 when the SP is
+               receiving bytes at a reasonable rate (from SP5 over eSPI).";
+           } usedwds[7:0] = 0;
+       } sp5_axi_to_ipcc_uart_usedwds;
+    
+    reg {
+          name = "SP IPCC UART (UART->AXI) FIFO USEDWDS Status";
+          field {
+              desc = "Number of FIFO bytes pending transmit *to* the SP5, should average near 0 when the SP5 is
+              receiving bytes at a reasonable rate, but is bursty over eSPI.";
+          } usedwds[7:0] = 0;
+      } sp5_ipcc_uart_to_axi_usedwds;
 
 };

--- a/hdl/projects/cosmo_seq/sequencer/sequencer_regs.rdl
+++ b/hdl/projects/cosmo_seq/sequencer/sequencer_regs.rdl
@@ -394,6 +394,16 @@ addrmap sequencer_regs {
         } mux_to_ignition[0:0] = 0;
     } ignition_control;
     
+    reg {
+        name = "PCIe Backplane Clock Control";
+        desc = "Control over the PCIe backplane clock. Normally we use SRIS on this interface in the rack, but for
+        minibar configs we need to drive a clock. Allow Hubris to control whether this clock is driven when something
+        is attached.";
+
+        field {
+            desc = "Enable the PCIe backplane clock. (Still gated by presence)";
+        } clk_en[0:0] = 0;
+    } pcie_clk_ctrl;
 
 };
    

--- a/hdl/projects/cosmo_seq/sequencer/sp5_sequencer.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sp5_sequencer.vhd
@@ -48,6 +48,7 @@ entity sp5_sequencer is
         nic_rails_pins : view nic_power_at_fpga;
         -- nic sequencing I/O
         nic_seq_pins: view nic_seq_at_fpga;
+        allow_backplane_pcie_clk : out std_logic;
 
         sp5_t6_power_en : in std_logic;
         sp5_t6_perst_l : in std_logic;
@@ -122,6 +123,7 @@ begin
         clk => clk,
         reset => reset,
         axi_if => axi_if,
+        allow_backplane_pcie_clk => allow_backplane_pcie_clk,
         early_power_ctrl => early_power_ctrl,
         early_power_rdbks => early_power_rdbks,
         power_ctrl => power_ctrl,

--- a/hdl/projects/cosmo_seq/sp5_hotplug_subsystem/sp5_hotplug_subsystem.vhd
+++ b/hdl/projects/cosmo_seq/sp5_hotplug_subsystem/sp5_hotplug_subsystem.vhd
@@ -33,6 +33,7 @@ entity sp5_hotplug_subsystem is
         a0_ok : in std_logic;
 
         axi_if : view axil_target;
+        allow_backplane_pcie_clk : in std_logic;
 
         -- M.2 things
         --m.2a
@@ -200,7 +201,11 @@ begin
     io(3)(3) <= '1';  -- PEDET for T6
     io(3)(1) <= '1'; -- TODO: power fault l
     io(3)(2) <= '1'; -- attnsw_l
-    pcie_clk_buff_rsw_oe_l <= pcie_aux_rsw_prsnt_buff_l;  -- Is this right?
+
+    -- Pass through presence, but gate it by hubris control over whether we drive this or not.
+    -- This is so that we don't send the clock into the backplane when in a rack, we don't need
+    -- it and it's bad for EMC.
+    pcie_clk_buff_rsw_oe_l <= pcie_aux_rsw_prsnt_buff_l when allow_backplane_pcie_clk else '1';
 
 
 

--- a/hdl/projects/cosmo_seq/sp5_uart_subsystem/BUCK
+++ b/hdl/projects/cosmo_seq/sp5_uart_subsystem/BUCK
@@ -3,7 +3,8 @@ load("//tools:rdl.bzl", "rdl_file")
 
 vhdl_unit(
     name = "sp5_uart_subsystem",
-    srcs = ["sp5_uart_subsystem.vhd",
+    srcs = glob(["*.vhd"]),
+    deps = [
         "//hdl/ip/vhd/uart:axi_fifo_uart",
         "//hdl/ip/vhd/axi_blocks:axist_if_2k19_pkg",
     ],

--- a/hdl/projects/cosmo_seq/sp5_uart_subsystem/sp5_uart_subsystem_pkg.vhd
+++ b/hdl/projects/cosmo_seq/sp5_uart_subsystem/sp5_uart_subsystem_pkg.vhd
@@ -1,0 +1,62 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+-- Copyright 2025 Oxide Computer Company
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+use work.calc_pkg.all;
+
+package sp5_uart_subsystem_pkg is
+
+    constant CONSOLE_FIFO_DEPTH : integer := 256; -- FIFO depth for UARTs
+    constant IPCC_FIFO_DEPTH : integer := 4096; -- FIFO depth for IPCC UART
+
+    -- To the debug interface
+    type console_uart_dbg_t is record
+        uart_to_axi_fifo_usedwds : std_logic_vector(log2ceil(CONSOLE_FIFO_DEPTH) downto 0);
+        axi_to_uart_fifo_usedwds : std_logic_vector(log2ceil(CONSOLE_FIFO_DEPTH) downto 0);
+        uart_rts_pin_copy : std_logic;
+        uart_cts_pin_copy : std_logic; 
+    end record;
+    view console_uart_ss of console_uart_dbg_t is
+        uart_to_axi_fifo_usedwds : out;
+        axi_to_uart_fifo_usedwds : out;
+        uart_rts_pin_copy : out;
+        uart_cts_pin_copy : out; 
+    end view;
+    alias console_uart_dbg is console_uart_ss'converse;
+
+    type ipcc_uart_dbg_t is record
+        uart_to_axi_fifo_usedwds : std_logic_vector(log2ceil(IPCC_FIFO_DEPTH) downto 0);
+        axi_to_uart_fifo_usedwds : std_logic_vector(log2ceil(IPCC_FIFO_DEPTH) downto 0);
+        uart_rts_pin_copy : std_logic;
+        uart_cts_pin_copy : std_logic; 
+    end record;
+    view ipcc_uart1_ss of ipcc_uart_dbg_t is
+        uart_to_axi_fifo_usedwds : out;
+        axi_to_uart_fifo_usedwds : out;
+        uart_rts_pin_copy : out;
+        uart_cts_pin_copy : out; 
+    end view;
+    alias ipcc_uart1_dbg is ipcc_uart1_ss'converse;
+
+    -- Now wrap all of that up into one big record
+    type uart_dbg_t is record
+        sp5_console_uart_to_header : std_logic;
+        sp_uart0 : console_uart_dbg_t;
+        host_uart0 : console_uart_dbg_t;
+        sp_uart1 : ipcc_uart_dbg_t;
+    end record;
+    view uart_dbg_ss_if of uart_dbg_t is
+        sp5_console_uart_to_header : out;
+        sp_uart0 : view console_uart_ss;
+        host_uart0 : view console_uart_ss;
+        sp_uart1 : view ipcc_uart1_ss;
+    end view;
+    alias uart_dbg_dbg_if is uart_dbg_ss_if'converse;
+
+end package;


### PR DESCRIPTION
We're going to let lab images enable this in an upcoming PR so minibar nics will work but we don't transmit the pcie clock out the back any time a sidecar is connected.

This also includes previously un-merged UART debug that doesn't really  affect anything functionally but is there for getting some more info out of the box for the host os team.