### PR TITLE
Fix i2c caching bugs around engine restart

### DIFF
--- a/hdl/projects/cosmo_seq/dimms_subsystem/sda_arbiter/sda_arbiter.vhd
+++ b/hdl/projects/cosmo_seq/dimms_subsystem/sda_arbiter/sda_arbiter.vhd
@@ -4,7 +4,7 @@
 --
 -- Copyright 2025 Oxide Computer Company
 --
--- This block monitors two I2C SDA signals, `a` and `b`, with the intention thatt hey are
+-- This block monitors two I2C SDA signals, `a` and `b`, with the intention that hey are
 -- essentially connected but proxied by the FPGA. It assumes the inactive state for the bus is high,
 -- and then monitors for `a` or `b` to pull the line low. It will then grant whichever side pulled
 -- the line low the bus until that side releases it, at which point after HYSTERESIS_CYCLES both

--- a/hdl/projects/cosmo_seq/dimms_subsystem/sims/spd_proxy_tb/spd_proxy_tb.vhd
+++ b/hdl/projects/cosmo_seq/dimms_subsystem/sims/spd_proxy_tb/spd_proxy_tb.vhd
@@ -68,7 +68,7 @@ begin
             -- write some data in
             command := (
                 op      => WRITE,
-                addr    => address(I2C_DIMM1_TGT_VC),
+                addr    => address(I2C_DIMM1F_TGT_VC),
                 reg     => std_logic_vector(exp_addr), 
                 len     => to_std_logic_vector(byte_len, command.len'length)
             );
@@ -90,10 +90,10 @@ begin
                 while not is_empty(fpga_exp_q) loop
                     data        := to_std_logic_vector(pop_byte(fpga_exp_q), data'length);
                     exp_addr    := to_std_logic_vector(byte_idx, exp_addr'length);
-                    check_written_byte(net, I2C_DIMM1_TGT_VC, data, exp_addr);
+                    check_written_byte(net, I2C_DIMM1F_TGT_VC, data, exp_addr);
                     byte_idx := byte_idx + 1;
                 end loop;
-                expect_stop(net, I2C_DIMM1_TGT_VC);
+                expect_stop(net, I2C_DIMM1F_TGT_VC);
             elsif run("cpu_transaction") then
                 -- Get the FPGA controller started on a transaction
                 init_controller;
@@ -102,7 +102,17 @@ begin
                 wait for rnd.RandInt(500, 4000) * 1 ns;
 
                 push_byte(cpu_tx_q, to_integer(rnd.RandSlv(0, 255, 8)));
-                i2c_write_txn(net, address(I2C_DIMM1_TGT_VC), cpu_tx_q, cpu_ack_q, I2C_CTRL_VC.p_actor);
+                i2c_write_txn(net, address(I2C_DIMM1F_TGT_VC), cpu_tx_q, cpu_ack_q, I2C_CTRL_VC.p_actor);
+             
+            elsif run("cpu_transaction_regression") then
+                -- Get the FPGA controller started on a transaction
+                init_controller;
+
+                -- At some point into the transaction, have the CPU start its own
+                wait for rnd.RandInt(500, 4000) * 1 ns;
+
+                push_byte(cpu_tx_q, to_integer(rnd.RandSlv(0, 255, 8)));
+                i2c_write_txn(net, address(I2C_DIMM1F_TGT_VC), cpu_tx_q, cpu_ack_q, I2C_CTRL_VC.p_actor);
 
             elsif run("cpu_with_simulated_start") then
                 -- Get the FPGA controller started on a transaction
@@ -112,7 +122,7 @@ begin
                 wait for 9500 ns;
 
                 push_byte(cpu_tx_q, to_integer(rnd.RandSlv(0, 255, 8)));
-                i2c_write_txn(net, address(I2C_DIMM1_TGT_VC), cpu_tx_q, cpu_ack_q, I2C_CTRL_VC.p_actor);
+                i2c_write_txn(net, address(I2C_DIMM1F_TGT_VC), cpu_tx_q, cpu_ack_q, I2C_CTRL_VC.p_actor);
             end if;
         end loop;
 

--- a/hdl/projects/cosmo_seq/dimms_subsystem/sims/spd_proxy_tb/spd_proxy_th.vhd
+++ b/hdl/projects/cosmo_seq/dimms_subsystem/sims/spd_proxy_tb/spd_proxy_th.vhd
@@ -62,7 +62,7 @@ begin
     -- simulated DIMM I2C target
     i2c_target_vc_inst: entity work.i2c_target_vc
         generic map(
-            I2C_TARGET_VC => I2C_DIMM1_TGT_VC
+            I2C_TARGET_VC => I2C_DIMM1F_TGT_VC
         )
         port map(
             scl => dimm_scl,

--- a/hdl/projects/cosmo_seq/dimms_subsystem/sims/spd_proxy_tb_pkg.vhd
+++ b/hdl/projects/cosmo_seq/dimms_subsystem/sims/spd_proxy_tb_pkg.vhd
@@ -26,8 +26,18 @@ package spd_proxy_tb_pkg is
 
     -- Verification Components
     constant I2C_CTRL_VC        : i2c_ctrl_vc_t     := new_i2c_ctrl_vc("cpu_i2c_vc");
-    constant I2C_DIMM1_TGT_VC         : i2c_target_vc_t   := new_i2c_target_vc("dimm1_i2c_vc");
-    constant I2C_DIMM2_TGT_VC         : i2c_target_vc_t   := new_i2c_target_vc("dimm2_i2c_vc", b"1010000");
+    constant I2C_DIMM1A_TGT_VC         : i2c_target_vc_t   := new_i2c_target_vc("dimm1a_i2c_vc", b"1010000");
+    constant I2C_DIMM1B_TGT_VC         : i2c_target_vc_t   := new_i2c_target_vc("dimm1b_i2c_vc", b"1010001");
+    constant I2C_DIMM1C_TGT_VC         : i2c_target_vc_t   := new_i2c_target_vc("dimm1c_i2c_vc", b"1010010");
+    constant I2C_DIMM1D_TGT_VC         : i2c_target_vc_t   := new_i2c_target_vc("dimm1d_i2c_vc", b"1010011");
+    constant I2C_DIMM1E_TGT_VC         : i2c_target_vc_t   := new_i2c_target_vc("dimm1e_i2c_vc", b"1010100");
+    constant I2C_DIMM1F_TGT_VC         : i2c_target_vc_t   := new_i2c_target_vc("dimm1f_i2c_vc", b"1010101");
+    constant I2C_DIMM2G_TGT_VC         : i2c_target_vc_t   := new_i2c_target_vc("dimm2g_i2c_vc", b"1010000");
+    constant I2C_DIMM2H_TGT_VC         : i2c_target_vc_t   := new_i2c_target_vc("dimm2h_i2c_vc", b"1010001");
+    constant I2C_DIMM2I_TGT_VC         : i2c_target_vc_t   := new_i2c_target_vc("dimm2i_i2c_vc", b"1010010");
+    constant I2C_DIMM2J_TGT_VC         : i2c_target_vc_t   := new_i2c_target_vc("dimm2j_i2c_vc", b"1010011");
+    constant I2C_DIMM2K_TGT_VC         : i2c_target_vc_t   := new_i2c_target_vc("dimm2k_i2c_vc", b"1010100");
+    constant I2C_DIMM2L_TGT_VC         : i2c_target_vc_t   := new_i2c_target_vc("dimm2l_i2c_vc", b"1010101");
     constant I2C_CMD_VC         : i2c_cmd_vc_t      := new_i2c_cmd_vc;
     constant TX_DATA_SOURCE_VC  : basic_source_t    := new_basic_source(8);
     constant RX_DATA_SINK_VC    : basic_sink_t      := new_basic_sink(8);
@@ -40,7 +50,7 @@ package spd_proxy_tb_pkg is
         signal net  : inout network_t;
         constant command : cmd_t;
         constant tx_data : queue_t;
-        constant i2c_target : i2c_target_vc_t := I2C_DIMM1_TGT_VC
+        constant i2c_target : i2c_target_vc_t := I2C_DIMM1F_TGT_VC
     );
 
 end package;
@@ -51,7 +61,7 @@ package body spd_proxy_tb_pkg is
         signal net  : inout network_t;
         constant command : cmd_t;
         constant tx_data : queue_t;
-        constant i2c_target : i2c_target_vc_t := I2C_DIMM1_TGT_VC
+        constant i2c_target : i2c_target_vc_t := I2C_DIMM1F_TGT_VC
     ) is
         variable ack    : boolean := FALSE;
     begin

--- a/hdl/projects/cosmo_seq/dimms_subsystem/sims/spd_proxy_top_th.vhd
+++ b/hdl/projects/cosmo_seq/dimms_subsystem/sims/spd_proxy_top_th.vhd
@@ -94,9 +94,49 @@ begin
     cpu_sda_if0.i <= cpu_abcdef_sda;
 
      -- simulated DIMM I2C target
-    dimm_abcdef_vc: entity work.i2c_target_vc
+    dimm_a_vc: entity work.i2c_target_vc
     generic map(
-        I2C_TARGET_VC => I2C_DIMM1_TGT_VC
+        I2C_TARGET_VC => I2C_DIMM1A_TGT_VC
+    )
+    port map(
+        scl => dimm_abcdef_scl,
+        sda => dimm_abcdef_sda
+    );
+    dimm_b_vc: entity work.i2c_target_vc
+    generic map(
+        I2C_TARGET_VC => I2C_DIMM1B_TGT_VC
+    )
+    port map(
+        scl => dimm_abcdef_scl,
+        sda => dimm_abcdef_sda
+    );
+    dimm_c_vc: entity work.i2c_target_vc
+    generic map(
+        I2C_TARGET_VC => I2C_DIMM1C_TGT_VC
+    )
+    port map(
+        scl => dimm_abcdef_scl,
+        sda => dimm_abcdef_sda
+    );
+    dimm_d_vc: entity work.i2c_target_vc
+    generic map(
+        I2C_TARGET_VC => I2C_DIMM1D_TGT_VC
+    )
+    port map(
+        scl => dimm_abcdef_scl,
+        sda => dimm_abcdef_sda
+    );
+    dimm_e_vc: entity work.i2c_target_vc
+    generic map(
+        I2C_TARGET_VC => I2C_DIMM1E_TGT_VC
+    )
+    port map(
+        scl => dimm_abcdef_scl,
+        sda => dimm_abcdef_sda
+    );
+    dimm_f_vc: entity work.i2c_target_vc
+    generic map(
+        I2C_TARGET_VC => I2C_DIMM1F_TGT_VC
     )
     port map(
         scl => dimm_abcdef_scl,
@@ -124,15 +164,54 @@ begin
     cpu_ghijkl_sda <= cpu_sda_if1.o when cpu_sda_if1.oe else 'H';
     cpu_sda_if1.i <= cpu_ghijkl_sda;
 
-    dimm_ghijkl_vc: entity work.i2c_target_vc
+    dimm_g_vc: entity work.i2c_target_vc
     generic map(
-        I2C_TARGET_VC => I2C_DIMM2_TGT_VC
+        I2C_TARGET_VC => I2C_DIMM2G_TGT_VC
     )
     port map(
         scl => dimm_ghijkl_scl,
         sda => dimm_ghijkl_sda
     );
-
+    dimm_h_vc: entity work.i2c_target_vc
+    generic map(
+        I2C_TARGET_VC => I2C_DIMM2H_TGT_VC
+    )
+    port map(
+        scl => dimm_ghijkl_scl,
+        sda => dimm_ghijkl_sda
+    );
+    dimm_i_vc: entity work.i2c_target_vc
+    generic map(
+        I2C_TARGET_VC => I2C_DIMM2I_TGT_VC
+    )
+    port map(
+        scl => dimm_ghijkl_scl,
+        sda => dimm_ghijkl_sda
+    );
+    dimm_j_vc: entity work.i2c_target_vc
+    generic map(
+        I2C_TARGET_VC => I2C_DIMM2J_TGT_VC
+    )
+    port map(
+        scl => dimm_ghijkl_scl,
+        sda => dimm_ghijkl_sda
+    );
+    dimm_k_vc: entity work.i2c_target_vc
+    generic map(
+        I2C_TARGET_VC => I2C_DIMM2K_TGT_VC
+    )
+    port map(
+        scl => dimm_ghijkl_scl,
+        sda => dimm_ghijkl_sda
+    );
+    dimm_l_vc: entity work.i2c_target_vc
+    generic map(
+        I2C_TARGET_VC => I2C_DIMM2L_TGT_VC
+    )
+    port map(
+        scl => dimm_ghijkl_scl,
+        sda => dimm_ghijkl_sda
+    );
     dimm_ghijkl_scl <= dimm_scl_if1.o when dimm_scl_if1.oe else 'H';
     dimm_scl_if1.i <= dimm_ghijkl_scl;
     


### PR DESCRIPTION
- Bug # 1: we latch the current dimm # and restart, thus skipping dimm0 on restart.
- Bug # 2: On an engine restart, we didn't set the page back to 0. This was actually tricky as we *intended* to do that but on a restart the i2c engine could be in a completed state and we'd skip the first page-set transaction accidentally.