### PR TITLE
Add sequencer irq pin and fix nic state reporting

### DIFF
--- a/hdl/projects/cosmo_seq/cosmo_seq_top.vhd
+++ b/hdl/projects/cosmo_seq/cosmo_seq_top.vhd
@@ -403,7 +403,7 @@ begin
     -- misc things tied:
     fpga1_to_fpga2_io <= (others => 'Z');
     fpga1_to_sp5_sys_reset_l <= 'Z';  -- We don't use this in product, external PU.
-    fpga1_to_sp_irq_l <= (others => '1');
+    fpga1_to_sp_irq_l(6 downto 2) <= (others => '1');
     fpga1_to_bp_buff_output_en_l <= '0'; -- This buffer has to be enabled to see any BP PCIe signals
     -- Enable various buffers when we're in A0:
     fpga1_espi0_cs_l_buff_oe_en_l <= '0' when sp5_seq_pins.pwr_good else 'Z';
@@ -626,6 +626,7 @@ begin
         axi_if => responders(SEQ_RESP_IDX),
         a0_ok => a0_ok,
         a0_idle => a0_idle,
+        irq_l_out => fpga1_to_sp_irq_l(1),
         allow_backplane_pcie_clk => allow_backplane_pcie_clk,
         early_power_pins => early_power,
         ddr_bulk_pins => ddr_bulk,

--- a/hdl/projects/cosmo_seq/sequencer/nic_seq.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/nic_seq.vhd
@@ -130,7 +130,15 @@ begin
                     api_state.nic_sm <= NIC_RESET;
 
                 when DONE =>
-                    api_state.nic_sm <= DONE;
+                    -- PRE-reset is done but we want to expose the final reset state to
+                    -- the API so that it can see that the NIC is up and running after the
+                    -- SP5 hotplug stuff happens and it is enabled vs immediately after power on
+                    -- while still in reset.
+                    if rst_nic_r.state = PERST_DEASSERTED then
+                        api_state.nic_sm <= DONE;
+                    else
+                        api_state.nic_sm <= NIC_RESET;
+                    end if;
 
             end case;
         end if;

--- a/hdl/projects/cosmo_seq/sequencer/sp5_sequencer.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sp5_sequencer.vhd
@@ -28,6 +28,7 @@ entity sp5_sequencer is
         reset : in std_logic;
 
         axi_if : view axil8x32_pkg.axil_target;
+        irq_l_out : out std_logic;
         -- These signals are useful throughout the design for dealing with
         -- buffers, a0-domain "reset" kinds of things etc
         a0_ok : out std_logic;


### PR DESCRIPTION
This adds sequencer irq wired all the way out to the pins for  hubris consumption, and fixes the A0PlusHP state to only be active when the NIC is finally commanded out of reset by the SP5.

Fixes #399 
Fixes #398 
