### PR TITLE
Wire up NIC API status

### DIFF
--- a/hdl/projects/cosmo_seq/sequencer/sequencer_regs.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sequencer_regs.vhd
@@ -30,6 +30,7 @@ entity sequencer_regs is
         seq_raw_status : in seq_raw_status_type;
         therm_trip : in std_logic;
         smerr_assert : in std_logic;
+        a0_faulted : in std_logic;
         -- from nic block
         nic_api_status : in nic_api_status_type;
         nic_raw_status : in nic_raw_status_type;
@@ -207,10 +208,16 @@ begin
         elsif rising_edge(clk) then
             ifr.thermtrip <= ifr.thermtrip or (not therm_trip_last and therm_trip);
             ifr.smerr_assert <= ifr.smerr_assert or (not smerr_assert_last and smerr_assert);
+            ifr.amd_rstn_fedge <= ifr.amd_rstn_fedge or amd_reset_l_fedge;
+            ifr.amd_pwrok_fedge <= ifr.amd_pwrok_fedge or amd_pwrok_fedge;
+            ifr.a0mapo <= ifr.a0mapo or a0_faulted;
+            -- TODO: not implemented yet
+            ifr.nicmapo <= '0';
+            ifr.fanfault <= '0';
 
             if active_write then
                 case to_integer(axi_if.write_address.addr) is
-                    when IFR_OFFSET => ifr <= ifr and (not axi_if.write_data.data);
+                    when IFR_OFFSET => ifr <= unpack(axi_if.write_data.data);
                     when IER_OFFSET => ier <= unpack(axi_if.write_data.data);
                     when EARLY_POWER_CTRL_OFFSET => early_power_ctrl <= unpack(axi_if.write_data.data);
                     when POWER_CTRL_OFFSET => power_ctrl <= unpack(axi_if.write_data.data);

--- a/hdl/projects/cosmo_seq/sequencer/sp5_sequencer.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sp5_sequencer.vhd
@@ -91,6 +91,7 @@ architecture rtl of sp5_sequencer is
     signal nic_overrides : nic_overrides_type;
     signal debug_enables : debug_enables_type;
     signal smerr_assert : std_logic;
+    signal a0_faulted : std_logic;
     
 
 
@@ -135,6 +136,7 @@ begin
         nic_raw_status => nic_raw_status,
         debug_enables => debug_enables,
         nic_overrides => nic_overrides,
+        a0_faulted => a0_faulted,
         rails_en_rdbk => rails_en_rdbk,
         rails_pg_rdbk => rails_pg_rdbk,
         sp5_readbacks => sp5_readbacks,
@@ -234,7 +236,7 @@ begin
         smerr_assert => smerr_assert,
         a0_ok => a0_ok,
         a0_idle => a0_idle,
-        a0_faulted => open,
+        a0_faulted => a0_faulted,
         sw_enable => power_ctrl.a0_en,
         raw_state => seq_raw_status,
         api_state => seq_api_status,

--- a/hdl/projects/cosmo_seq/sequencer/sp5_sequencer.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sp5_sequencer.vhd
@@ -256,7 +256,7 @@ begin
         nic_idle => nic_idle,
         sw_enable => power_ctrl.a0_en,
         raw_state => nic_raw_status,
-        api_state => open,
+        api_state => nic_api_status,
         upstream_ok => a0_ok,
         nic_overrides_reg => nic_overrides,
         debug_enables => debug_enables,


### PR DESCRIPTION
I noticed that that `humility dashboard` is never showing us in `A0PlusHP`.  It looks like the NIC API status register never changes:
```
   nic_api_status: NicApiStatusDebug { nic_sm: Ok(Idle) }, nic_raw_status: NicRawStatusDebug { hw_sm: 0x0 } }
   nic_api_status: NicApiStatusDebug { nic_sm: Ok(Idle) }, nic_raw_status: NicRawStatusDebug { hw_sm: 0x0 } }
   nic_api_status: NicApiStatusDebug { nic_sm: Ok(Idle) }, nic_raw_status: NicRawStatusDebug { hw_sm: 0x0 } }
   nic_api_status: NicApiStatusDebug { nic_sm: Ok(Idle) }, nic_raw_status: NicRawStatusDebug { hw_sm: 0x2 } }
   nic_api_status: NicApiStatusDebug { nic_sm: Ok(Idle) }, nic_raw_status: NicRawStatusDebug { hw_sm: 0x2 } }
   nic_api_status: NicApiStatusDebug { nic_sm: Ok(Idle) }, nic_raw_status: NicRawStatusDebug { hw_sm: 0x3 } }
   nic_api_status: NicApiStatusDebug { nic_sm: Ok(Idle) }, nic_raw_status: NicRawStatusDebug { hw_sm: 0x4 } }
   nic_api_status: NicApiStatusDebug { nic_sm: Ok(Idle) }, nic_raw_status: NicRawStatusDebug { hw_sm: 0x6 } }
```

Pattern-matching with nearby code, I think this is the issue!

I have added a bug-fix to the IFR flags also reported by matt to this PR.