### PR TITLE
cosmo fixes and features rollup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,99 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Quartz is a collection of soft-logic designs and hardware abstraction libraries (HALs) for various subsystems found in Oxide hardware. This includes components such as Ignition, power sequencing for system boards, and QSFP interface management.
+
+## Build System
+
+Quartz uses two build systems in parallel:
+
+### Buck2 (Primary/Modern)
+- Used for VHDL and RDL flows with VUnit simulations
+- Supports Xilinx FPGA toolchain integration
+- Supports Lattice FPGAs via Yosys and GDHL VHDL plugin
+
+#### Prerequisites
+- Buck2 installed: `cargo +nightly-2024-10-13 install --git https://github.com/facebook/buck2.git --tag "2025-02-01" buck2`
+- Python 3.10+ with packages: `pip install -r tools/requirements.txt`
+- NVC simulator (minimum version 1.13.1)
+- Vivado on PATH for Xilinx designs
+
+#### Key Commands
+- `buck2 ctargets /...` - List all available targets
+- `buck2 run <target>` - Run a simulation
+- `buck2 bxl //tools/vunit-sims.bxl:vunit_sim_gen` - List all simulation testbenches
+- `buck2 run //tools/multitool:multitool -- lsp-toml` - Generate vhdl_ls.toml for LSP
+- `buck2 run //tools/multitool:multitool -- format` - Auto-format VHDL code
+- `buck2 run //tools/multitool:multitool -- tb-gen --name <name> --path <path>` - Generate testbench boilerplate
+
+#### Running All Simulations
+```bash
+buck2 bxl //tools/vunit-sims.bxl:vunit_sim_gen | while IFS= read -r line; do eval "$line" ; done
+```
+
+### Cobble (Legacy)
+- Used for BSV designs and RDL generation targeting yosys toolchain
+- Requires BUILD.vars configuration (copy BUILD.vars.example and adapt paths)
+- See COBALT_README.md for detailed instructions
+
+## Architecture
+
+### Directory Structure
+- `hdl/ip/` - Reusable IP blocks
+  - `bsv/` - Bluespec SystemVerilog IP (BUILD-based)
+  - `vhd/` - VHDL IP modules (BUCK-based)
+- `hdl/projects/` - Complete FPGA designs for specific hardware
+  - Each project contains top-level designs, constraints, and project-specific modules
+- `tools/` - Build system utilities and custom tools
+- `prelude/` - Buck2 build rules and configurations
+- `vnd/` - Vendor/third-party dependencies
+
+### VHDL Module Organization
+Each VHDL module should have its own `vhdl_unit` rule in BUCK files. Package files that are reused across modules should be in separate rules. Dependencies are specified via the `deps` attribute.
+
+### SystemRDL Integration
+- Each RDL file gets its own `rdl_file` rule
+- Generates VHDL packages, BSV modules, JSON, HTML documentation
+- Address maps with nested instances require bottom-to-top ordering
+
+## Key Hardware Projects
+- **cosmo_seq** - SP5 sequencer for Oxide systems
+- **cosmo_hp** - Hot plug controller
+- **grapefruit** - FPGA design with ESPI and peripheral interfaces
+- **gimlet** - System sequencer with ignition support
+- **sidecar** - Network switch controller with QSFP management
+
+## Development Tools
+
+### Code Formatting
+VHDL code uses vhdl-style-guide with custom rules in `vsg_config.json`. Format code with:
+```bash
+buck2 run //tools/multitool:multitool -- format
+```
+
+### LSP Support
+Generate vhdl_ls.toml for VHDL language server:
+```bash
+buck2 run //tools/multitool:multitool -- lsp-toml
+```
+
+### Release Tool
+For FPGA releases:
+```bash
+buck2 run //tools/fpga_releaser:cli -- --fpga <fpga-name> --hubris <hubris-path>
+```
+
+## Important Files
+- `BUILD.vars` - Machine-specific tool paths (copy from BUILD.vars.example)
+- `BUCK_RULES.md` - Detailed BUCK rule documentation
+- `RDL_EXAMPLES.md` - SystemRDL usage examples
+- `vsg_config.json` - VHDL formatting rules
+- `tools/requirements.txt` - Python dependencies
+
+## Testing
+- VUnit is used for VHDL testbenches
+- BSV uses built-in Bluesim for simulation
+- Testbenches follow naming convention: `*_tb.vhd` (testbench), `*_th.vhd` (test harness)

--- a/hdl/ip/vhd/espi/link_layer/link_layer.vhd
+++ b/hdl/ip/vhd/espi/link_layer/link_layer.vhd
@@ -101,7 +101,7 @@ begin
     end process;
 
 
-    -- Saleae is made decoding spi signals if they are not byte-aligned with the enable
+    -- Saleae is mad decoding spi signals if they are not byte-aligned with the enable
     -- our responses are always shifted by 2 clocks due to the TA phase so this provides
     -- a fake enable that allows us to run a 2nd decoder for the response channel
     saleae_response_cs_gen: process(clk, reset)

--- a/hdl/projects/cosmo_seq/cosmo_seq_top.vhd
+++ b/hdl/projects/cosmo_seq/cosmo_seq_top.vhd
@@ -390,6 +390,7 @@ architecture rtl of cosmo_seq_top is
     alias a0_ok_to_fpga2 : std_logic is fpga1_to_fpga2_io(2);
     signal uart_dbg_if : uart_dbg_t;
     signal allow_backplane_pcie_clk : std_logic;
+    signal nic_dbg_pins : t6_debug_if;
 
 begin
 
@@ -634,7 +635,7 @@ begin
         sp5_seq_pins => sp5_seq_pins,
         nic_rails_pins => nic_rails,
         nic_seq_pins => nic_seq_pins,
-        sp5_t6_power_en => sp5_t6_power_en,
+        nic_dbg_pins => nic_dbg_pins,
         sp5_t6_perst_l => sp5_t6_perst_l,
         ignition_mux_sel => fpga1_to_sp_mux_ign_mux_sel,
         ignition_creset => fpga1_to_ign_trgt_fpga_creset
@@ -791,12 +792,12 @@ begin
         uart0_fpga1_to_sp_dat  =>  uart0_fpga1_to_sp_dat,
         uart0_fpga1_to_sp5_dat  =>  uart0_fpga1_to_sp5_dat_buff,
         uart0_sp5_to_fpga1_dat  =>  uart0_sp5_to_fpga1_dat,
-
         -- ESPI signals
         espi0_sp5_to_fpga_clk => espi0_sp5_to_fpga1_clk,
         espi0_sp5_to_fpga_cs_l => espi0_sp5_to_fpga1_cs_l,
         espi0_sp5_to_fpga1_dat => espi0_sp5_to_fpga1_dat,
         espi_resp_csn => espi_resp_csn,
+        nic_dbg_pins => nic_dbg_pins,
 
         fpga1_spare_v1p8 => fpga1_spare_v1p8
     );

--- a/hdl/projects/cosmo_seq/debug_module/BUCK
+++ b/hdl/projects/cosmo_seq/debug_module/BUCK
@@ -19,6 +19,7 @@ vhdl_unit(
         ":debug_regs_rdl",
         "//hdl/ip/vhd/axi_blocks:axilite_if_2k19",
         "//hdl/projects/cosmo_seq/sp5_uart_subsystem:sp5_uart_subsystem",
+        "//hdl/projects/cosmo_seq/sequencer:sequencer",
     ],
     visibility = ["PUBLIC"],
     standard = "2019",

--- a/hdl/projects/cosmo_seq/debug_module/debug_header.vhd
+++ b/hdl/projects/cosmo_seq/debug_module/debug_header.vhd
@@ -10,6 +10,7 @@ use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
 use work.debug_regs_pkg.all;
+use work.sequencer_io_pkg.all;
 
 entity debug_header is
     port (
@@ -40,12 +41,13 @@ entity debug_header is
         uart0_fpga1_to_sp_dat : in std_logic; -- sp console
         uart0_fpga1_to_sp5_dat : in std_logic; -- sp5 console
         uart0_sp5_to_fpga1_dat : in std_logic; -- sp5 console
-
         -- ESPI signals
         espi0_sp5_to_fpga_clk: in std_logic;
         espi0_sp5_to_fpga_cs_l: in std_logic;
         espi0_sp5_to_fpga1_dat: in std_logic_vector(3 downto 0);
         espi_resp_csn: in std_logic;
+        -- T6 signals
+        nic_dbg_pins : view t6_debug_dbg;
 
         fpga1_spare_v1p8 : out std_logic_vector(7 downto 0); -- 8 spare pins on the debug header
 
@@ -72,12 +74,20 @@ architecture rtl of debug_header is
     signal uart0_fpga1_to_sp_dat_int : std_logic;
     signal uart0_fpga1_to_sp5_dat_int : std_logic;
     signal uart0_sp5_to_fpga1_dat_int : std_logic;
+    signal espi0_sp5_to_fpga_clk_int : std_logic;
+    signal espi0_sp5_to_fpga_cs_l_int : std_logic;
+    signal espi0_sp5_to_fpga1_dat_int : std_logic_vector(3 downto 0);
+    signal espi_resp_csn_int : std_logic;
+    signal dbg_1v8_ctrl_200 : dbg_1v8_ctrl_type;
+    signal fpga1_spare_reg : std_logic_vector(7 downto 0);
+    signal nic_dbg_pins_int : t6_debug_if;
 
 
 begin
 sample_reg: process(clk_200m, reset_200m)
     begin
         if rising_edge(clk_200m) then
+            dbg_1v8_ctrl_200 <= dbg_1v8_ctrl;
             i2c_sp_to_fpga1_sda_int <= i2c_sp_to_fpga1_sda;
             i2c_sp_to_fpga1_scl_int <= i2c_sp_to_fpga1_scl;
             i2c_sp5_to_fpgax_hp_sda_int <= i2c_sp5_to_fpgax_hp_sda;
@@ -96,159 +106,203 @@ sample_reg: process(clk_200m, reset_200m)
             uart0_fpga1_to_sp_dat_int <= uart0_fpga1_to_sp_dat;
             uart0_fpga1_to_sp5_dat_int <= uart0_fpga1_to_sp5_dat;
             uart0_sp5_to_fpga1_dat_int <= uart0_sp5_to_fpga1_dat;
+            espi0_sp5_to_fpga_clk_int <= espi0_sp5_to_fpga_clk;
+            espi0_sp5_to_fpga_cs_l_int <= espi0_sp5_to_fpga_cs_l;
+            espi0_sp5_to_fpga1_dat_int <= espi0_sp5_to_fpga1_dat;
+            espi_resp_csn_int <= espi_resp_csn;
+            nic_dbg_pins_int <= nic_dbg_pins;
         end if;
     end process;
 
 hdr_dbg_reg_1v8: process(clk_200m, reset_200m)
     begin
-        if rising_edge(clk_200m) then
+        if reset_200m = '1' then
+            fpga1_spare_reg <= (others => '0');
+        
+        elsif rising_edge(clk_200m) then
+            if dbg_1v8_ctrl_200.pins7_6 /= NONE then
+                fpga1_spare_v1p8(7 downto 6) <= fpga1_spare_reg(7 downto 6);
+            else
+                fpga1_spare_v1p8(7 downto 6) <= (others => 'Z');
+            end if;
+            if dbg_1v8_ctrl_200.pins5_4 /= NONE then
+                fpga1_spare_v1p8(5 downto 4) <= fpga1_spare_reg(5 downto 4);
+            else
+                fpga1_spare_v1p8(4 downto 4) <= (others => 'Z');
+            end if;
+            if dbg_1v8_ctrl_200.pins3_2 /= NONE then
+                fpga1_spare_v1p8(3 downto 2) <= fpga1_spare_reg(3 downto 2);
+            else
+                fpga1_spare_v1p8(3 downto 2) <= (others => 'Z');
+            end if;
+            if dbg_1v8_ctrl_200.pins1_0 /= NONE then
+                fpga1_spare_v1p8(1 downto 0) <= fpga1_spare_reg(1 downto 0);
+            else
+                fpga1_spare_v1p8(1 downto 0) <= (others => 'Z');
+            end if;
 
             -- Deal with pins7..6
-            case dbg_1v8_ctrl.pins7_6 is
+            case dbg_1v8_ctrl_200.pins7_6 is
                 when I2C_DIMM0_BUS =>
-                    fpga1_spare_v1p8(7) <= i3c_fpga1_to_dimm_abcdef_scl_int;
-                    fpga1_spare_v1p8(6) <= i3c_fpga1_to_dimm_abcdef_sda_int;
+                    fpga1_spare_reg(7) <= i3c_fpga1_to_dimm_abcdef_scl_int;
+                    fpga1_spare_reg(6) <= i3c_fpga1_to_dimm_abcdef_sda_int;
                 when I2C_DIMM1_BUS =>
-                    fpga1_spare_v1p8(7) <= i3c_fpga1_to_dimm_ghijkl_scl_int;
-                    fpga1_spare_v1p8(6) <= i3c_fpga1_to_dimm_ghijkl_sda_int;
+                    fpga1_spare_reg(7) <= i3c_fpga1_to_dimm_ghijkl_scl_int;
+                    fpga1_spare_reg(6) <= i3c_fpga1_to_dimm_ghijkl_sda_int;
                 when I2C_SP5_DIMM0_BUS =>
-                    fpga1_spare_v1p8(7) <= i3c_sp5_to_fpga1_abcdef_scl_int;
-                    fpga1_spare_v1p8(6) <= i3c_sp5_to_fpga1_abcdef_sda_int;
+                    fpga1_spare_reg(7) <= i3c_sp5_to_fpga1_abcdef_scl_int;
+                    fpga1_spare_reg(6) <= i3c_sp5_to_fpga1_abcdef_sda_int;
                 when I2C_SP5_DIMM1_BUS =>
-                    fpga1_spare_v1p8(7) <= i3c_sp5_to_fpga1_ghijkl_scl_int;
-                    fpga1_spare_v1p8(6) <= i3c_sp5_to_fpga1_ghijkl_sda_int;
+                    fpga1_spare_reg(7) <= i3c_sp5_to_fpga1_ghijkl_scl_int;
+                    fpga1_spare_reg(6) <= i3c_sp5_to_fpga1_ghijkl_sda_int;
                 when I2C_SP5_HP_BUS =>
-                    fpga1_spare_v1p8(7) <= i2c_sp5_to_fpgax_hp_scl_int;
-                    fpga1_spare_v1p8(6) <= i2c_sp5_to_fpgax_hp_sda_int;
+                    fpga1_spare_reg(7) <= i2c_sp5_to_fpgax_hp_scl_int;
+                    fpga1_spare_reg(6) <= i2c_sp5_to_fpgax_hp_sda_int;
                 when I2C_SP_MUX_BUS =>
-                    fpga1_spare_v1p8(7) <= i2c_sp_to_fpga1_scl_int;
-                    fpga1_spare_v1p8(6) <= i2c_sp_to_fpga1_sda_int;
+                    fpga1_spare_reg(7) <= i2c_sp_to_fpga1_scl_int;
+                    fpga1_spare_reg(6) <= i2c_sp_to_fpga1_sda_int;
                 when ESPI_BUS =>
-                    fpga1_spare_v1p8(7) <= espi0_sp5_to_fpga_clk;
-                    fpga1_spare_v1p8(6) <= espi0_sp5_to_fpga_cs_l;
+                    fpga1_spare_reg(7) <= espi0_sp5_to_fpga_clk_int;
+                    fpga1_spare_reg(6) <= espi0_sp5_to_fpga_cs_l_int;
                 when SP_CONSOLE_BUS =>
-                    fpga1_spare_v1p8(7) <= uart1_fpga1_to_sp_dat_int;
-                    fpga1_spare_v1p8(6) <= uart0_sp_to_fpga1_dat_int;
+                    fpga1_spare_reg(7) <= uart1_fpga1_to_sp_dat_int;
+                    fpga1_spare_reg(6) <= uart0_sp_to_fpga1_dat_int;
                 when SP5_CONSOLE_BUS =>
-                    fpga1_spare_v1p8(7) <= uart0_fpga1_to_sp5_dat_int;
-                    fpga1_spare_v1p8(6) <= uart0_sp5_to_fpga1_dat_int;
+                    fpga1_spare_reg(7) <= uart0_fpga1_to_sp5_dat_int;
+                    fpga1_spare_reg(6) <= uart0_sp5_to_fpga1_dat_int;
                 when SP_IPCC_BUS =>
-                    fpga1_spare_v1p8(7) <= uart1_fpga1_to_sp_dat_int;
-                    fpga1_spare_v1p8(6) <= uart1_sp_to_fpga1_dat;
+                    fpga1_spare_reg(7) <= uart1_fpga1_to_sp_dat_int;
+                    fpga1_spare_reg(6) <= uart1_sp_to_fpga1_dat_int;
+                when T6_SEQUENCER =>
+                    -- T6 debug pins
+                    fpga1_spare_reg(7) <= nic_dbg_pins_int.rails_en;
+                    fpga1_spare_reg(6) <= nic_dbg_pins_int.rails_pg;
                 when others =>
                     -- Default case, do nothing
-                    fpga1_spare_v1p8(7 downto 6) <= (others => 'Z');
+                    fpga1_spare_reg(7 downto 6) <= (others => '0');
             end case;
             -- Deal with pins5..4
-            case dbg_1v8_ctrl.pins5_4 is
+            case dbg_1v8_ctrl_200.pins5_4 is
                 when I2C_DIMM0_BUS =>
-                    fpga1_spare_v1p8(5) <= i3c_fpga1_to_dimm_abcdef_scl_int;
-                    fpga1_spare_v1p8(4) <= i3c_fpga1_to_dimm_abcdef_sda_int;
+                    fpga1_spare_reg(5) <= i3c_fpga1_to_dimm_abcdef_scl_int;
+                    fpga1_spare_reg(4) <= i3c_fpga1_to_dimm_abcdef_sda_int;
                 when I2C_DIMM1_BUS =>
-                    fpga1_spare_v1p8(5) <= i3c_fpga1_to_dimm_ghijkl_scl_int;
-                    fpga1_spare_v1p8(4) <= i3c_fpga1_to_dimm_ghijkl_sda_int;
+                    fpga1_spare_reg(5) <= i3c_fpga1_to_dimm_ghijkl_scl_int;
+                    fpga1_spare_reg(4) <= i3c_fpga1_to_dimm_ghijkl_sda_int;
                 when I2C_SP5_DIMM0_BUS =>
-                    fpga1_spare_v1p8(5) <= i3c_sp5_to_fpga1_abcdef_scl_int;
-                    fpga1_spare_v1p8(4) <= i3c_sp5_to_fpga1_abcdef_sda_int;
+                    fpga1_spare_reg(5) <= i3c_sp5_to_fpga1_abcdef_scl_int;
+                    fpga1_spare_reg(4) <= i3c_sp5_to_fpga1_abcdef_sda_int;
                 when I2C_SP5_DIMM1_BUS =>
-                    fpga1_spare_v1p8(5) <= i3c_sp5_to_fpga1_ghijkl_scl_int;
-                    fpga1_spare_v1p8(4) <= i3c_sp5_to_fpga1_ghijkl_sda_int;
+                    fpga1_spare_reg(5) <= i3c_sp5_to_fpga1_ghijkl_scl_int;
+                    fpga1_spare_reg(4) <= i3c_sp5_to_fpga1_ghijkl_sda_int;
                 when I2C_SP5_HP_BUS =>
-                    fpga1_spare_v1p8(5) <= i2c_sp5_to_fpgax_hp_scl_int;
-                    fpga1_spare_v1p8(4) <= i2c_sp5_to_fpgax_hp_sda_int;
+                    fpga1_spare_reg(5) <= i2c_sp5_to_fpgax_hp_scl_int;
+                    fpga1_spare_reg(4) <= i2c_sp5_to_fpgax_hp_sda_int;
                 when I2C_SP_MUX_BUS =>
-                    fpga1_spare_v1p8(5) <= i2c_sp_to_fpga1_scl_int;
-                    fpga1_spare_v1p8(4) <= i2c_sp_to_fpga1_sda_int;
+                    fpga1_spare_reg(5) <= i2c_sp_to_fpga1_scl_int;
+                    fpga1_spare_reg(4) <= i2c_sp_to_fpga1_sda_int;
                 when ESPI_BUS =>
-                    fpga1_spare_v1p8(5) <= espi0_sp5_to_fpga1_dat(1);
-                    fpga1_spare_v1p8(4) <= espi0_sp5_to_fpga1_dat(0);
+                    fpga1_spare_reg(5) <= espi0_sp5_to_fpga1_dat_int(1);
+                    fpga1_spare_reg(4) <= espi0_sp5_to_fpga1_dat_int(0);
                 when SP_CONSOLE_BUS =>
-                    fpga1_spare_v1p8(5) <= uart1_fpga1_to_sp_dat_int;
-                    fpga1_spare_v1p8(4) <= uart0_sp_to_fpga1_dat_int;
+                    fpga1_spare_reg(5) <= uart1_fpga1_to_sp_dat_int;
+                    fpga1_spare_reg(4) <= uart0_sp_to_fpga1_dat_int;
                 when SP5_CONSOLE_BUS =>
-                    fpga1_spare_v1p8(5) <= uart0_fpga1_to_sp5_dat_int;
-                    fpga1_spare_v1p8(4) <= uart0_sp5_to_fpga1_dat_int;
+                    fpga1_spare_reg(5) <= uart0_fpga1_to_sp5_dat_int;
+                    fpga1_spare_reg(4) <= uart0_sp5_to_fpga1_dat_int;
                 when SP_IPCC_BUS =>
-                    fpga1_spare_v1p8(5) <= uart1_fpga1_to_sp_dat_int;
-                    fpga1_spare_v1p8(4) <= uart1_sp_to_fpga1_dat;
+                    fpga1_spare_reg(5) <= uart1_fpga1_to_sp_dat_int;
+                    fpga1_spare_reg(4) <= uart1_sp_to_fpga1_dat_int;
+                 when T6_SEQUENCER =>
+                    -- T6 debug pins
+                    fpga1_spare_reg(5) <= nic_dbg_pins.cld_rst_l;
+                    fpga1_spare_reg(4) <=  nic_dbg_pins.perst_l;
                 when others =>
                     -- Default case, do nothing
-                    fpga1_spare_v1p8(5 downto 4) <= (others => 'Z');
+                    fpga1_spare_reg(5 downto 4) <= (others => '0');
             end case;
             -- Deal with pins3..2
-            case dbg_1v8_ctrl.pins3_2 is
+            case dbg_1v8_ctrl_200.pins3_2 is
                 when I2C_DIMM0_BUS =>
-                    fpga1_spare_v1p8(3) <= i3c_fpga1_to_dimm_abcdef_scl_int;
-                    fpga1_spare_v1p8(2) <= i3c_fpga1_to_dimm_abcdef_sda_int;
+                    fpga1_spare_reg(3) <= i3c_fpga1_to_dimm_abcdef_scl_int;
+                    fpga1_spare_reg(2) <= i3c_fpga1_to_dimm_abcdef_sda_int;
                 when I2C_DIMM1_BUS =>
-                    fpga1_spare_v1p8(3) <= i3c_fpga1_to_dimm_ghijkl_scl_int;
-                    fpga1_spare_v1p8(2) <= i3c_fpga1_to_dimm_ghijkl_sda_int;
+                    fpga1_spare_reg(3) <= i3c_fpga1_to_dimm_ghijkl_scl_int;
+                    fpga1_spare_reg(2) <= i3c_fpga1_to_dimm_ghijkl_sda_int;
                 when I2C_SP5_DIMM0_BUS =>
-                    fpga1_spare_v1p8(3) <= i3c_sp5_to_fpga1_abcdef_scl_int;
-                    fpga1_spare_v1p8(2) <= i3c_sp5_to_fpga1_abcdef_sda_int;
+                    fpga1_spare_reg(3) <= i3c_sp5_to_fpga1_abcdef_scl_int;
+                    fpga1_spare_reg(2) <= i3c_sp5_to_fpga1_abcdef_sda_int;
                 when I2C_SP5_DIMM1_BUS =>
-                    fpga1_spare_v1p8(3) <= i3c_sp5_to_fpga1_ghijkl_scl_int;
-                    fpga1_spare_v1p8(2) <= i3c_sp5_to_fpga1_ghijkl_sda_int;
+                    fpga1_spare_reg(3) <= i3c_sp5_to_fpga1_ghijkl_scl_int;
+                    fpga1_spare_reg(2) <= i3c_sp5_to_fpga1_ghijkl_sda_int;
                 when I2C_SP5_HP_BUS =>
-                    fpga1_spare_v1p8(3) <= i2c_sp5_to_fpgax_hp_scl_int;
-                    fpga1_spare_v1p8(2) <= i2c_sp5_to_fpgax_hp_sda_int;
+                    fpga1_spare_reg(3) <= i2c_sp5_to_fpgax_hp_scl_int;
+                    fpga1_spare_reg(2) <= i2c_sp5_to_fpgax_hp_sda_int;
                 when I2C_SP_MUX_BUS =>
-                    fpga1_spare_v1p8(3) <= i2c_sp_to_fpga1_scl_int;
-                    fpga1_spare_v1p8(2) <= i2c_sp_to_fpga1_sda_int;
+                    fpga1_spare_reg(3) <= i2c_sp_to_fpga1_scl_int;
+                    fpga1_spare_reg(2) <= i2c_sp_to_fpga1_sda_int;
                 when ESPI_BUS =>
-                    fpga1_spare_v1p8(3) <= espi_resp_csn;
-                    fpga1_spare_v1p8(2) <= 'Z'; -- Unused in this case
+                    fpga1_spare_reg(3) <= espi_resp_csn;
+                    fpga1_spare_reg(2) <= '0'; -- Unused in this case
                 when SP_CONSOLE_BUS =>
-                    fpga1_spare_v1p8(3) <= uart1_fpga1_to_sp_dat_int;
-                    fpga1_spare_v1p8(2) <= uart0_sp_to_fpga1_dat_int;
+                    fpga1_spare_reg(3) <= uart1_fpga1_to_sp_dat_int;
+                    fpga1_spare_reg(2) <= uart0_sp_to_fpga1_dat_int;
                 when SP5_CONSOLE_BUS =>
-                    fpga1_spare_v1p8(3) <= uart0_fpga1_to_sp5_dat_int;
-                    fpga1_spare_v1p8(2) <= uart0_sp5_to_fpga1_dat_int;
+                    fpga1_spare_reg(3) <= uart0_fpga1_to_sp5_dat_int;
+                    fpga1_spare_reg(2) <= uart0_sp5_to_fpga1_dat_int;
                 when SP_IPCC_BUS =>
-                    fpga1_spare_v1p8(3) <= uart1_fpga1_to_sp_dat_int;
-                    fpga1_spare_v1p8(2) <= uart1_sp_to_fpga1_dat;
+                    fpga1_spare_reg(3) <= uart1_fpga1_to_sp_dat_int;
+                    fpga1_spare_reg(2) <= uart1_sp_to_fpga1_dat_int;
+                when T6_SEQUENCER =>
+                    fpga1_spare_reg(3) <= nic_dbg_pins.sp5_mfg_mode_l;
+                    fpga1_spare_reg(2) <= nic_dbg_pins.nic_mfg_mode_l;
                 when others =>
                     -- Default case, do nothing
-                    fpga1_spare_v1p8(3 downto 2) <= (others => 'Z');
+                    fpga1_spare_reg(3 downto 2) <= (others => '0');
             end case;
 
             -- Deal with pins1..0
-            case dbg_1v8_ctrl.pins1_0 is
+            case dbg_1v8_ctrl_200.pins1_0 is
                 when I2C_DIMM0_BUS =>
-                    fpga1_spare_v1p8(1) <= i3c_fpga1_to_dimm_abcdef_scl_int;
-                    fpga1_spare_v1p8(0) <= i3c_fpga1_to_dimm_abcdef_sda_int;
+                    fpga1_spare_reg(1) <= i3c_fpga1_to_dimm_abcdef_scl_int;
+                    fpga1_spare_reg(0) <= i3c_fpga1_to_dimm_abcdef_sda_int;
                 when I2C_DIMM1_BUS =>
-                    fpga1_spare_v1p8(1) <= i3c_fpga1_to_dimm_ghijkl_scl_int;
-                    fpga1_spare_v1p8(0) <= i3c_fpga1_to_dimm_ghijkl_sda_int;
+                    fpga1_spare_reg(1) <= i3c_fpga1_to_dimm_ghijkl_scl_int;
+                    fpga1_spare_reg(0) <= i3c_fpga1_to_dimm_ghijkl_sda_int;
                 when I2C_SP5_DIMM0_BUS =>
-                    fpga1_spare_v1p8(1) <= i3c_sp5_to_fpga1_abcdef_scl_int;
-                    fpga1_spare_v1p8(0) <= i3c_sp5_to_fpga1_abcdef_sda_int;
+                    fpga1_spare_reg(1) <= i3c_sp5_to_fpga1_abcdef_scl_int;
+                    fpga1_spare_reg(0) <= i3c_sp5_to_fpga1_abcdef_sda_int;
                 when I2C_SP5_DIMM1_BUS =>
-                    fpga1_spare_v1p8(1) <= i3c_sp5_to_fpga1_ghijkl_scl_int;
-                    fpga1_spare_v1p8(0) <= i3c_sp5_to_fpga1_ghijkl_sda_int;
+                    fpga1_spare_reg(1) <= i3c_sp5_to_fpga1_ghijkl_scl_int;
+                    fpga1_spare_reg(0) <= i3c_sp5_to_fpga1_ghijkl_sda_int;
                 when I2C_SP5_HP_BUS =>
-                    fpga1_spare_v1p8(1) <= i2c_sp5_to_fpgax_hp_scl_int;
-                    fpga1_spare_v1p8(0) <= i2c_sp5_to_fpgax_hp_sda_int;
+                    fpga1_spare_reg(1) <= i2c_sp5_to_fpgax_hp_scl_int;
+                    fpga1_spare_reg(0) <= i2c_sp5_to_fpgax_hp_sda_int;
                 when I2C_SP_MUX_BUS =>
-                    fpga1_spare_v1p8(1) <= i2c_sp_to_fpga1_scl_int;
-                    fpga1_spare_v1p8(0) <= i2c_sp_to_fpga1_sda_int;
+                    fpga1_spare_reg(1) <= i2c_sp_to_fpga1_scl_int;
+                    fpga1_spare_reg(0) <= i2c_sp_to_fpga1_sda_int;
                 when ESPI_BUS =>
-                    fpga1_spare_v1p8(1) <= espi0_sp5_to_fpga1_dat(3);
-                    fpga1_spare_v1p8(0) <= espi0_sp5_to_fpga1_dat(2);
+                    fpga1_spare_reg(1) <= espi0_sp5_to_fpga1_dat_int(3);
+                    fpga1_spare_reg(0) <= espi0_sp5_to_fpga1_dat_int(2);
                 when SP_CONSOLE_BUS =>
-                    fpga1_spare_v1p8(1) <= uart1_fpga1_to_sp_dat_int;
-                    fpga1_spare_v1p8(0) <= uart0_sp_to_fpga1_dat_int;
+                    fpga1_spare_reg(1) <= uart1_fpga1_to_sp_dat_int;
+                    fpga1_spare_reg(0) <= uart0_sp_to_fpga1_dat_int;
                 when SP5_CONSOLE_BUS =>
-                    fpga1_spare_v1p8(1) <= uart0_fpga1_to_sp5_dat_int;
-                    fpga1_spare_v1p8(0) <= uart0_sp5_to_fpga1_dat_int;
+                    fpga1_spare_reg(1) <= uart0_fpga1_to_sp5_dat_int;
+                    fpga1_spare_reg(0) <= uart0_sp5_to_fpga1_dat_int;
                 when SP_IPCC_BUS =>
-                    fpga1_spare_v1p8(1) <= uart1_fpga1_to_sp_dat_int;
-                    fpga1_spare_v1p8(0) <= uart1_sp_to_fpga1_dat;
+                    fpga1_spare_reg(1) <= uart1_fpga1_to_sp_dat_int;
+                    fpga1_spare_reg(0) <= uart1_sp_to_fpga1_dat_int;
+                when T6_SEQUENCER =>
+                    fpga1_spare_reg(1) <= nic_dbg_pins.ext_rst_l;
+                    fpga1_spare_reg(0) <= '0'; -- Unused in this case.
                 when others =>
                     -- Default case, do nothing
-                    fpga1_spare_v1p8(1 downto 0) <= (others => 'Z');
+                    fpga1_spare_reg(1 downto 0) <= (others => '0');
             end case;
         end if;
     end process;
+
+
 
 end rtl;

--- a/hdl/projects/cosmo_seq/debug_module/debug_header.vhd
+++ b/hdl/projects/cosmo_seq/debug_module/debug_header.vhd
@@ -299,7 +299,7 @@ hdr_dbg_reg_1v8: process(clk_200m, reset_200m)
                     fpga1_spare_reg(0) <= uart1_sp_to_fpga1_dat_int;
                 when T6_SEQUENCER =>
                     fpga1_spare_reg(1) <= nic_dbg_pins.ext_rst_l;
-                    fpga1_spare_reg(0) <= '0'; -- Unused in this case.
+                    fpga1_spare_reg(0) <= sp5_debug2_pin_int; -- Unused in this case.
                 when others =>
                     -- Default case, do nothing
                     fpga1_spare_reg(1 downto 0) <= (others => '0');

--- a/hdl/projects/cosmo_seq/debug_module/debug_header.vhd
+++ b/hdl/projects/cosmo_seq/debug_module/debug_header.vhd
@@ -48,6 +48,8 @@ entity debug_header is
         espi_resp_csn: in std_logic;
         -- T6 signals
         nic_dbg_pins : view t6_debug_dbg;
+        -- sp5 toggle pins
+        sp5_debug2_pin : in std_logic;
 
         fpga1_spare_v1p8 : out std_logic_vector(7 downto 0); -- 8 spare pins on the debug header
 
@@ -81,6 +83,7 @@ architecture rtl of debug_header is
     signal dbg_1v8_ctrl_200 : dbg_1v8_ctrl_type;
     signal fpga1_spare_reg : std_logic_vector(7 downto 0);
     signal nic_dbg_pins_int : t6_debug_if;
+    signal sp5_debug2_pin_int : std_logic;
 
 
 begin
@@ -111,6 +114,7 @@ sample_reg: process(clk_200m, reset_200m)
             espi0_sp5_to_fpga1_dat_int <= espi0_sp5_to_fpga1_dat;
             espi_resp_csn_int <= espi_resp_csn;
             nic_dbg_pins_int <= nic_dbg_pins;
+            sp5_debug2_pin_int <= sp5_debug2_pin;
         end if;
     end process;
 

--- a/hdl/projects/cosmo_seq/debug_module/debug_module_top.vhd
+++ b/hdl/projects/cosmo_seq/debug_module/debug_module_top.vhd
@@ -110,6 +110,7 @@ begin
         espi0_sp5_to_fpga1_dat => espi0_sp5_to_fpga1_dat,
         espi_resp_csn => espi_resp_csn,
         nic_dbg_pins => nic_dbg_pins,
+        sp5_debug2_pin => sp5_debug2_pin,
         fpga1_spare_v1p8 => fpga1_spare_v1p8
     );
 

--- a/hdl/projects/cosmo_seq/debug_module/debug_module_top.vhd
+++ b/hdl/projects/cosmo_seq/debug_module/debug_module_top.vhd
@@ -14,6 +14,7 @@ use work.axil8x32_pkg.all;
 
 use work.debug_regs_pkg.all;
 use work.sp5_uart_subsystem_pkg.all;
+use work.sequencer_io_pkg.all;
 
 entity debug_module_top is
     port (
@@ -51,12 +52,13 @@ entity debug_module_top is
         uart0_fpga1_to_sp_dat : in std_logic; -- sp console
         uart0_fpga1_to_sp5_dat : in std_logic; -- sp5 console
         uart0_sp5_to_fpga1_dat : in std_logic; -- sp5 console
-
         -- ESPI signals
         espi0_sp5_to_fpga_clk: in std_logic;
         espi0_sp5_to_fpga_cs_l: in std_logic;
         espi0_sp5_to_fpga1_dat: in std_logic_vector(3 downto 0);
         espi_resp_csn: in std_logic;
+        --T6 signals
+        nic_dbg_pins : view t6_debug_dbg;
 
         fpga1_spare_v1p8 : out std_logic_vector(7 downto 0); -- 8 spare pins on the debug header
 
@@ -107,6 +109,7 @@ begin
         espi0_sp5_to_fpga_cs_l => espi0_sp5_to_fpga_cs_l,
         espi0_sp5_to_fpga1_dat => espi0_sp5_to_fpga1_dat,
         espi_resp_csn => espi_resp_csn,
+        nic_dbg_pins => nic_dbg_pins,
         fpga1_spare_v1p8 => fpga1_spare_v1p8
     );
 
@@ -218,6 +221,11 @@ begin
                             dbg_1v8_ctrl.pins5_4 <= ESPI_BUS;
                             dbg_1v8_ctrl.pins3_2 <= ESPI_BUS;
                             dbg_1v8_ctrl.pins1_0 <= ESPI_BUS;
+                        elsif dbg_convenience.t6_seq_en then
+                            dbg_1v8_ctrl.pins7_6 <= T6_SEQUENCER;
+                            dbg_1v8_ctrl.pins5_4 <= T6_SEQUENCER;
+                            dbg_1v8_ctrl.pins3_2 <= T6_SEQUENCER;
+                            dbg_1v8_ctrl.pins1_0 <= T6_SEQUENCER;
                         end if;
 
                     when others => null;

--- a/hdl/projects/cosmo_seq/debug_module/debug_regs.rdl
+++ b/hdl/projects/cosmo_seq/debug_module/debug_regs.rdl
@@ -123,6 +123,7 @@ addrmap debug_regs {
             sp_console_bus = 8'h08 {desc = "SP <-> FPGA console UART to pins";};
             sp5_console_bus = 8'h09 {desc = "SP5 <-> FPGA console UART to pins";};
             sp_ipcc_bus = 8'h0a {desc = "SP <-> FPGA IPCC UART to pins";};
+            t6_sequencer = 8'h0b {desc = "T6 sequencer debug output to pins";};
         };
         field {
             desc = "Selects which debug output is sent to the 1v8 debug header in sets of two pins.
@@ -156,6 +157,9 @@ addrmap debug_regs {
 
     reg {
         name = "Debug Convenience";
+         field {
+            desc = "convenience bit for setting up T6 sequencing debug out. This uses 1v8 debug header pins 7..0. Hw clears";
+        } t6_seq_en[2:2] = 0;
         field {
             desc = "convenience bit for setting up x4 espi debug out. This uses 1v8 debug header pins 7..0. Hw clears";
         } espi_dbg_x4_en[1:1] = 0;

--- a/hdl/projects/cosmo_seq/sequencer/sequencer_io_pkg.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sequencer_io_pkg.vhd
@@ -87,6 +87,27 @@ package sequencer_io_pkg is
         sp5_mfg_mode_l : in;
     end view;
     alias nic_seq_at_nic is nic_seq_at_fpga'converse;
+
+    type t6_debug_if is record
+        cld_rst_l : std_logic; -- T6 cld reset (FPGA output)
+        ext_rst_l : std_logic; -- T6 external reset (FPGA input)
+        rails_en : std_logic; -- T6 power rails enable (FPGA output combined)
+        rails_pg : std_logic; -- T6 power rails power good (FPGA input combined)
+        nic_mfg_mode_l : std_logic; -- T6 NIC manufacturing mode (FPGA output)
+        sp5_mfg_mode_l : std_logic; -- T6 SP5 manufacturing mode (FPGA input)
+        perst_l : std_logic; -- T6 PCIe reset (FPGA output)
+    end record;
+    view t6_debug_seq_ss of t6_debug_if is
+        cld_rst_l : out;
+        ext_rst_l : out;
+        rails_en : out;
+        rails_pg : out;
+        nic_mfg_mode_l : out;
+        sp5_mfg_mode_l : out;
+        perst_l : out;
+    end view;
+    alias t6_debug_dbg is t6_debug_seq_ss'converse;
+
     type early_power_t is record
         fan_central_hsc_pg : std_logic;
         fan_east_hsc_pg : std_logic;

--- a/hdl/projects/cosmo_seq/sequencer/sims/sp5_seq_sim_th.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sims/sp5_seq_sim_th.vhd
@@ -43,7 +43,6 @@ architecture th of sp5_seq_sim_th is
     signal nic_rails_pins : nic_power_t;
     signal a0_ok : std_logic;
     signal a0_idle : std_logic;
-    signal sp5_t6_power_en : std_logic;
     signal sp5_t6_perst_l : std_logic;
     signal axi_if : axil8x32_pkg.axil_t;
 
@@ -72,7 +71,7 @@ begin
        sp5_seq_pins => sp5_seq_pins,
        nic_rails_pins => nic_rails_pins,
        nic_seq_pins => nic_seq_pins,
-       sp5_t6_power_en => sp5_t6_power_en,
+       nic_dbg_pins => open,
        sp5_t6_perst_l => sp5_t6_perst_l
    );
 

--- a/hdl/projects/cosmo_seq/sequencer/sp5_sequencer.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sp5_sequencer.vhd
@@ -49,8 +49,8 @@ entity sp5_sequencer is
         -- nic sequencing I/O
         nic_seq_pins: view nic_seq_at_fpga;
         allow_backplane_pcie_clk : out std_logic;
+        nic_dbg_pins : view t6_debug_seq_ss;
 
-        sp5_t6_power_en : in std_logic;
         sp5_t6_perst_l : in std_logic;
 
         ignition_mux_sel : out std_logic;
@@ -259,8 +259,8 @@ begin
         upstream_ok => a0_ok,
         nic_overrides_reg => nic_overrides,
         debug_enables => debug_enables,
-        sp5_t6_power_en => sp5_t6_power_en,
         sp5_t6_perst_l => sp5_t6_perst_l,
+        nic_dbg_pins => nic_dbg_pins,
         nic_rails => nic_rails,
         nic_seq_pins => nic_seq
     );

--- a/hdl/projects/cosmo_seq/sp_i2c_subsystem/sp_i2c_subsystem.vhd
+++ b/hdl/projects/cosmo_seq/sp_i2c_subsystem/sp_i2c_subsystem.vhd
@@ -40,9 +40,9 @@ architecture rtl of sp_i2c_subsystem is
     type mux_sel_t is array (natural range <>) of std_logic_vector(1 downto 0);
 
     constant mux_i2c_addr:  io_i2c_addr_t(0 to 2) := (
-        b"1110_000",  -- Mux 1: M.2 A/B
-        b"1110_001",  -- Mux 2: APML / SEC
-        b"1110_010"   -- Mux 3: Fan VPD / NIC Therm
+        b"1110_000",  -- Mux 1: 0x70 M.2 A/B
+        b"1110_001",  -- Mux 2: 0x71 APML / SEC
+        b"1110_010"   -- Mux 3: 0x72 Fan VPD / NIC Therm
     );
     signal sp_tgt_scl : std_logic_vector(mux_i2c_addr'range);
     signal sp_tgt_scl_o : std_logic_vector(mux_i2c_addr'range);


### PR DESCRIPTION
* Added a basic CLAUDE.md
* Added T6 sequencing pins to debug header so we can look at them
* remap a chunk of host flash for the  APOB section to a different place in spi nor. This allows host flash images to hash w/o the APOB info which is unit-specific. This intercepts host fetches and rather than just applying the flash page offset it sends them to a known window where hubris has stored the APOB info.