### PR TITLE
pmbus sequencer alerts

### DIFF
--- a/hdl/projects/cosmo_seq/cosmo_seq_top.vhd
+++ b/hdl/projects/cosmo_seq/cosmo_seq_top.vhd
@@ -391,6 +391,7 @@ architecture rtl of cosmo_seq_top is
     signal uart_dbg_if : uart_dbg_t;
     signal allow_backplane_pcie_clk : std_logic;
     signal nic_dbg_pins : t6_debug_if;
+    signal reg_alert_l_pins : seq_power_alert_pins_t;
 
 begin
 
@@ -639,7 +640,8 @@ begin
         nic_dbg_pins => nic_dbg_pins,
         sp5_t6_perst_l => sp5_t6_perst_l,
         ignition_mux_sel => fpga1_to_sp_mux_ign_mux_sel,
-        ignition_creset => fpga1_to_ign_trgt_fpga_creset
+        ignition_creset => fpga1_to_ign_trgt_fpga_creset,
+        reg_alert_l_pins => reg_alert_l_pins
     );
 
     -- early power related pins
@@ -729,7 +731,26 @@ begin
     dimm_ghijkl_scl_if.i <= i3c_fpga1_to_dimm_ghijkl_scl;
     i3c_fpga1_to_dimm_ghijkl_sda <= dimm_ghijkl_sda_if.o when dimm_ghijkl_sda_if.oe else 'Z';
     dimm_ghijkl_sda_if.i <= i3c_fpga1_to_dimm_ghijkl_sda;
+
     
+    reg_alert_l_pins.smbus_fan_central_hsc_to_fpga1_alert_l <= smbus_fan_central_hsc_to_fpga1_alert_l;
+    reg_alert_l_pins.smbus_fan_east_hsc_to_fpga1_alert_l <= smbus_fan_east_hsc_to_fpga1_alert_l;
+    reg_alert_l_pins.smbus_fan_west_hsc_to_fpga1_alert_l <= smbus_fan_west_hsc_to_fpga1_alert_l;
+    reg_alert_l_pins.smbus_ibc_to_fpga1_alert_l <= smbus_ibc_to_fpga1_alert_l;
+    reg_alert_l_pins.smbus_m2_hsc_to_fpga1_alert_l <= smbus_m2_hsc_to_fpga1_alert_l;
+    reg_alert_l_pins.smbus_nic_hsc_to_fpga1_alert_l <= smbus_nic_hsc_to_fpga1_alert_l;
+    reg_alert_l_pins.smbus_v12_ddr5_abcdef_hsc_to_fpga1_alert <= smbus_v12_ddr5_abcdef_hsc_to_fpga1_alert;
+    reg_alert_l_pins.smbus_v12_ddr5_ghijkl_hsc_to_fpga1_alert <= smbus_v12_ddr5_ghijkl_hsc_to_fpga1_alert;
+    reg_alert_l_pins.smbus_v12_mcio_a0hp_hsc_to_fpga1_alert_l <= smbus_v12_mcio_a0hp_hsc_to_fpga1_alert_l;
+    reg_alert_l_pins.main_hsc_to_fpga1_alert_l <= main_hsc_to_fpga1_alert_l;
+    reg_alert_l_pins.vr_v1p8_sys_to_fpga1_alert_l <= vr_v1p8_sys_to_fpga1_alert_l;
+    reg_alert_l_pins.vr_v3p3_sys_to_fpga1_alert_l <= vr_v3p3_sys_to_fpga1_alert_l;
+    reg_alert_l_pins.vr_v5p0_sys_to_fpga1_alert_l <= vr_v5p0_sys_to_fpga1_alert_l;
+    reg_alert_l_pins.pwr_cont1_to_fpga1_alert_l <= pwr_cont1_to_fpga1_alert_l;
+    reg_alert_l_pins.v0p96_nic_to_fpga1_alert_l <= v0p96_nic_to_fpga1_alert_l;
+    reg_alert_l_pins.pwr_cont2_to_fpga1_alert_l <= pwr_cont2_to_fpga1_alert_l;
+    reg_alert_l_pins.pwr_cont3_to_fpga1_alert_l <= pwr_cont3_to_fpga1_alert_l;
+
     dimm_spd_proxy_top_inst: entity work.dimms_subsystem_top
      generic map(
         CLK_PER_NS => 8,

--- a/hdl/projects/cosmo_seq/sequencer/seq_sync.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/seq_sync.vhd
@@ -24,6 +24,7 @@ entity seq_sync is
         sp5_seq_pins : view sp5_seq_at_fpga;
         nic_rails_pins : view nic_power_at_fpga;
         nic_seq_pins: view nic_seq_at_fpga;
+        reg_alert_l_pins : view power_alert_at_fpga;
         -- internal, synchronized interfaces
         early_power : view early_power_on_board;
         ddr_bulk: view ddr_bulk_at_reg;
@@ -32,7 +33,8 @@ entity seq_sync is
         group_c : view group_c_power_at_reg;
         sp5_seq : view sp5_seq_at_sp5;
         nic_rails : view nic_power_at_reg;
-        nic_seq: view nic_seq_at_nic
+        nic_seq: view nic_seq_at_nic;
+        reg_alert_l : view power_alert_at_reg;
     );
     end entity;
 
@@ -271,4 +273,113 @@ begin
        sycnd_output => nic_seq.sp5_mfg_mode_l
     );
 
+    -- Alert sync stuff
+       
+
+    smbus_fan_central_hsc_to_fpga1_alert_l_sync: entity work.meta_sync
+    port map(
+       async_input => reg_alert_l_pins.smbus_fan_central_hsc_to_fpga1_alert_l,
+       clk => clk,
+       sycnd_output => reg_alert_l.smbus_fan_central_hsc_to_fpga1_alert_l
+    );
+    smbus_fan_east_hsc_to_fpga1_alert_l_sync: entity work.meta_sync
+    port map(
+       async_input => reg_alert_l_pins.smbus_fan_east_hsc_to_fpga1_alert_l,
+       clk => clk,
+       sycnd_output => reg_alert_l.smbus_fan_east_hsc_to_fpga1_alert_l
+    );
+    smbus_fan_west_hsc_to_fpga1_alert_l_sync: entity work.meta_sync
+    port map(
+       async_input => reg_alert_l_pins.smbus_fan_west_hsc_to_fpga1_alert_l,
+       clk => clk,
+       sycnd_output => reg_alert_l.smbus_fan_west_hsc_to_fpga1_alert_l
+    );
+   smbus_ibc_to_fpga1_alert_l_sync: entity work.meta_sync
+    port map(
+       async_input => reg_alert_l_pins.smbus_ibc_to_fpga1_alert_l,
+       clk => clk,
+       sycnd_output => reg_alert_l.smbus_ibc_to_fpga1_alert_l
+    );
+   smbus_m2_hsc_to_fpga1_alert_l_sync: entity work.meta_sync
+    port map(
+       async_input => reg_alert_l_pins.smbus_m2_hsc_to_fpga1_alert_l,
+       clk => clk,
+       sycnd_output => reg_alert_l.smbus_m2_hsc_to_fpga1_alert_l
+    );
+   smbus_nic_hsc_to_fpga1_alert_l_sync: entity work.meta_sync
+    port map(
+       async_input => reg_alert_l_pins.smbus_nic_hsc_to_fpga1_alert_l,
+       clk => clk,
+       sycnd_output => reg_alert_l.smbus_nic_hsc_to_fpga1_alert_l
+    );
+    smbus_v12_ddr5_abcdef_hsc_to_fpga1_alert_sync: entity work.meta_sync
+    port map(
+       async_input => reg_alert_l_pins.smbus_v12_ddr5_abcdef_hsc_to_fpga1_alert,
+       clk => clk,
+       sycnd_output => reg_alert_l.smbus_v12_ddr5_abcdef_hsc_to_fpga1_alert
+    );
+
+    smbus_v12_ddr5_ghijkl_hsc_to_fpga1_alert_sync: entity work.meta_sync
+    port map(
+       async_input => reg_alert_l_pins.smbus_v12_ddr5_ghijkl_hsc_to_fpga1_alert,
+       clk => clk,
+       sycnd_output => reg_alert_l.smbus_v12_ddr5_ghijkl_hsc_to_fpga1_alert
+    );
+    smbus_v12_mcio_a0hp_hsc_to_fpga1_alert_l_sync: entity work.meta_sync
+    port map(
+       async_input => reg_alert_l_pins.smbus_v12_mcio_a0hp_hsc_to_fpga1_alert_l,
+       clk => clk,
+       sycnd_output => reg_alert_l.smbus_v12_mcio_a0hp_hsc_to_fpga1_alert_l
+    );
+   main_hsc_to_fpga1_alert_l_sync: entity work.meta_sync
+    port map(
+       async_input => reg_alert_l_pins.main_hsc_to_fpga1_alert_l,
+       clk => clk,
+       sycnd_output => reg_alert_l.main_hsc_to_fpga1_alert_l
+    );
+   vr_v1p8_sys_to_fpga1_alert_l_sync: entity work.meta_sync
+    port map(
+       async_input => reg_alert_l_pins.vr_v1p8_sys_to_fpga1_alert_l,
+       clk => clk,
+       sycnd_output => reg_alert_l.vr_v1p8_sys_to_fpga1_alert_l
+    );
+   vr_v3p3_sys_to_fpga1_alert_l_sync: entity work.meta_sync
+    port map(
+       async_input => reg_alert_l_pins.vr_v3p3_sys_to_fpga1_alert_l,
+       clk => clk,
+       sycnd_output => reg_alert_l.vr_v3p3_sys_to_fpga1_alert_l
+    );
+    vr_v5p0_sys_to_fpga1_alert_l_sync: entity work.meta_sync
+    port map(
+       async_input => reg_alert_l_pins.vr_v5p0_sys_to_fpga1_alert_l,
+       clk => clk,
+       sycnd_output => reg_alert_l.vr_v5p0_sys_to_fpga1_alert_l
+    );
+
+   pwr_cont1_to_fpga1_alert_l_sync: entity work.meta_sync
+    port map(
+       async_input => reg_alert_l_pins.pwr_cont1_to_fpga1_alert_l,
+       clk => clk,
+       sycnd_output => reg_alert_l.pwr_cont1_to_fpga1_alert_l
+    );
+   v0p96_nic_to_fpga1_alert_l_sync: entity work.meta_sync
+    port map(
+       async_input => reg_alert_l_pins.v0p96_nic_to_fpga1_alert_l,
+       clk => clk,
+       sycnd_output => reg_alert_l.v0p96_nic_to_fpga1_alert_l
+    );
+   pwr_cont2_to_fpga1_alert_l_sync: entity work.meta_sync
+    port map(
+       async_input => reg_alert_l_pins.pwr_cont2_to_fpga1_alert_l,
+       clk => clk,
+       sycnd_output => reg_alert_l.pwr_cont2_to_fpga1_alert_l
+    );
+   pwr_cont3_to_fpga1_alert_l_sync: entity work.meta_sync
+    port map(
+       async_input => reg_alert_l_pins.pwr_cont3_to_fpga1_alert_l,
+       clk => clk,
+       sycnd_output => reg_alert_l.pwr_cont3_to_fpga1_alert_l
+    );
+
+    
 end rtl;

--- a/hdl/projects/cosmo_seq/sequencer/sequencer_io_pkg.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sequencer_io_pkg.vhd
@@ -65,6 +65,46 @@ package sequencer_io_pkg is
     end view;
     alias sp5_seq_at_sp5 is sp5_seq_at_fpga'converse;
 
+    type seq_power_alert_pins_t is record
+        smbus_fan_central_hsc_to_fpga1_alert_l : std_logic;
+        smbus_fan_east_hsc_to_fpga1_alert_l : std_logic;
+        smbus_fan_west_hsc_to_fpga1_alert_l : std_logic;
+        smbus_ibc_to_fpga1_alert_l : std_logic;
+        smbus_m2_hsc_to_fpga1_alert_l : std_logic;
+        smbus_nic_hsc_to_fpga1_alert_l : std_logic;
+        smbus_v12_ddr5_abcdef_hsc_to_fpga1_alert : std_logic;
+        smbus_v12_ddr5_ghijkl_hsc_to_fpga1_alert : std_logic;
+        smbus_v12_mcio_a0hp_hsc_to_fpga1_alert_l : std_logic;
+        main_hsc_to_fpga1_alert_l : std_logic;
+        vr_v1p8_sys_to_fpga1_alert_l : std_logic;
+        vr_v3p3_sys_to_fpga1_alert_l : std_logic;
+        vr_v5p0_sys_to_fpga1_alert_l : std_logic;
+        pwr_cont1_to_fpga1_alert_l : std_logic;
+        v0p96_nic_to_fpga1_alert_l : std_logic;
+        pwr_cont2_to_fpga1_alert_l : std_logic;
+        pwr_cont3_to_fpga1_alert_l : std_logic;
+    end record;
+    view power_alert_at_fpga of seq_power_alert_pins_t is
+        smbus_fan_central_hsc_to_fpga1_alert_l : in;
+        smbus_fan_east_hsc_to_fpga1_alert_l : in;
+        smbus_fan_west_hsc_to_fpga1_alert_l : in;
+        smbus_ibc_to_fpga1_alert_l : in;
+        smbus_m2_hsc_to_fpga1_alert_l : in;
+        smbus_nic_hsc_to_fpga1_alert_l : in;
+        smbus_v12_ddr5_abcdef_hsc_to_fpga1_alert : in;
+        smbus_v12_ddr5_ghijkl_hsc_to_fpga1_alert : in;
+        smbus_v12_mcio_a0hp_hsc_to_fpga1_alert_l : in;
+        main_hsc_to_fpga1_alert_l : in;
+        vr_v1p8_sys_to_fpga1_alert_l : in;
+        vr_v3p3_sys_to_fpga1_alert_l : in;
+        vr_v5p0_sys_to_fpga1_alert_l : in;
+        pwr_cont1_to_fpga1_alert_l : in;
+        v0p96_nic_to_fpga1_alert_l : in;
+        pwr_cont2_to_fpga1_alert_l : in;
+        pwr_cont3_to_fpga1_alert_l : in;
+    end view;
+    alias power_alert_at_reg is power_alert_at_fpga'converse;
+
     -- Nic sequencing-related control/feedback pins
     type nic_seq_pins_t is record
         cld_rst_l : std_logic;

--- a/hdl/projects/cosmo_seq/sequencer/sequencer_regs.rdl
+++ b/hdl/projects/cosmo_seq/sequencer/sequencer_regs.rdl
@@ -12,27 +12,82 @@ addrmap sequencer_regs {
  
     // IRQ for faults
     reg irq {
-           field {
-               desc = "Fan Fault";
-           } fanfault[1];
-           field {
-               desc = "Thermtrip- Thermal trip indicated from SP5 (sticky since fpga reset or last clear)";
-           } thermtrip[1];
-           field {
-               desc = "SMERR_L asserted low while CPU was powered up";
-           } smerr_assert[1];
-           field {
-               desc = "A1A0 MAPO- A fault in the A1-A0 domain(s) caused a MAPO (sticky since fpga reset or last clear)";
-           } a0mapo[1];
-           field {
-               desc = "Nic MAPO- A fault in the A0 domain caused a MAPO (sticky since fpga reset or last clear)";
-           } nicmapo[1];
-           field {
-               desc = "AMD PWROK falling edge while in >=A0 (sticky since fpga reset or last clear)";
-           } amd_pwrok_fedge[1];
-           field {
-               desc = "AMD RESET falling edge while in >=A0 (sticky since fpga reset or last clear)";
-           } amd_rstn_fedge[1];
+        field {
+            desc = "Fan Fault";
+        } fanfault[1];
+        field {
+            desc = "Thermtrip- Thermal trip indicated from SP5 (sticky since fpga reset or last clear)";
+        } thermtrip[1];
+        field {
+            desc = "SMERR_L asserted low while CPU was powered up";
+        } smerr_assert[1];
+        field {
+            desc = "A1A0 MAPO- A fault in the A1-A0 domain(s) caused a MAPO (sticky since fpga reset or last clear)";
+        } a0mapo[1];
+        field {
+            desc = "Nic MAPO- A fault in the A0 domain caused a MAPO (sticky since fpga reset or last clear)";
+        } nicmapo[1];
+        field {
+            desc = "AMD PWROK falling edge while in >=A0 (sticky since fpga reset or last clear)";
+        } amd_pwrok_fedge[1];
+        field {
+            desc = "AMD RESET falling edge while in >=A0 (sticky since fpga reset or last clear)";
+        } amd_rstn_fedge[1];
+        
+        field {
+            desc = "Live. Set '1' when smbus_fan_central_hsc_to_fpga1_alert_l is active (low on board)";
+        } fan_central_hsc_alert[1];
+        field {
+            desc = "Live. Set '1' when smbus_fan_east_hsc_to_fpga1_alert_l is active (low on board)";
+        } fan_east_hsc_alert[1];
+        field {
+            desc = "Live. Set '1' when smbus_fan_west_hsc_to_fpga1_alert_l is active (low on board)";
+        } fan_west_hsc_alert[1];
+        field {
+            desc = "Live. Set '1' when smbus_ibc_to_fpga1_alert_l is active (low on board)";
+        } ibc_alert[1];
+        field {
+            desc = "Live. Set '1' when smbus_m2_hsc_to_fpga1_alert_l is active (low on board)";
+        } m2_hsc_alert[1];
+        field {
+            desc = "Live. Set '1' when smbus_nic_hsc_to_fpga1_alert_l is active (low on board)";
+        } nic_hsc_alert[1];
+        field {
+            desc = "Live. Set '1' when smbus_v12_ddr5_abcdef_hsc_to_fpga1_alert_l is active (low on board)";
+        } v12_ddr5_abcdef_hsc_alert[1];
+        field {
+            desc = "Live. Set '1' when smbus_v12_ddr5_ghijkl_hsc_to_fpga1_alert_l is active (low on board)";
+        } v12_ddr5_ghijkl_hsc_alert[1];
+        field {
+            desc = "Live. Set '1' when smbus_v12_mcio_a0hp_hsc_to_fpga1_alert_l is active (low on board)";
+        } v12_mcio_a0hp_hsc_alert[1];
+        field {
+            desc = "Live. Set '1' when main_hsc_to_fpga1_alert_l is active (low on board)";
+        } main_hsc_alert[1];
+        field {
+            desc = "Live. Set '1' when vr_v1p8_sys_to_fpga1_alert_l is active (low on board)";
+        } vr_v1p8_sys_to_fpga1_alert[1];
+        field {
+            desc = "Live. Set '1' when vr_v3p3_sys_to_fpga1_alert_l is active (low on board)";
+        } vr_v3p3_sys_to_fpga1_alert[1];
+        field {
+            desc = "Live. Set '1' when vr_v5p0_sys_to_fpga1_alert_l is active (low on board)";
+        } vr_v5p0_sys_to_fpga1_alert[1];
+        field {
+            desc = "Live. Set '1' when v0p96_nic_to_fpga1_alert_l is active (low on board)";
+        } v0p96_nic_to_fpga1_alert[1];
+         field {
+            desc = "Live. Set '1' when pwr_cont1_to_fpga1_alert_l is active (low on board).
+This regulator controls VDDCR_CPU0_EN and VDDCR_SOC rails.";
+        } pwr_cont1_to_fpga1_alert[1];
+        field {
+            desc = "Live. Set '1' when pwr_cont2_to_fpga1_alert_l is active (low on board)
+This regulator controls VDDCR_CPU1_EN and VDDIO_SP5 rails.";
+        } pwr_cont2_to_fpga1_alert[1];
+        field {
+            desc = "Live. Set '1' when pwr_cont3_to_fpga1_alert_l is active (low on board).
+This regulator controls V1P1_SP5_A0, V1P8_SP5_A0 and V3P3_SP5_A0 rails.";
+        } pwr_cont3_to_fpga1_alert[1];
        };
     // Set up interrupt registers using a common irq_type
     irq IFR;

--- a/hdl/projects/cosmo_seq/sequencer/sequencer_regs.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sequencer_regs.vhd
@@ -12,6 +12,7 @@ use ieee.numeric_std_unsigned.all;
 use work.axil_common_pkg.all;
 use work.axil8x32_pkg;
 
+use work.sequencer_io_pkg.all;
 use work.sequencer_regs_pkg.all;
 
 entity sequencer_regs is
@@ -44,7 +45,9 @@ entity sequencer_regs is
         nic_readbacks : in nic_readbacks_type;
         -- Ignition mux and reconfig control
         ignition_mux_sel : out std_logic;
-        ignition_creset : out std_logic
+        ignition_creset : out std_logic;
+        -- regulator alerts
+        reg_alert_l : in seq_power_alert_pins_t
 
 
     );
@@ -237,6 +240,25 @@ begin
                     when others => null;
                 end case;
             end if;
+            -- These  are done after the write action since they are "live" and not sticky
+            -- so we don't allow writing to actually clear them so these will take precedence.
+            ifr.pwr_cont3_to_fpga1_alert <= not reg_alert_l.pwr_cont3_to_fpga1_alert_l;
+            ifr.pwr_cont2_to_fpga1_alert <= not reg_alert_l.pwr_cont2_to_fpga1_alert_l;
+            ifr.pwr_cont1_to_fpga1_alert <= not reg_alert_l.pwr_cont1_to_fpga1_alert_l;
+            ifr.v0p96_nic_to_fpga1_alert <= not reg_alert_l.v0p96_nic_to_fpga1_alert_l;
+            ifr.vr_v5p0_sys_to_fpga1_alert <= not reg_alert_l.vr_v5p0_sys_to_fpga1_alert_l;
+            ifr.vr_v3p3_sys_to_fpga1_alert <= not reg_alert_l.vr_v3p3_sys_to_fpga1_alert_l;
+            ifr.vr_v1p8_sys_to_fpga1_alert <= not reg_alert_l.vr_v1p8_sys_to_fpga1_alert_l;
+            ifr.main_hsc_alert <= not reg_alert_l.main_hsc_to_fpga1_alert_l;
+            ifr.v12_mcio_a0hp_hsc_alert <= not reg_alert_l.smbus_v12_mcio_a0hp_hsc_to_fpga1_alert_l;
+            ifr.v12_ddr5_ghijkl_hsc_alert <= not reg_alert_l.smbus_v12_ddr5_ghijkl_hsc_to_fpga1_alert;
+            ifr.v12_ddr5_abcdef_hsc_alert <= not reg_alert_l.smbus_v12_ddr5_abcdef_hsc_to_fpga1_alert;
+            ifr.nic_hsc_alert <= not reg_alert_l.smbus_nic_hsc_to_fpga1_alert_l;
+            ifr.m2_hsc_alert <= not reg_alert_l.smbus_m2_hsc_to_fpga1_alert_l;
+            ifr.ibc_alert <= not reg_alert_l.smbus_ibc_to_fpga1_alert_l;
+            ifr.fan_west_hsc_alert <= not reg_alert_l.smbus_fan_west_hsc_to_fpga1_alert_l;
+            ifr.fan_east_hsc_alert <= not reg_alert_l.smbus_fan_east_hsc_to_fpga1_alert_l;
+            ifr.fan_central_hsc_alert <= not reg_alert_l.smbus_fan_central_hsc_to_fpga1_alert_l;
 
         end if;
     end process;

--- a/hdl/projects/cosmo_seq/sequencer/sims/sp5_seq_sim_th.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sims/sp5_seq_sim_th.vhd
@@ -39,6 +39,25 @@ architecture th of sp5_seq_sim_th is
         fan_east_hsc_disable => 'Z',
         fan_west_hsc_disable => 'Z'
         );
+    signal reg_alert_l_pins : seq_power_alert_pins_t := (
+        smbus_fan_central_hsc_to_fpga1_alert_l => '1',
+        smbus_fan_east_hsc_to_fpga1_alert_l => '1',
+        smbus_fan_west_hsc_to_fpga1_alert_l => '1',
+        smbus_ibc_to_fpga1_alert_l => '1',
+        smbus_m2_hsc_to_fpga1_alert_l => '1',
+        smbus_nic_hsc_to_fpga1_alert_l => '1',
+        smbus_v12_ddr5_abcdef_hsc_to_fpga1_alert => '1',
+        smbus_v12_ddr5_ghijkl_hsc_to_fpga1_alert => '1',
+        smbus_v12_mcio_a0hp_hsc_to_fpga1_alert_l => '1',
+        main_hsc_to_fpga1_alert_l => '1',
+        vr_v1p8_sys_to_fpga1_alert_l => '1',
+        vr_v3p3_sys_to_fpga1_alert_l => '1',
+        vr_v5p0_sys_to_fpga1_alert_l => '1',
+        pwr_cont1_to_fpga1_alert_l => '1',
+        v0p96_nic_to_fpga1_alert_l => '1',
+        pwr_cont2_to_fpga1_alert_l => '1',
+        pwr_cont3_to_fpga1_alert_l => '1'
+    );
     signal ddr_bulk_pins : ddr_bulk_power_t;
     signal nic_rails_pins : nic_power_t;
     signal a0_ok : std_logic;
@@ -73,7 +92,9 @@ begin
        nic_rails_pins => nic_rails_pins,
        nic_seq_pins => nic_seq_pins,
        nic_dbg_pins => nic_dbg_pins,
-       sp5_t6_perst_l => sp5_t6_perst_l
+       sp5_t6_perst_l => sp5_t6_perst_l,
+      irq_l_out => open,
+      reg_alert_l_pins => reg_alert_l_pins
    );
 
    axi_lite_master_inst: entity vunit_lib.axi_lite_master

--- a/hdl/projects/cosmo_seq/sequencer/sp5_sequencer.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sp5_sequencer.vhd
@@ -51,6 +51,8 @@ entity sp5_sequencer is
         nic_seq_pins: view nic_seq_at_fpga;
         allow_backplane_pcie_clk : out std_logic;
         nic_dbg_pins : view t6_debug_seq_ss;
+        -- regulator alerts
+        reg_alert_l_pins : view power_alert_at_fpga;
 
         sp5_t6_perst_l : in std_logic;
 
@@ -93,6 +95,7 @@ architecture rtl of sp5_sequencer is
     signal debug_enables : debug_enables_type;
     signal smerr_assert : std_logic;
     signal a0_faulted : std_logic;
+    signal reg_alert_l : seq_power_alert_pins_t;
     
 
 
@@ -117,7 +120,9 @@ begin
         group_c => group_c,
         sp5_seq => sp5_seq,
         nic_rails => nic_rails,
-        nic_seq => nic_seq
+        nic_seq => nic_seq,
+        reg_alert_l_pins => reg_alert_l_pins,
+        reg_alert_l => reg_alert_l
     );
 
     regs: entity work.sequencer_regs
@@ -144,7 +149,8 @@ begin
         nic_readbacks => nic_readbacks,
         ignition_mux_sel => ignition_mux_sel,
         ignition_creset => ignition_creset,
-        irq_l_out => irq_l_out
+        irq_l_out => irq_l_out,
+        reg_alert_l => reg_alert_l
     );
 
     -- control from hubris


### PR DESCRIPTION
We bring a bunch of alert signals from on-board sm/pmbus regulators into the interrupt block on cosmo so hubris can choose to get real interrupts (or poll the live status) on these.

We also turn them to be active high in the IFR register since that matches other interrupt sources.