### PR TITLE
Fix typo in crc implementation that was breaking ignition

### DIFF
--- a/hdl/ip/vhd/crc/crc8autostar_8wide.vhd
+++ b/hdl/ip/vhd/crc/crc8autostar_8wide.vhd
@@ -53,7 +53,7 @@ begin
                 crc_reg(2) <= crc_reg(0) xor crc_reg(1) xor crc_reg(2) xor crc_reg(3) xor crc_reg(4) xor crc_reg(6) xor
                               data_in(0) xor data_in(1) xor data_in(2) xor data_in(3) xor data_in(4) xor data_in(6);
                 crc_reg(3) <= crc_reg(0) xor crc_reg(1) xor crc_reg(2) xor crc_reg(4) xor 
-                              data_in(0) xor data_in(1) xor data_in(2) xor data_in(4) xor data_in(5);
+                              data_in(0) xor data_in(1) xor data_in(2) xor data_in(4);
                 crc_reg(4) <= crc_reg(1) xor crc_reg(2) xor crc_reg(3) xor crc_reg(5) xor 
                               data_in(1) xor data_in(2) xor data_in(3) xor data_in(5); 
                 crc_reg(5) <= crc_reg(0) xor crc_reg(2) xor crc_reg(4) xor crc_reg(5) xor crc_reg(6) xor crc_reg(7) xor 


### PR DESCRIPTION
Due to ?? reasons my initial implementation of this was wrong, I assume due to either a column-mode copy-paste error or some other editing mistake.

Since only one factor was messed up, the crc worked fine for some data patterns and generated incorrect data for others.