### PR TITLE
allow forcing cem clk enables

### DIFF
--- a/hdl/projects/cosmo_hp/BUCK
+++ b/hdl/projects/cosmo_hp/BUCK
@@ -15,10 +15,21 @@ rdl_file(
     ]
 )
 
+rdl_file(
+    name = "hp_debug_regs_rdl",
+    src = "hp_subsystem/hp_debug_regs.rdl",
+    outputs = [
+        "hp_debug_regs.html", 
+        "hp_debug_regs.json",
+        "hp_debug_regs_pkg.vhd"
+    ]
+)
+
 vhdl_unit(
     name = "hp_subsystem_top",
     srcs = glob(["hp_subsystem/*.vhd"]),
     deps = [
+        ":hp_debug_regs_rdl",
         "//hdl/ip/vhd/i2c/io_expanders/PCA9506ish:pca9506_top",
     ],
     standard = "2008",

--- a/hdl/projects/cosmo_hp/cosmo_hp_top.vhd
+++ b/hdl/projects/cosmo_hp/cosmo_hp_top.vhd
@@ -223,7 +223,8 @@ architecture rtl of cosmo_hp_top is
     constant config_array : axil_responder_cfg_array_t := 
     (0 => (base_addr => x"00000000", addr_span_bits => 8),
      1 => (base_addr => x"00000100", addr_span_bits => 8),
-     2 => (base_addr => x"00000200", addr_span_bits => 8)
+     2 => (base_addr => x"00000200", addr_span_bits => 8),
+     3 => (base_addr => x"00000300", addr_span_bits => 8)
      );
 
     signal sp_write_address_addr : std_logic_vector(15 downto 0);
@@ -286,6 +287,7 @@ architecture rtl of cosmo_hp_top is
     alias amd_gen_int_l is fpga2_to_fpga1_io(2); -- goes to fpga1 which can do the alert generation
     signal amd_gen_int : std_logic;
     signal spi_fpga2_to_sp_mux_dat_int : std_logic;
+    signal fpga2_to_clk_buff_ufl_oe_l_int : std_logic;
     
 begin
 
@@ -340,7 +342,7 @@ begin
     fpga2_to_v12_mcio_a0hp_hsc_en <= '0';
     fpga2_to_clk_buff_mcio_oe_l <= 'Z';
     -- pin the ufl clock buffer off
-    fpga2_to_clk_buff_ufl_oe_l <= 'Z';
+    fpga2_to_clk_buff_ufl_oe_l <= '0' when fpga2_to_clk_buff_ufl_oe_l_int = '0' else 'Z';
 
     ---------------------------------------
     -- Hubris SPI interface
@@ -580,6 +582,28 @@ axil_interconnect_2k8_inst: entity work.axil_interconnect_2k8
      port map(
         clk => clk_50m,
         reset => reset_50m,
+         --   AXI interface
+        awvalid => responders_write_address_valid(3),
+        awready => responders_write_address_ready(3),
+        awaddr => responders_write_address_addr(3)(7 downto 0),
+        -- write data channel
+        wvalid => responders_write_data_valid(3),
+        wready => responders_write_data_ready(3),
+        wdata => responders_write_data_data(3),
+        wstrb => responders_write_data_strb(3),
+        -- write response channel
+        bvalid => responders_write_response_valid(3),
+        bready => responders_write_response_ready(3),
+        bresp => responders_write_response_resp(3),
+        -- read address channel
+        arvalid => responders_read_address_valid(3),
+        arready => responders_read_address_ready(3),
+        araddr => responders_read_address_addr(3)(7 downto 0),
+        -- read data channel
+        rvalid => responders_read_data_valid(3),
+        rready => responders_read_data_ready(3),
+        rdata => responders_read_data_data(3),
+        rresp => responders_read_data_resp(3),
         cema_to_fpga2_alert_l => cema_to_fpga2_alert_l,
         cema_to_fpga2_ifdet_l => cema_to_fpga2_ifdet_l,
         cema_to_fpga2_pg_l => cema_to_fpga2_pg_l,
@@ -680,6 +704,7 @@ axil_interconnect_2k8_inst: entity work.axil_interconnect_2k8
         fpga2_to_cemj_perst_l => fpga2_to_cemj_perst_l_int,
         fpga2_to_cemj_pwren => fpga2_to_cemj_pwren,
         fpga2_to_clk_buff_cemj_oe_l => fpga2_to_clk_buff_cemj_oe_l_int,
+        fpga2_to_clk_buff_ufl_oe_l => fpga2_to_clk_buff_ufl_oe_l_int,
         io => pca_io,
         io_o => pca_io_o,
         io_oe => pca_io_oe

--- a/hdl/projects/cosmo_hp/hp_subsystem/hp_debug_regs.rdl
+++ b/hdl/projects/cosmo_hp/hp_subsystem/hp_debug_regs.rdl
@@ -1,0 +1,60 @@
+// Copyright 2025 Oxide Computer Company
+// This is SystemRDL description of the sw-accessible common board-info registers
+
+addrmap hp_debug_regs {
+    name = "Hotplug Debug Registers";
+    desc = "Registers accessible on the Axi bus (via SP SPI) providing hotplug debug functionality";
+
+    default regwidth = 32;
+    default sw = rw;
+    default hw = r;
+ reg {
+        name = "clk_en_force";
+        desc = "";
+
+        field {
+            default sw = r;
+            desc = "Set to 1 to force on the UFL clock buffer";
+        } ufl_clk_buf_force_on[10:10] =  0;
+        field {
+            default sw = r;
+            desc = "Set to 1 to force on the CEM(n) clock buffer";
+        } cema_clk_buf_force_on[9:9] =  0;
+         field {
+            default sw = r;
+            desc = "Set to 1 to force on the CEM(n) clock buffer";
+        } cemb_clk_buf_force_on[8:8] =  0;
+         field {
+            default sw = r;
+            desc = "Set to 1 to force on the CEM(n) clock buffer";
+        } cemc_clk_buf_force_on[7:7] =  0;
+         field {
+            default sw = r;
+            desc = "Set to 1 to force on the CEM(n) clock buffer";
+        } cemd_clk_buf_force_on[6:6] =  0;
+         field {
+            default sw = r;
+            desc = "Set to 1 to force on the CEM(n) clock buffer";
+        } ceme_clk_buf_force_on[5:5] =  0;
+         field {
+            default sw = r;
+            desc = "Set to 1 to force on the CEM(n) clock buffer";
+        } cemf_clk_buf_force_on[4:4] =  0;
+         field {
+            default sw = r;
+            desc = "Set to 1 to force on the CEM(n) clock buffer";
+        } cemg_clk_buf_force_on[3:3] =  0;
+         field {
+            default sw = r;
+            desc = "Set to 1 to force on the CEM(n) clock buffer";
+        } cemh_clk_buf_force_on[2:2] =  0;
+         field {
+            default sw = r;
+            desc = "Set to 1 to force on the CEM(n) clock buffer";
+        } cemi_clk_buf_force_on[1:1] =  0;
+        field {
+            default sw = r;
+            desc = "Set to 1 to force on the CEM(n) clock buffer";
+        } cemj_clk_buf_force_on[0:0] =  0;
+    } clk_buf_force;
+};

--- a/hdl/projects/cosmo_hp/hp_subsystem/hp_debug_regs.vhd
+++ b/hdl/projects/cosmo_hp/hp_subsystem/hp_debug_regs.vhd
@@ -1,0 +1,132 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+-- Copyright 2025 Oxide Computer Company
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use ieee.numeric_std_unsigned.all;
+
+use work.hp_debug_regs_pkg.all;
+
+entity hp_debug_regs is
+    port (
+        clk   : in    std_logic;
+        reset : in    std_logic;
+        -- System Interface
+        -- axi interface. This is not using VHDL2019 views so that it's compatible with
+        -- GHDL/yosys based toolchains
+        -- write address channel
+        awvalid : in std_logic;
+        awready : out std_logic;
+        awaddr : in std_logic_vector(7 downto 0) ;
+        -- write data channel
+        wvalid : in std_logic;
+        wready : out std_logic;
+        wdata : in std_logic_vector(31 downto 0);
+        wstrb : in std_logic_vector(3 downto 0); -- un-used
+        -- write response channel
+        bvalid : out std_logic;
+        bready : in std_logic;
+        bresp : out std_logic_vector(1 downto 0);
+        -- read address channel
+        arvalid : in std_logic;
+        arready : out std_logic;
+        araddr : in std_logic_vector(7 downto 0);
+        -- read data channel
+        rvalid : out std_logic;
+        rready : in std_logic;
+        rdata : out std_logic_vector(31 downto 0);
+        rresp : out std_logic_vector(1 downto 0);
+
+        -- 
+        clk_buff_cema_force_oe_l : out std_logic;
+        clk_buff_cemb_force_oe_l : out std_logic;
+        clk_buff_cemc_force_oe_l : out std_logic;
+        clk_buff_cemd_force_oe_l : out std_logic;
+        clk_buff_ceme_force_oe_l : out std_logic;
+        clk_buff_cemf_force_oe_l : out std_logic;
+        clk_buff_cemg_force_oe_l : out std_logic;
+        clk_buff_cemh_force_oe_l : out std_logic;
+        clk_buff_cemi_force_oe_l : out std_logic;
+        clk_buff_cemj_force_oe_l : out std_logic;
+        clk_buff_ufl_force_oe_l : out std_logic
+
+    );
+end entity;
+
+architecture rtl of hp_debug_regs is
+
+    signal clk_buf_force : clk_buf_force_type;
+    signal active_read: std_logic;
+    signal active_write: std_logic;
+
+begin
+
+    axil_target_txn_inst: entity work.axil_target_txn
+    port map(
+       clk => clk,
+       reset => reset,
+       arvalid => arvalid,
+       arready => arready,
+       awvalid => awvalid,
+       awready =>awready,
+       wvalid => wvalid,
+       wready => wready,
+       bvalid => bvalid,
+       bready => bready,
+       bresp => bresp,
+       rvalid => rvalid,
+       rready => rready,
+       rresp =>rresp,
+       active_read => active_read,
+       active_write => active_write
+   );
+
+
+
+    write_logic: process(clk, reset)
+    begin
+        if reset then
+            clk_buf_force <= rec_reset;
+        elsif rising_edge(clk) then
+            if active_write then
+                case to_integer(awaddr) is
+                    when CLK_BUF_FORCE_OFFSET => clk_buf_force <= write_byte_enable(clk_buf_force, wdata, wstrb);
+                    when others => null;
+                end case;
+            end if;
+        end if;
+    end process;
+
+    read_logic: process(clk, reset)
+    begin
+        if reset then
+            rdata <= (others => '0');
+        elsif rising_edge(clk) then
+            if active_read then
+                case to_integer(araddr) is
+                    when CLK_BUF_FORCE_OFFSET => rdata <= pack(clk_buf_force);
+                    when others =>
+                        rdata <= (others => '0');
+                end case;
+            end if;
+        end if;
+    end process;
+
+
+    clk_buff_cema_force_oe_l <= not clk_buf_force.cema_clk_buf_force_on;
+    clk_buff_cemb_force_oe_l <= not clk_buf_force.cemb_clk_buf_force_on;
+    clk_buff_cemc_force_oe_l <= not clk_buf_force.cemc_clk_buf_force_on;
+    clk_buff_cemd_force_oe_l <= not clk_buf_force.cemd_clk_buf_force_on;
+    clk_buff_ceme_force_oe_l <= not clk_buf_force.ceme_clk_buf_force_on;
+    clk_buff_cemf_force_oe_l <= not clk_buf_force.cemf_clk_buf_force_on;
+    clk_buff_cemg_force_oe_l <= not clk_buf_force.cemg_clk_buf_force_on;
+    clk_buff_cemh_force_oe_l <= not clk_buf_force.cemh_clk_buf_force_on;
+    clk_buff_cemi_force_oe_l <= not clk_buf_force.cemi_clk_buf_force_on;
+    clk_buff_cemj_force_oe_l <= not clk_buf_force.cemj_clk_buf_force_on;
+    clk_buff_ufl_force_oe_l <= not clk_buf_force.ufl_clk_buf_force_on;
+
+end rtl;

--- a/hdl/projects/cosmo_hp/hp_subsystem/sims/cem_hp_sim_th.vhd
+++ b/hdl/projects/cosmo_hp/hp_subsystem/sims/cem_hp_sim_th.vhd
@@ -84,6 +84,27 @@ begin
      port map(
         clk => clk,
         reset => reset,
+        awvalid => '0',
+        awready => open,
+        awaddr => (others => '0'),
+        -- write data channel
+        wvalid => '0',
+        wready => open,
+        wdata => (others => '0'),
+        wstrb => (others => '0'),
+        -- write response channel
+        bvalid => open,
+        bready => '0',
+        bresp => open,
+        -- read address channel
+        arvalid => '0',
+        arready => open,
+        araddr => (others => '0'),
+        -- read data channel
+        rvalid => open,
+        rready => '0',
+        rdata => open,
+        rresp => open,
         cema_to_fpga2_alert_l => cema_to_fpga2_alert_l,
         cema_to_fpga2_ifdet_l => cema_to_fpga2_ifdet_l,
         cema_to_fpga2_pg_l => cema_to_fpga2_pg_l,


### PR DESCRIPTION
This allows us to force-enable cem via spi transactions to FPGA2.
Tested and working on a cosmo in EMY