### PR TITLE
A couple of minor improvements and cleanliness work

### DIFF
--- a/hdl/ip/vhd/espi/peripheral_channel/uart_channel_pkg.vhd
+++ b/hdl/ip/vhd/espi/peripheral_channel/uart_channel_pkg.vhd
@@ -25,7 +25,7 @@ package uart_channel_pkg is
 
     type uart_resp_t is record
         st : st_uart_t;
-        avail_bytes : std_logic_vector(11 downto 0);
+        avail_bytes : std_logic_vector(12 downto 0);
     end record;
 
     view uart_resp_src of uart_resp_t is

--- a/hdl/ip/vhd/espi/peripheral_channel/uart_channel_top.vhd
+++ b/hdl/ip/vhd/espi/peripheral_channel/uart_channel_top.vhd
@@ -102,7 +102,7 @@ begin
     -- tx_rusedwds is potentially cycles behind the empty flag due to fifo latencies.
     -- since we're using it in the avail bytes, we need to ensure we're at least > 0
     sp_to_host_espi.st.valid <= '1' when tx_rempty /= '1' and tx_rusedwds > 0 else '0';
-    sp_to_host_espi.avail_bytes <= resize(tx_rusedwds, sp_to_host_espi.avail_bytes'length);
+    sp_to_host_espi.avail_bytes <= tx_rusedwds;
     to_sp_uart_valid <= not rx_rempty;
 
     fifo_read_by_espi <= sp_to_host_espi.st.valid and sp_to_host_espi.st.ready;

--- a/hdl/ip/vhd/espi/txn_layer/response_processor.vhd
+++ b/hdl/ip/vhd/espi/txn_layer/response_processor.vhd
@@ -125,7 +125,7 @@ begin
            -- to get this working well we're going to cap the payload at 61 bytes
            -- we can re-evaluate this later, but this will support the smallest OOB channel
            -- with 3 bytes of SMB headers
-           response_chan_mux.length     <= minimum(sp_to_host_espi.avail_bytes, 61);  -- cap to tx max
+           response_chan_mux.length     <= resize(minimum(sp_to_host_espi.avail_bytes, 61), response_chan_mux.length'length);  -- cap to tx max
            flash_resp.ready             <= '0';
            resp_data <= sp_to_host_espi.st.data;
            sp_to_host_espi.st.ready <= '1' when data_to_host.ready = '1' and r.cur_valid = '1' and r.state = RESPONSE_PAYLOAD else '0';

--- a/hdl/projects/cosmo_seq/sp5_uart_subsystem/sp5_uart_subsystem.vhd
+++ b/hdl/projects/cosmo_seq/sp5_uart_subsystem/sp5_uart_subsystem.vhd
@@ -133,7 +133,7 @@ begin
         parity => false,
         use_hw_handshake => true,
         fifo_depth => CONSOLE_FIFO_DEPTH,
-        full_threshold => CONSOLE_FIFO_DEPTH
+        full_threshold => CONSOLE_FIFO_ALMOST_FULL
     )
      port map(
         clk => clk,
@@ -180,7 +180,7 @@ begin
         parity => false,
         use_hw_handshake => true,
         fifo_depth => IPCC_FIFO_DEPTH,
-        full_threshold => IPCC_FIFO_DEPTH
+        full_threshold => IPCC_FIFO_ALMOST_FULL
     )
      port map(
         clk => clk,

--- a/hdl/projects/cosmo_seq/sp5_uart_subsystem/sp5_uart_subsystem_pkg.vhd
+++ b/hdl/projects/cosmo_seq/sp5_uart_subsystem/sp5_uart_subsystem_pkg.vhd
@@ -13,7 +13,9 @@ use work.calc_pkg.all;
 package sp5_uart_subsystem_pkg is
 
     constant CONSOLE_FIFO_DEPTH : integer := 256; -- FIFO depth for UARTs
-    constant IPCC_FIFO_DEPTH : integer := 16; -- FIFO depth for IPCC UART
+    constant CONSOLE_FIFO_ALMOST_FULL : integer := CONSOLE_FIFO_DEPTH - 8; -- Threshold for "almost full" status signal
+    constant IPCC_FIFO_DEPTH : integer := 32; -- FIFO depth for IPCC UART
+    constant IPCC_FIFO_ALMOST_FULL : integer := IPCC_FIFO_DEPTH - 8; -- Threshold for "almost full" status signal
 
     -- To the debug interface
     type console_uart_dbg_t is record


### PR DESCRIPTION
We really want to assert UART backpressure *before* we're  full. This adjusts down the almost full threshold. In practice, I don't believe that we'd ever actually end up filling the rx FIFO here b/c it just bleeds immediately into the much bigger (4kB) IPCC fifo in the eSPI block, but for correctness I think this is a solid change.

I also adjusted where we do the available bytes resizing for clarity.  eSPI generally only allocates 12 bits for transfers, but we have a 4kB fifo so 13bits are required to represent a completely full FIFO. I moved the resize over to where we're stuffing eSPI packets, where we're *already* doing a minimum(bytes_in_fifo, 61) so we'll never send more than 61. We also never see a full IPCC FIFO in practice so I think none of this ends up being a functional change.
