### PR TITLE
wait until i2c stop to update mux

### DIFF
--- a/hdl/ip/vhd/i2c/muxes/PCA9545ish/pca9545ish_top.vhd
+++ b/hdl/ip/vhd/i2c/muxes/PCA9545ish/pca9545ish_top.vhd
@@ -66,6 +66,7 @@ architecture rtl of pca9545ish_top is
     signal resp_data : std_logic_vector(7 downto 0);
     signal resp_valid : std_logic;
     signal resp_ready : std_logic;
+    signal stop_condition : std_logic;
 
 begin
 
@@ -91,7 +92,8 @@ begin
         txn_header => txn_header,
         resp_data => resp_data,
         resp_valid => resp_valid,
-        resp_ready => resp_ready
+        resp_ready => resp_ready,
+        stop_condition => stop_condition
     );
 
     -- mux functional logic
@@ -106,6 +108,7 @@ begin
         mux_sel => mux_sel,
         allowed_to_enable => allowed_to_enable,
         mux_is_active => mux_is_active,
+        stop_condition => stop_condition,
         inst_data => inst_data,
         inst_valid => inst_valid,
         inst_ready => inst_ready,

--- a/hdl/ip/vhd/i2c/muxes/PCA9545ish/sims/i2c_pca9545ish_tb.vhd
+++ b/hdl/ip/vhd/i2c/muxes/PCA9545ish/sims/i2c_pca9545ish_tb.vhd
@@ -48,6 +48,7 @@ begin
         variable ack_queue        : queue_t              := new_queue;
         variable expected_ack_queue        : queue_t     := new_queue;
         variable ack_status : boolean := false;
+        variable actor : actor_t := find("i2c_ctrl_vc");
 
     begin
         -- Always the first thing in the process, set up things for the VUnit test runner
@@ -63,13 +64,14 @@ begin
                 -- Enable ch0 of the mux via i2c command
                 push_byte(tx_queue, to_integer(std_logic_vector'(8x"01")));
                 i2c_write_txn (net, mux0_addr, tx_queue, ack_queue);
+                wait_until_idle(net, actor);
                 check_true(contains_all_acks(ack_queue), "Either no acks or some Nacks were found");
                 -- Verify mux ch0 is selected
                 check_equal(mux0_sel, chA_selected, "CHA Mux not selected after write");
 
                 -- Now read back the register
                 i2c_read_txn(net, mux0_addr, 1, rx_queue, ack_status);
-                wait for 1 us;
+                wait_until_idle(net, actor);
                 check_true(ack_status, "Target didn't ack during readback");
                 check_equal(pop_byte(rx_queue), 1, "CHA Readback didn't return expected value");
 
@@ -78,6 +80,7 @@ begin
                 -- Enable ch0 of the mux via i2c command
                 push_byte(tx_queue, to_integer(std_logic_vector'(8x"01")));
                 i2c_write_txn (net, mux1_addr, tx_queue, ack_queue);
+                wait_until_idle(net, actor);
                 check_true(contains_all_acks(ack_queue), "Either no acks or some Nacks were found");
                 -- Verify mux chA is selected on the alternate address
                 -- not on the default address
@@ -85,7 +88,7 @@ begin
                 check_equal(mux1_sel, chA_selected, "CHA on Mux1 was not selected after write");
                 -- Now read back the register
                 i2c_read_txn(net, mux1_addr, 1, rx_queue, ack_status);
-                wait for 1 us;
+                wait_until_idle(net, actor);
                 check_true(ack_status, "Target didn't ack during readback");
                 check_equal(pop_byte(rx_queue), 1, "CHA Readback didn't return expected value");
             elsif run("nack-wrong-target") then
@@ -93,12 +96,14 @@ begin
                 push_byte(tx_queue, to_integer(std_logic_vector'(8x"01")));
                 -- Write *something* to the wrong target address, expecting a NACK
                 i2c_write_txn(net, 7x"75", tx_queue, ack_queue);
+                wait_until_idle(net, actor);
                 check_true(target_addr_nack(ack_queue), "Target unexpectedly ACK'd write at wrong address");
                 check_equal(mux0_sel, not_selected, "Mux not still disconnected after NACK'd write");
 
                 push_byte(tx_queue, to_integer(std_logic_vector'(8x"01")));
                 -- Write *something* to the wrong target address, expecting a NACK
                 i2c_read_txn(net, 7x"75", 1, rx_queue, ack_status);
+                wait_until_idle(net, actor);
                 check_false(ack_status, "Target ACK'd read at wrong address");
 
             elsif run("multi-channel-attempt") then
@@ -106,11 +111,13 @@ begin
                 -- Enable ch0 of the mux via i2c command
                 push_byte(tx_queue, to_integer(std_logic_vector'(8x"01")));
                 i2c_write_txn (net, mux0_addr, tx_queue, ack_queue);
+                wait_until_idle(net, actor);
                 -- Verify mux ch0 is selected
                 check_equal(mux0_sel, chA_selected, "CHA Mux not selected after write");
                 -- Now errantly try to enable multiple channels
                 push_byte(tx_queue, to_integer(std_logic_vector'(8x"03")));
                 i2c_write_txn (net, mux0_addr, tx_queue, ack_queue);
+                wait_until_idle(net, actor);
                 -- We expect a NACK on the control register 2nd byte, and the mux should remain in its previous state
                 push_boolean(expected_ack_queue, true);  -- ACK on the target address byte
                 push_boolean(expected_ack_queue, false);  -- NACK on the control register 2nd byte
@@ -123,11 +130,13 @@ begin
                 -- Enable chA of the mux via i2c command
                 push_byte(tx_queue, to_integer(std_logic_vector'(8x"01")));
                 i2c_write_txn (net, mux0_addr, tx_queue, ack_queue);
+                wait_until_idle(net, actor);
                 -- Verify mux0 chA is selected
                 check_equal(mux0_sel, chA_selected, "CHA Mux0 not selected after write");
                 -- Now errantly try to enable another mux
                 push_byte(tx_queue, to_integer(std_logic_vector'(8x"01")));
                 i2c_write_txn (net, mux1_addr, tx_queue, ack_queue);
+                wait_until_idle(net, actor);
                 -- We expect a NACK on the control register 2nd byte, and the mux should remain in its previous state
                 push_boolean(expected_ack_queue, true);  -- ACK on the target address byte
                 push_boolean(expected_ack_queue, false);  -- NACK on the control register 2nd byte
@@ -142,44 +151,52 @@ begin
                 -- Enable ch0 of the mux via i2c command
                 push_byte(tx_queue, to_integer(std_logic_vector'(8x"01")));
                 i2c_write_txn (net, mux0_addr, tx_queue, ack_queue);
+                wait_until_idle(net, actor);
                 -- Verify mux ch0 is selected
                 check_equal(mux0_sel, chA_selected, "CHA Mux not selected after write");
 
                 -- Now read back the register
                 i2c_read_txn(net, mux0_addr, 1, rx_queue, ack_status);
+                wait_until_idle(net, actor);
                 check_true(ack_status, "Target didn't ack during readback");
                 check_equal(pop_byte(rx_queue), 1, "CHA Readback didn't return expected value");
 
                 -- Enable ch1 of the mux via i2c command
                 push_byte(tx_queue, to_integer(std_logic_vector'(8x"02")));
                 i2c_write_txn (net, mux0_addr, tx_queue, ack_queue);
+                wait_until_idle(net, actor);
                 -- Verify mux ch1 is selected
                 check_equal(mux0_sel, chB_selected, "CHB Mux not selected after write");
 
                 -- Now read back the register
                 i2c_read_txn(net, mux0_addr, 1, rx_queue, ack_status);
+                wait_until_idle(net, actor);
                 check_true(ack_status, "Target didn't ack during readback");
                 check_equal(pop_byte(rx_queue), 2, "CHB Readback didn't return expected value");
 
                 -- Enable ch2 of the mux via i2c command
                 push_byte(tx_queue, to_integer(std_logic_vector'(8x"04")));
                 i2c_write_txn (net, mux0_addr, tx_queue, ack_queue);
+                wait_until_idle(net, actor);
                 -- Verify mux ch1 is selected
                 check_equal(mux0_sel, chC_selected, "CHC Mux not selected after write");
 
                 -- Now read back the register
                 i2c_read_txn(net, mux0_addr, 1, rx_queue, ack_status);
+                wait_until_idle(net, actor);
                 check_true(ack_status, "Target didn't ack during readback");
                 check_equal(pop_byte(rx_queue), 4, "CHC Readback didn't return expected value");
 
                 -- Disable all of the mux via i2c command
                 push_byte(tx_queue, to_integer(std_logic_vector'(8x"00")));
                 i2c_write_txn (net, mux0_addr, tx_queue, ack_queue);
+                wait_until_idle(net, actor);
                 -- Verify mux ch1 is selected
                 check_equal(mux0_sel, not_selected, "Some mux still not selected after write");
 
                 -- Now read back the register
                 i2c_read_txn(net, mux0_addr, 1, rx_queue, ack_status);
+                wait_until_idle(net, actor);
                 check_true(ack_status, "Target didn't ack during readback");
                 check_equal(pop_byte(rx_queue), 0, "Readback didn't return expected value 0");
 

--- a/hdl/ip/vhd/vunit_components/i2c_controller/i2c_ctrlr_vc.vhd
+++ b/hdl/ip/vhd/vunit_components/i2c_controller/i2c_ctrlr_vc.vhd
@@ -236,6 +236,12 @@ begin
             reply_msg := new_msg;
             push(reply_msg, ack_nack = '0');  -- 0 is a positive ack
             reply(net, request_msg, reply_msg);
+        elsif msg_type = wait_until_idle_msg then
+            -- Not idle while we're shifting
+            while state /= idle loop
+                wait on state;
+            end loop;
+            handle_wait_until_idle(net, msg_type, request_msg);
         else
             unexpected_msg_type(msg_type);
         end if;


### PR DESCRIPTION
previously i2c mux actions were taken immediately on the write. In a properly working system, this is a don't care usually but probably not correct. And definitely in a system where the segment we're turning on is already unhappy this breaks the saleae decode and makes debugging harder.

All of the silicon i2c muxes I can find, including the 9545 state something along the lines of:

> When a channel is selected, the channel will become active after a STOP condition has
> been placed on the I2C-bus. This ensures that all SCx/SDx lines are in a HIGH state
> when the channel is made active, so that no false conditions are generated at the time of
> connection.

So we fix that here, and adjust the simulations to wait for the transaction to completely finish before enabling the selected channel.

Fixes #387 