### PR TITLE
Add registers for GPIO toggle debug

### DIFF
--- a/hdl/projects/gimlet/sequencer/A0Block.bsv
+++ b/hdl/projects/gimlet/sequencer/A0Block.bsv
@@ -113,6 +113,14 @@ import PowerRail::*;
             mkConnection(source.thermtrip, sink.thermtrip);
             mkConnection(source.amd_reset_fedge, sink.amd_reset_fedge);
             mkConnection(source.amd_pwrok_fedge, sink.amd_pwrok_fedge);
+            mkConnection(source.gpio_edge_cnt3, sink.gpio_edge_cnt3);
+            mkConnection(source.gpio_edge_cnt2, sink.gpio_edge_cnt2);
+            mkConnection(source.gpio_edge_cnt1, sink.gpio_edge_cnt1);
+            mkConnection(source.gpio_edge_cnt0, sink.gpio_edge_cnt0);
+            mkConnection(source.gpio_cycle_cnt3, sink.gpio_cycle_cnt3);
+            mkConnection(source.gpio_cycle_cnt2, sink.gpio_cycle_cnt2);
+            mkConnection(source.gpio_cycle_cnt1, sink.gpio_cycle_cnt1);
+            mkConnection(source.gpio_cycle_cnt0, sink.gpio_cycle_cnt0);
         endmodule
     endinstance
 

--- a/hdl/projects/gimlet/sequencer/A0Block.bsv
+++ b/hdl/projects/gimlet/sequencer/A0Block.bsv
@@ -293,6 +293,7 @@ module mkA0BlockSeq#(Integer one_ms_counts)(A0BlockTop);
     // Registers for GPIO toggle detection and counting
     Reg#(Bit#(1)) gpio_last <- mkReg(1);
     PulseWire gpio_toggled <- mkPulseWire();
+    Reg#(UInt#(32)) gpio_cntr_max <- mkReg('hffffffff);
     Reg#(UInt#(32)) gpio_edge_count <- mkReg(0);
     Reg#(UInt#(32)) gpio_cycle_count <- mkReg(0);
 
@@ -369,7 +370,7 @@ module mkA0BlockSeq#(Integer one_ms_counts)(A0BlockTop);
         if (gpio_toggled) begin
             gpio_edge_count <= gpio_edge_count + 1;
             gpio_cycle_count <= 0;
-        end else begin
+        end else if (gpio_cycle_count < gpio_cntr_max) begin
             gpio_cycle_count <= gpio_cycle_count + 1;
         end
     endrule

--- a/hdl/projects/gimlet/sequencer/A0Block.bsv
+++ b/hdl/projects/gimlet/sequencer/A0Block.bsv
@@ -925,7 +925,7 @@ module mkSP3Model(SP3Model);
     Reg#(Bit#(1)) sp3_to_seq_pwrok_v3p3 <- mkReg(0);
     Reg#(Bit#(1)) sp3_to_seq_reset_v3p3_l <- mkReg(0);
     Reg#(Bit#(1)) sp3_to_seq_thermtrip_l <- mkReg(1);
-    Reg#(Bit#(1)) sp3_to_seq_fsr_req_l <- mkReg(1);
+    Reg#(Bit#(1)) sp3_to_seq_fsr_req_l <- mkReg(0);
     Reg#(Bit#(1)) sp3_to_sp_nic_pwren_l <- mkReg(1);
     
     // To SP3

--- a/hdl/projects/gimlet/sequencer/BUILD
+++ b/hdl/projects/gimlet/sequencer/BUILD
@@ -116,7 +116,8 @@ bluesim_tests('A0Tests',
         'mkA0MAPOTest',
         'mkA0ThermtripTest',
         'mkA0DebugBrokenTest',
-        'mkA0PowerErrorsTest'
+        'mkA0PowerErrorsTest',
+        'mkFsrReqGpioToggleTest',
     ],
     deps = [
         ':A0Block'

--- a/hdl/projects/gimlet/sequencer/GimletRegs.bsv
+++ b/hdl/projects/gimlet/sequencer/GimletRegs.bsv
@@ -126,6 +126,14 @@ module mkGimletRegs(GimletRegIF);
     Wire#(NicOutput2Type) nic2_out_status <- mkDWire(unpack(0));
     Wire#(NicOutput1Type) nic1_out_status <- mkDWire(unpack(0));
     Wire#(NicCtrl) nic_ctrl_next <- mkDWire(defaultValue);
+    Wire#(GpioEdgeCnt3) gpio_edge_cnt3 <- mkDWire(defaultValue);
+    Wire#(GpioEdgeCnt2) gpio_edge_cnt2 <- mkDWire(defaultValue);
+    Wire#(GpioEdgeCnt1) gpio_edge_cnt1 <- mkDWire(defaultValue);
+    Wire#(GpioEdgeCnt0) gpio_edge_cnt0 <- mkDWire(defaultValue);
+    Wire#(GpioCycleCnt3) gpio_cycle_cnt3 <- mkDWire(defaultValue);
+    Wire#(GpioCycleCnt2) gpio_cycle_cnt2 <- mkDWire(defaultValue);
+    Wire#(GpioCycleCnt1) gpio_cycle_cnt1 <- mkDWire(defaultValue);
+    Wire#(GpioCycleCnt0) gpio_cycle_cnt0 <- mkDWire(defaultValue);
 
     IRQBlock#(IrqType) irq_block <- mkIRQBlock();
 
@@ -230,6 +238,14 @@ module mkGimletRegs(GimletRegIF);
             fromInteger(fltGroupbPgOffset) : readdata <= tagged Valid (pack(flt_a0_groupB_pg));
             fromInteger(fltGroupcPgOffset) : readdata <= tagged Valid (pack(flt_a0_groupC_pg));
             fromInteger(miscCtrlOffset) : readdata <= tagged Valid (pack(misc_ctrl));
+            fromInteger(gpioEdgeCnt3Offset) : readdata <= tagged Valid (pack(gpio_edge_cnt3));
+            fromInteger(gpioEdgeCnt2Offset) : readdata <= tagged Valid (pack(gpio_edge_cnt2));
+            fromInteger(gpioEdgeCnt1Offset) : readdata <= tagged Valid (pack(gpio_edge_cnt1));
+            fromInteger(gpioEdgeCnt0Offset) : readdata <= tagged Valid (pack(gpio_edge_cnt0));
+            fromInteger(gpioCycleCnt3Offset) : readdata <= tagged Valid (pack(gpio_cycle_cnt3));
+            fromInteger(gpioCycleCnt2Offset) : readdata <= tagged Valid (pack(gpio_cycle_cnt2));
+            fromInteger(gpioCycleCnt1Offset) : readdata <= tagged Valid (pack(gpio_cycle_cnt1));
+            fromInteger(gpioCycleCnt0Offset) : readdata <= tagged Valid (pack(gpio_cycle_cnt0));
             default : readdata <= tagged Valid ('hff);
         endcase
     endrule
@@ -354,6 +370,14 @@ module mkGimletRegs(GimletRegIF);
                 amd_pwrokn_fedge.send();
             end
         endmethod
+        method gpio_edge_cnt3 = gpio_edge_cnt3._write;
+        method gpio_edge_cnt2 = gpio_edge_cnt2._write;
+        method gpio_edge_cnt1 = gpio_edge_cnt1._write;
+        method gpio_edge_cnt0 = gpio_edge_cnt0._write;
+        method gpio_cycle_cnt3 = gpio_cycle_cnt3._write;
+        method gpio_cycle_cnt2 = gpio_cycle_cnt2._write;
+        method gpio_cycle_cnt1 = gpio_cycle_cnt1._write;
+        method gpio_cycle_cnt0 = gpio_cycle_cnt0._write;
     endinterface
     interface NicRegsReverse nic_block;
         method Bool en;

--- a/hdl/projects/gimlet/sequencer/gimlet_seq_fpga_regs.rdl
+++ b/hdl/projects/gimlet/sequencer/gimlet_seq_fpga_regs.rdl
@@ -517,7 +517,7 @@ addrmap gimlet_seq_fpga {
             desc = "inverted CPU's thermtrip_L, 500ms to shut down power planes into S5 state. De-assertion of PWROK resets THERMTRIP_L";
         } THERMTRIP[1] = 0;
         field {
-            desc = "inverted FSR_REQ_L net. Maybe used in host reset detection, see RFD138. No defined use in power-up";
+            desc = "Inverted FSR_REQ_L net. We do not use this GPIO, so it has been repurposed. See quartz#415.";
         } FSR_REQ[1] = 0;
         field {
             desc = "Output from the AMD processor that it has effectively acknowledged that power is itself
@@ -774,4 +774,77 @@ addrmap gimlet_seq_fpga {
             desc = "Control of the seq_proxy_sp3_to_rsw_pwren_l pin (inverted by FPGA, so a '1' here will drive the pin low)";
         } RSW_PWREN[0:0] = 0;
     } MISC_CTRL;
+
+    // GPIO Cycle Counters
+    reg {
+        name = "GPIO Edge Counts MSB";
+        default sw = r;
+
+        field {
+            desc = "MSB of the 32-bit gpio edge counter register";
+        } VAL[7:0] = 0;
+    } GPIO_EDGE_CNT_3;
+
+    reg {
+        name = "GPIO Edge Counts MSB-1";
+        default sw = r;
+
+        field {
+            desc = "MSB-1 of the 32-bit gpio edge counter register";
+        } VAL[7:0] = 0;
+    } GPIO_EDGE_CNT_2;
+
+    reg {
+        name = "GPIO Edge Counts LSB+1";
+        default sw = r;
+
+        field {
+            desc = "LSB+1 of the 32-bit gpio edge counter register";
+        } VAL[7:0] = 0;
+    } GPIO_EDGE_CNT_1;
+
+    reg {
+        name = "GPIO Edge Counts LSB";
+        default sw = r;
+
+        field {
+            desc = "LSB of the 32-bit gpio edge counter register";
+        } VAL[7:0] = 0;
+    } GPIO_EDGE_CNT_0;
+
+    reg {
+        name = "Cycles since last GPIO edge MSB";
+        default sw = r;
+
+        field {
+            desc = "MSB of the 32-bit gpio edge counter register";
+        } VAL[7:0] = 0;
+    } GPIO_CYCLE_CNT_3;
+
+    reg {
+        name = "Cycles since last GPIO edge MSB-1";
+        default sw = r;
+
+        field {
+            desc = "MSB-1 of the 32-bit gpio edge counter register";
+        } VAL[7:0] = 0;
+    } GPIO_CYCLE_CNT_2;
+
+    reg {
+        name = "Cycles since last GPIO edge LSB+1";
+        default sw = r;
+
+        field {
+            desc = "LSB+1 of the 32-bit gpio edge counter register";
+        } VAL[7:0] = 0;
+    } GPIO_CYCLE_CNT_1;
+
+    reg {
+        name = "Cycles since last GPIO edge LSB";
+        default sw = r;
+
+        field {
+            desc = "LSB of the 32-bit gpio edge counter register";
+        } VAL[7:0] = 0;
+    } GPIO_CYCLE_CNT_0;
 };


### PR DESCRIPTION
This commit re-purposes the `sp3_to_seq_fsr_req_l` input to drive two different counters in the sequencer. The "edge" counter will count how many times that pin is observed to change value. The "cycle" counter will count how many clock cycles have elapsed since the last change in value, therefore resetting to zero when an edge is observed. Both of these counters are 32-bits wide and will roll over.

fixes #415