### PR TITLE
Add internal PU to deal with no hw PU on FPGA2's genint output

### DIFF
--- a/hdl/projects/cosmo_hp/cosmo_hp.pcf
+++ b/hdl/projects/cosmo_hp/cosmo_hp.pcf
@@ -140,7 +140,7 @@ set_io --warn-no-port i2c_sp5_to_fpga2_sda L7
 set_io --warn-no-port i2c_sp5_to_fpga2_xltr_en N2
 set_io --warn-no-port smbus_sp_to_fpga2_smclk T7
 set_io --warn-no-port smbus_sp_to_fpga2_smdat T8
-set_io --warn-no-port sp5_to_fpga_genint_3v3_l K5
+set_io --warn-no-port -pullup yes sp5_to_fpga_genint_3v3_l K5
 set_io --warn-no-port sp_to_fpga2_system_reset_l N6
 set_io --warn-no-port spi_fpga2_to_sp_mux_dat P12
 set_io --warn-no-port spi_sp_mux_to_fpga2_cs_l R12

--- a/hdl/projects/cosmo_seq/sp5_hotplug_subsystem/sp5_hotplug_subsystem.vhd
+++ b/hdl/projects/cosmo_seq/sp5_hotplug_subsystem/sp5_hotplug_subsystem.vhd
@@ -185,7 +185,6 @@ begin
     t6_perst_l <= t6_power_en;
 
     -- Backplane connected switch
-    -- TODO: this stuff is likely not totally correct
     pcie_aux_power_en <= not io_o(3)(4) when io_oe(3)(4) else '0';
     pcie_perst_oneshot: entity work.perst_oneshot
      generic map(


### PR DESCRIPTION
This prevents the genint line from being held low since the 'Z' output doesn't properly drive the on-board tri-state buffer without a PU.

Fixes #450 
Also remove stale TODO as this interface is functioning as intended.