### PR TITLE
Better modularize the debug header

### DIFF
--- a/hdl/projects/cosmo_seq/cosmo_seq_top.vhd
+++ b/hdl/projects/cosmo_seq/cosmo_seq_top.vhd
@@ -399,20 +399,6 @@ begin
         clk => clk_125m,
         sycnd_output => fpga2_hp_irq_n
     );
-
-    espi_dbg: process(clk_200m, reset_200m)
-    begin
-        if rising_edge(clk_200m) then
-            fpga1_spare_v1p8(0) <= uart0_sp_to_fpga1_dat;
-            fpga1_spare_v1p8(7) <= uart0_fpga1_to_sp5_dat_buff;
-            fpga1_spare_v1p8(6) <= amd_hp_irq_n_final;
-            fpga1_spare_v1p8(1) <= espi0_sp5_to_fpga1_clk;
-            fpga1_spare_v1p8(2) <= espi0_sp5_to_fpga1_cs_l;
-            fpga1_spare_v1p8(3) <= espi0_sp5_to_fpga1_dat(0);
-            fpga1_spare_v1p8(4) <= espi0_sp5_to_fpga1_dat(1);
-            fpga1_spare_v1p8(5) <= espi_resp_csn;
-        end if;
-    end process;
     -- misc things tied:
     fpga1_to_fpga2_io <= (others => 'Z');
     fpga1_to_sp5_sys_reset_l <= 'Z';  -- We don't use this in product, external PU.
@@ -775,12 +761,44 @@ begin
 
     debug_module_top_inst: entity work.debug_module_top
      port map(
+        clk_200m => clk_200m,
+        reset_200m => reset_200m,
         clk => clk_125m,
         reset => reset_125m,
         axi_if => responders(DBG_CTRL_RESP_IDX),
         in_a0 => a0_ok,
         sp5_debug2_pin => sp5_to_fpga1_debug2,
-        uart_dbg_if => uart_dbg_if
+        uart_dbg_if => uart_dbg_if,
+         -- hotplug
+        i2c_sp5_to_fpgax_hp_sda => i2c_sp5_to_fpgax_hp_sda,
+        i2c_sp5_to_fpgax_hp_scl => i2c_sp5_to_fpgax_hp_scl,
+        -- sp
+        i2c_sp_to_fpga1_scl => i2c_sp_to_fpga1_scl,
+        i2c_sp_to_fpga1_sda => i2c_sp_to_fpga1_sda,
+        -- dimms
+        i3c_sp5_to_fpga1_abcdef_scl => i3c_sp5_to_fpga1_abcdef_scl,
+        i3c_sp5_to_fpga1_abcdef_sda => i3c_sp5_to_fpga1_abcdef_sda,
+        i3c_sp5_to_fpga1_ghijkl_scl => i3c_sp5_to_fpga1_ghijkl_scl,
+        i3c_sp5_to_fpga1_ghijkl_sda => i3c_sp5_to_fpga1_ghijkl_sda,
+        i3c_fpga1_to_dimm_abcdef_scl => i3c_fpga1_to_dimm_abcdef_scl,
+        i3c_fpga1_to_dimm_abcdef_sda => i3c_fpga1_to_dimm_abcdef_sda,
+        i3c_fpga1_to_dimm_ghijkl_scl => i3c_fpga1_to_dimm_ghijkl_scl,
+        i3c_fpga1_to_dimm_ghijkl_sda => i3c_fpga1_to_dimm_ghijkl_sda,
+        -- UARTs
+        uart1_sp_to_fpga1_dat =>  uart1_sp_to_fpga1_dat,
+        uart1_fpga1_to_sp_dat  =>  uart1_fpga1_to_sp_dat,
+        uart0_sp_to_fpga1_dat =>  uart0_sp_to_fpga1_dat,
+        uart0_fpga1_to_sp_dat  =>  uart0_fpga1_to_sp_dat,
+        uart0_fpga1_to_sp5_dat  =>  uart0_fpga1_to_sp5_dat_buff,
+        uart0_sp5_to_fpga1_dat  =>  uart0_sp5_to_fpga1_dat,
+
+        -- ESPI signals
+        espi0_sp5_to_fpga_clk => espi0_sp5_to_fpga1_clk,
+        espi0_sp5_to_fpga_cs_l => espi0_sp5_to_fpga1_cs_l,
+        espi0_sp5_to_fpga1_dat => espi0_sp5_to_fpga1_dat,
+        espi_resp_csn => espi_resp_csn,
+
+        fpga1_spare_v1p8 => fpga1_spare_v1p8
     );
 
 

--- a/hdl/projects/cosmo_seq/debug_module/debug_header.vhd
+++ b/hdl/projects/cosmo_seq/debug_module/debug_header.vhd
@@ -1,0 +1,254 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+-- Copyright 2025 Oxide Computer Company
+
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+use work.debug_regs_pkg.all;
+
+entity debug_header is
+    port (
+        clk_200m : in std_logic;
+        reset_200m : in std_logic;
+
+        dbg_1v8_ctrl: in dbg_1v8_ctrl_type;
+
+        -- hotplug
+        i2c_sp5_to_fpgax_hp_sda: in std_logic;
+        i2c_sp5_to_fpgax_hp_scl: in std_logic;
+        -- sp
+        i2c_sp_to_fpga1_scl: in std_logic;
+        i2c_sp_to_fpga1_sda: in std_logic;
+        -- dimms
+        i3c_sp5_to_fpga1_abcdef_scl: in std_logic;
+        i3c_sp5_to_fpga1_abcdef_sda: in std_logic;
+        i3c_sp5_to_fpga1_ghijkl_scl: in std_logic;
+        i3c_sp5_to_fpga1_ghijkl_sda: in std_logic;
+        i3c_fpga1_to_dimm_abcdef_scl: in std_logic;
+        i3c_fpga1_to_dimm_abcdef_sda: in std_logic;
+        i3c_fpga1_to_dimm_ghijkl_scl: in std_logic;
+        i3c_fpga1_to_dimm_ghijkl_sda: in std_logic;
+        -- UARTs
+        uart1_sp_to_fpga1_dat: in std_logic; -- sp ipcc
+        uart1_fpga1_to_sp_dat : in std_logic; -- sp ipcc
+        uart0_sp_to_fpga1_dat: in std_logic; -- sp console
+        uart0_fpga1_to_sp_dat : in std_logic; -- sp console
+        uart0_fpga1_to_sp5_dat : in std_logic; -- sp5 console
+        uart0_sp5_to_fpga1_dat : in std_logic; -- sp5 console
+
+        -- ESPI signals
+        espi0_sp5_to_fpga_clk: in std_logic;
+        espi0_sp5_to_fpga_cs_l: in std_logic;
+        espi0_sp5_to_fpga1_dat: in std_logic_vector(3 downto 0);
+        espi_resp_csn: in std_logic;
+
+        fpga1_spare_v1p8 : out std_logic_vector(7 downto 0); -- 8 spare pins on the debug header
+
+       
+    );
+end entity;
+
+architecture rtl of debug_header is
+    signal i2c_sp_to_fpga1_sda_int : std_logic;
+    signal i2c_sp_to_fpga1_scl_int : std_logic;
+    signal i2c_sp5_to_fpgax_hp_sda_int: std_logic;
+    signal i2c_sp5_to_fpgax_hp_scl_int: std_logic;
+    signal i3c_sp5_to_fpga1_abcdef_scl_int: std_logic;
+    signal i3c_sp5_to_fpga1_abcdef_sda_int: std_logic;
+    signal i3c_sp5_to_fpga1_ghijkl_scl_int: std_logic;
+    signal i3c_sp5_to_fpga1_ghijkl_sda_int: std_logic;
+    signal i3c_fpga1_to_dimm_abcdef_scl_int: std_logic;
+    signal i3c_fpga1_to_dimm_abcdef_sda_int: std_logic;
+    signal i3c_fpga1_to_dimm_ghijkl_scl_int: std_logic;
+    signal i3c_fpga1_to_dimm_ghijkl_sda_int: std_logic;
+    signal uart1_sp_to_fpga1_dat_int : std_logic;
+    signal uart1_fpga1_to_sp_dat_int : std_logic;
+    signal uart0_sp_to_fpga1_dat_int : std_logic;
+    signal uart0_fpga1_to_sp_dat_int : std_logic;
+    signal uart0_fpga1_to_sp5_dat_int : std_logic;
+    signal uart0_sp5_to_fpga1_dat_int : std_logic;
+
+
+begin
+sample_reg: process(clk_200m, reset_200m)
+    begin
+        if rising_edge(clk_200m) then
+            i2c_sp_to_fpga1_sda_int <= i2c_sp_to_fpga1_sda;
+            i2c_sp_to_fpga1_scl_int <= i2c_sp_to_fpga1_scl;
+            i2c_sp5_to_fpgax_hp_sda_int <= i2c_sp5_to_fpgax_hp_sda;
+            i2c_sp5_to_fpgax_hp_scl_int <= i2c_sp5_to_fpgax_hp_scl;
+            i3c_sp5_to_fpga1_abcdef_scl_int <= i3c_sp5_to_fpga1_abcdef_scl; 
+            i3c_sp5_to_fpga1_abcdef_sda_int <= i3c_sp5_to_fpga1_abcdef_sda; 
+            i3c_sp5_to_fpga1_ghijkl_scl_int <= i3c_sp5_to_fpga1_ghijkl_scl; 
+            i3c_sp5_to_fpga1_ghijkl_sda_int <= i3c_sp5_to_fpga1_ghijkl_sda; 
+            i3c_fpga1_to_dimm_abcdef_scl_int <= i3c_fpga1_to_dimm_abcdef_scl;
+            i3c_fpga1_to_dimm_abcdef_sda_int <= i3c_fpga1_to_dimm_abcdef_sda;
+            i3c_fpga1_to_dimm_ghijkl_scl_int <= i3c_fpga1_to_dimm_ghijkl_scl;
+            i3c_fpga1_to_dimm_ghijkl_sda_int <= i3c_fpga1_to_dimm_ghijkl_sda;
+            uart1_sp_to_fpga1_dat_int <= uart1_sp_to_fpga1_dat;
+            uart1_fpga1_to_sp_dat_int <= uart1_fpga1_to_sp_dat;
+            uart0_sp_to_fpga1_dat_int <= uart0_sp_to_fpga1_dat;
+            uart0_fpga1_to_sp_dat_int <= uart0_fpga1_to_sp_dat;
+            uart0_fpga1_to_sp5_dat_int <= uart0_fpga1_to_sp5_dat;
+            uart0_sp5_to_fpga1_dat_int <= uart0_sp5_to_fpga1_dat;
+        end if;
+    end process;
+
+hdr_dbg_reg_1v8: process(clk_200m, reset_200m)
+    begin
+        if rising_edge(clk_200m) then
+
+            -- Deal with pins7..6
+            case dbg_1v8_ctrl.pins7_6 is
+                when I2C_DIMM0_BUS =>
+                    fpga1_spare_v1p8(7) <= i3c_fpga1_to_dimm_abcdef_scl_int;
+                    fpga1_spare_v1p8(6) <= i3c_fpga1_to_dimm_abcdef_sda_int;
+                when I2C_DIMM1_BUS =>
+                    fpga1_spare_v1p8(7) <= i3c_fpga1_to_dimm_ghijkl_scl_int;
+                    fpga1_spare_v1p8(6) <= i3c_fpga1_to_dimm_ghijkl_sda_int;
+                when I2C_SP5_DIMM0_BUS =>
+                    fpga1_spare_v1p8(7) <= i3c_sp5_to_fpga1_abcdef_scl_int;
+                    fpga1_spare_v1p8(6) <= i3c_sp5_to_fpga1_abcdef_sda_int;
+                when I2C_SP5_DIMM1_BUS =>
+                    fpga1_spare_v1p8(7) <= i3c_sp5_to_fpga1_ghijkl_scl_int;
+                    fpga1_spare_v1p8(6) <= i3c_sp5_to_fpga1_ghijkl_sda_int;
+                when I2C_SP5_HP_BUS =>
+                    fpga1_spare_v1p8(7) <= i2c_sp5_to_fpgax_hp_scl_int;
+                    fpga1_spare_v1p8(6) <= i2c_sp5_to_fpgax_hp_sda_int;
+                when I2C_SP_MUX_BUS =>
+                    fpga1_spare_v1p8(7) <= i2c_sp_to_fpga1_scl_int;
+                    fpga1_spare_v1p8(6) <= i2c_sp_to_fpga1_sda_int;
+                when ESPI_BUS =>
+                    fpga1_spare_v1p8(7) <= espi0_sp5_to_fpga_clk;
+                    fpga1_spare_v1p8(6) <= espi0_sp5_to_fpga_cs_l;
+                when SP_CONSOLE_BUS =>
+                    fpga1_spare_v1p8(7) <= uart1_fpga1_to_sp_dat_int;
+                    fpga1_spare_v1p8(6) <= uart0_sp_to_fpga1_dat_int;
+                when SP5_CONSOLE_BUS =>
+                    fpga1_spare_v1p8(7) <= uart0_fpga1_to_sp5_dat_int;
+                    fpga1_spare_v1p8(6) <= uart0_sp5_to_fpga1_dat_int;
+                when SP_IPCC_BUS =>
+                    fpga1_spare_v1p8(7) <= uart1_fpga1_to_sp_dat_int;
+                    fpga1_spare_v1p8(6) <= uart1_sp_to_fpga1_dat;
+                when others =>
+                    -- Default case, do nothing
+                    fpga1_spare_v1p8(7 downto 6) <= (others => 'Z');
+            end case;
+            -- Deal with pins5..4
+            case dbg_1v8_ctrl.pins5_4 is
+                when I2C_DIMM0_BUS =>
+                    fpga1_spare_v1p8(5) <= i3c_fpga1_to_dimm_abcdef_scl_int;
+                    fpga1_spare_v1p8(4) <= i3c_fpga1_to_dimm_abcdef_sda_int;
+                when I2C_DIMM1_BUS =>
+                    fpga1_spare_v1p8(5) <= i3c_fpga1_to_dimm_ghijkl_scl_int;
+                    fpga1_spare_v1p8(4) <= i3c_fpga1_to_dimm_ghijkl_sda_int;
+                when I2C_SP5_DIMM0_BUS =>
+                    fpga1_spare_v1p8(5) <= i3c_sp5_to_fpga1_abcdef_scl_int;
+                    fpga1_spare_v1p8(4) <= i3c_sp5_to_fpga1_abcdef_sda_int;
+                when I2C_SP5_DIMM1_BUS =>
+                    fpga1_spare_v1p8(5) <= i3c_sp5_to_fpga1_ghijkl_scl_int;
+                    fpga1_spare_v1p8(4) <= i3c_sp5_to_fpga1_ghijkl_sda_int;
+                when I2C_SP5_HP_BUS =>
+                    fpga1_spare_v1p8(5) <= i2c_sp5_to_fpgax_hp_scl_int;
+                    fpga1_spare_v1p8(4) <= i2c_sp5_to_fpgax_hp_sda_int;
+                when I2C_SP_MUX_BUS =>
+                    fpga1_spare_v1p8(5) <= i2c_sp_to_fpga1_scl_int;
+                    fpga1_spare_v1p8(4) <= i2c_sp_to_fpga1_sda_int;
+                when ESPI_BUS =>
+                    fpga1_spare_v1p8(5) <= espi0_sp5_to_fpga1_dat(1);
+                    fpga1_spare_v1p8(4) <= espi0_sp5_to_fpga1_dat(0);
+                when SP_CONSOLE_BUS =>
+                    fpga1_spare_v1p8(5) <= uart1_fpga1_to_sp_dat_int;
+                    fpga1_spare_v1p8(4) <= uart0_sp_to_fpga1_dat_int;
+                when SP5_CONSOLE_BUS =>
+                    fpga1_spare_v1p8(5) <= uart0_fpga1_to_sp5_dat_int;
+                    fpga1_spare_v1p8(4) <= uart0_sp5_to_fpga1_dat_int;
+                when SP_IPCC_BUS =>
+                    fpga1_spare_v1p8(5) <= uart1_fpga1_to_sp_dat_int;
+                    fpga1_spare_v1p8(4) <= uart1_sp_to_fpga1_dat;
+                when others =>
+                    -- Default case, do nothing
+                    fpga1_spare_v1p8(5 downto 4) <= (others => 'Z');
+            end case;
+            -- Deal with pins3..2
+            case dbg_1v8_ctrl.pins3_2 is
+                when I2C_DIMM0_BUS =>
+                    fpga1_spare_v1p8(3) <= i3c_fpga1_to_dimm_abcdef_scl_int;
+                    fpga1_spare_v1p8(2) <= i3c_fpga1_to_dimm_abcdef_sda_int;
+                when I2C_DIMM1_BUS =>
+                    fpga1_spare_v1p8(3) <= i3c_fpga1_to_dimm_ghijkl_scl_int;
+                    fpga1_spare_v1p8(2) <= i3c_fpga1_to_dimm_ghijkl_sda_int;
+                when I2C_SP5_DIMM0_BUS =>
+                    fpga1_spare_v1p8(3) <= i3c_sp5_to_fpga1_abcdef_scl_int;
+                    fpga1_spare_v1p8(2) <= i3c_sp5_to_fpga1_abcdef_sda_int;
+                when I2C_SP5_DIMM1_BUS =>
+                    fpga1_spare_v1p8(3) <= i3c_sp5_to_fpga1_ghijkl_scl_int;
+                    fpga1_spare_v1p8(2) <= i3c_sp5_to_fpga1_ghijkl_sda_int;
+                when I2C_SP5_HP_BUS =>
+                    fpga1_spare_v1p8(3) <= i2c_sp5_to_fpgax_hp_scl_int;
+                    fpga1_spare_v1p8(2) <= i2c_sp5_to_fpgax_hp_sda_int;
+                when I2C_SP_MUX_BUS =>
+                    fpga1_spare_v1p8(3) <= i2c_sp_to_fpga1_scl_int;
+                    fpga1_spare_v1p8(2) <= i2c_sp_to_fpga1_sda_int;
+                when ESPI_BUS =>
+                    fpga1_spare_v1p8(3) <= espi_resp_csn;
+                    fpga1_spare_v1p8(2) <= 'Z'; -- Unused in this case
+                when SP_CONSOLE_BUS =>
+                    fpga1_spare_v1p8(3) <= uart1_fpga1_to_sp_dat_int;
+                    fpga1_spare_v1p8(2) <= uart0_sp_to_fpga1_dat_int;
+                when SP5_CONSOLE_BUS =>
+                    fpga1_spare_v1p8(3) <= uart0_fpga1_to_sp5_dat_int;
+                    fpga1_spare_v1p8(2) <= uart0_sp5_to_fpga1_dat_int;
+                when SP_IPCC_BUS =>
+                    fpga1_spare_v1p8(3) <= uart1_fpga1_to_sp_dat_int;
+                    fpga1_spare_v1p8(2) <= uart1_sp_to_fpga1_dat;
+                when others =>
+                    -- Default case, do nothing
+                    fpga1_spare_v1p8(3 downto 2) <= (others => 'Z');
+            end case;
+
+            -- Deal with pins1..0
+            case dbg_1v8_ctrl.pins1_0 is
+                when I2C_DIMM0_BUS =>
+                    fpga1_spare_v1p8(1) <= i3c_fpga1_to_dimm_abcdef_scl_int;
+                    fpga1_spare_v1p8(0) <= i3c_fpga1_to_dimm_abcdef_sda_int;
+                when I2C_DIMM1_BUS =>
+                    fpga1_spare_v1p8(1) <= i3c_fpga1_to_dimm_ghijkl_scl_int;
+                    fpga1_spare_v1p8(0) <= i3c_fpga1_to_dimm_ghijkl_sda_int;
+                when I2C_SP5_DIMM0_BUS =>
+                    fpga1_spare_v1p8(1) <= i3c_sp5_to_fpga1_abcdef_scl_int;
+                    fpga1_spare_v1p8(0) <= i3c_sp5_to_fpga1_abcdef_sda_int;
+                when I2C_SP5_DIMM1_BUS =>
+                    fpga1_spare_v1p8(1) <= i3c_sp5_to_fpga1_ghijkl_scl_int;
+                    fpga1_spare_v1p8(0) <= i3c_sp5_to_fpga1_ghijkl_sda_int;
+                when I2C_SP5_HP_BUS =>
+                    fpga1_spare_v1p8(1) <= i2c_sp5_to_fpgax_hp_scl_int;
+                    fpga1_spare_v1p8(0) <= i2c_sp5_to_fpgax_hp_sda_int;
+                when I2C_SP_MUX_BUS =>
+                    fpga1_spare_v1p8(1) <= i2c_sp_to_fpga1_scl_int;
+                    fpga1_spare_v1p8(0) <= i2c_sp_to_fpga1_sda_int;
+                when ESPI_BUS =>
+                    fpga1_spare_v1p8(1) <= espi0_sp5_to_fpga1_dat(3);
+                    fpga1_spare_v1p8(0) <= espi0_sp5_to_fpga1_dat(2);
+                when SP_CONSOLE_BUS =>
+                    fpga1_spare_v1p8(1) <= uart1_fpga1_to_sp_dat_int;
+                    fpga1_spare_v1p8(0) <= uart0_sp_to_fpga1_dat_int;
+                when SP5_CONSOLE_BUS =>
+                    fpga1_spare_v1p8(1) <= uart0_fpga1_to_sp5_dat_int;
+                    fpga1_spare_v1p8(0) <= uart0_sp5_to_fpga1_dat_int;
+                when SP_IPCC_BUS =>
+                    fpga1_spare_v1p8(1) <= uart1_fpga1_to_sp_dat_int;
+                    fpga1_spare_v1p8(0) <= uart1_sp_to_fpga1_dat;
+                when others =>
+                    -- Default case, do nothing
+                    fpga1_spare_v1p8(1 downto 0) <= (others => 'Z');
+            end case;
+        end if;
+    end process;
+
+end rtl;

--- a/hdl/projects/cosmo_seq/debug_module/debug_regs.rdl
+++ b/hdl/projects/cosmo_seq/debug_module/debug_regs.rdl
@@ -107,4 +107,60 @@ addrmap debug_regs {
             desc = "Saturating u32 counter that counts the number 8ns clock cycles since last SP5 DBG2 pin toggle in this a0 power cycle.";
         } cnts[31:0] = 0;
     } sp5_dbg2_toggle_timer;
+
+    reg {
+        name = "1V8 Header Debug Control";
+         
+         enum debug_mux_sel {
+            NONE = 8'h00 {desc = "No Outputs assigned here";};
+            i2c_dimm0_bus = 8'h01 {desc = "FPGA -> DIMM0 i2c bus to pins";};
+            i2c_dimm1_bus = 8'h02 {desc = "FPGA -> DIMM1 i2c bus to pins";};
+            i2c_sp5_dimm0_bus = 8'h03 {desc = "SP5 -> FPGA DIMM0 i2c bus to pins";};
+            i2c_sp5_dimm1_bus = 8'h04 {desc = "SP5 -> FPGA DIMM1 i2c bus to pins";};
+            i2c_sp5_hp_bus = 8'h05 {desc = "SP5 -> FPGA Hotplug i2c bus to pins";};
+            i2c_sp_mux_bus = 8'h06 {desc = "SP -> FPGA MUX i2c bus to pins";};
+            espi_bus = 8'h07 {desc = "SP5 -> eSPI bus to pins";};
+            sp_console_bus = 8'h08 {desc = "SP <-> FPGA console UART to pins";};
+            sp5_console_bus = 8'h09 {desc = "SP5 <-> FPGA console UART to pins";};
+            sp_ipcc_bus = 8'h0a {desc = "SP <-> FPGA IPCC UART to pins";};
+        };
+        field {
+            desc = "Selects which debug output is sent to the 1v8 debug header in sets of two pins.
+            For i2c buses the highest bit is the clock, the next bit is the data.
+            For UARTs the highest bit is the 'from FPGA' side the next bit is the 'to FPGA' side.
+            Espi buses have defined pins (TBD) to match standard debug setup.";
+            encode = debug_mux_sel;
+        } pins7_6[31:24] = 0;
+        field {
+            desc = "Selects which debug output is sent to the 1v8 debug header in sets of two pins.
+            For i2c buses the highest bit is the clock, the next bit is the data.
+            For UARTs the highest bit is the 'from FPGA' side the next bit is the 'to FPGA' side.
+            Espi buses have defined pins (TBD) to match standard debug setup.";
+            encode = debug_mux_sel;
+        } pins5_4[23:16] = 0;
+        field {
+            desc = "Selects which debug output is sent to the 1v8 debug header in sets of two pins.
+            For i2c buses the highest bit is the clock, the next bit is the data.
+            For UARTs the highest bit is the 'from FPGA' side the next bit is the 'to FPGA' side.
+            Espi buses have defined pins (TBD) to match standard debug setup.";
+            encode = debug_mux_sel;
+        } pins3_2[15:8] = 0;
+        field {
+            desc = "Selects which debug output is sent to the 1v8 debug header in sets of two pins.
+            For i2c buses the highest bit is the clock, the next bit is the data.
+            For UARTs the highest bit is the 'from FPGA' side the next bit is the 'to FPGA' side.
+            Espi buses have defined pins (TBD) to match standard debug setup.";
+            encode = debug_mux_sel;
+        } pins1_0[7:0] = 0;
+    } dbg_1v8_ctrl;
+
+    reg {
+        name = "Debug Convenience";
+        field {
+            desc = "convenience bit for setting up x4 espi debug out. This uses 1v8 debug header pins 7..0. Hw clears";
+        } espi_dbg_x4_en[1:1] = 0;
+        field {
+            desc = "convenience bit for setting up x1 espi debug out.. This uses 1v8 debug header pins 7..2. Hw clears";
+        } espi_dbg_x1_en[0:0] = 0;
+    } dbg_convenience;
 };

--- a/hdl/projects/cosmo_seq/dimms_subsystem/sims/spd_proxy_top_tb.vhd
+++ b/hdl/projects/cosmo_seq/dimms_subsystem/sims/spd_proxy_top_tb.vhd
@@ -66,10 +66,14 @@ begin
                 -- Expect to get 3 bytes back, so poll until we see that in the FIFO
                 data32 := 32x"3";
                 wait_until_read_equals(net, bus_handle, To_StdLogicVector(BUS0_RX_BYTE_COUNT_OFFSET, bus_handle.p_address_length), data32);
+                --read_bus(net, bus_handle, To_StdLogicVector(BUS0_RX_RDATA_OFFSET, bus_handle.p_address_length), data32);
                 -- check the response.
                 read_bus(net, bus_handle, To_StdLogicVector(BUS0_RX_RDATA_OFFSET, bus_handle.p_address_length), data32);
                 check_match(data32, std_logic_vector'(X"--CCBBAA"), "Read data mismatch");
-                null;
+                write_bus(net, bus_handle, To_StdLogicVector(FIFO_CTRL_OFFSET, bus_handle.p_address_length), X"FFFF_FFFF");
+
+                read_bus(net, bus_handle, To_StdLogicVector(BUS0_RX_RADDR_OFFSET, bus_handle.p_address_length), data32);
+
             elsif run("spd_sm_prefetch") then
                 write_word(memory(I2C_DIMM1_TGT_VC), 16#80#, X"AA");
                 write_word(memory(I2C_DIMM1_TGT_VC), 16#81#, X"BB");


### PR DESCRIPTION
This sets up an arbitrary condiment dispenser for the 1v8 debug header.  I've grouped the pins in sets of 2 and you can mux out any of a few interfaces to these pins by setting the correct bits in the mux registers.  ESPI is special in that it has a defined pinout, and there are convenience registers to set all of this up correctly in one shot.

This was already in place but we have to clock this in the 200MHz domain (since we want to faithfully represent espi), so we have false-path entries to the debug pins to make timing work. We can see if this is a problem long-term but I think it's not.

This also provides a means to grow our allowable, and run-time selectable debug and allows concurrent debug of multiple interfaces, limited by having to have pairs of signals and the number of pins available.