### PR TITLE
cosmo-seq: fix missing wire for sequencer IRQ

### DIFF
--- a/hdl/projects/cosmo_seq/sequencer/sp5_sequencer.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sp5_sequencer.vhd
@@ -143,7 +143,8 @@ begin
         sp5_readbacks => sp5_readbacks,
         nic_readbacks => nic_readbacks,
         ignition_mux_sel => ignition_mux_sel,
-        ignition_creset => ignition_creset
+        ignition_creset => ignition_creset,
+        irq_l_out => irq_l_out
     );
 
     -- control from hubris


### PR DESCRIPTION
We got it into the register interface and then from the sequencer to the pin, but didn't tie the register to the pin in the sequencer itself.