### PR TITLE
Fix fpga-releaser to work with new matrix build paths and archives

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,15 @@ jobs:
 
           echo "base_commit=$BASE_COMMIT" >> "$GITHUB_OUTPUT"
 
+          # Check if this workflow or the shared parser script changed.
+          # These aren't buck2 inputs so BTD won't detect them, but they
+          # can affect builds (toolchain versions, env vars, build flags).
+          if git diff --name-only "$BASE_COMMIT" HEAD | grep -qE '\.github/workflows/build\.yml|\.github/scripts/'; then
+            echo "ci_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ci_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Generate base snapshot
         run: |
           git checkout ${{ steps.changed-files.outputs.base_commit }}
@@ -124,9 +133,12 @@ jobs:
         run: |
           mkdir -p /tmp/btd_results
 
-          # Run parser script; --fallback means BTD failed so run everything
+          # Run parser script; --fallback means run everything
           FALLBACK_FLAG=""
           if [ "${{ steps.btd.outputs.succeeded }}" != "true" ]; then
+            FALLBACK_FLAG="--fallback"
+          elif [ "${{ steps.changed-files.outputs.ci_changed }}" = "true" ]; then
+            echo "CI workflow changed — rebuilding all FPGA targets"
             FALLBACK_FLAG="--fallback"
           fi
 
@@ -195,7 +207,7 @@ jobs:
           echo "Build output: $OUTPUT"
           echo "Output directory: $OUTPUT_DIR"
           echo "output_dir=$OUTPUT_DIR" >> "$GITHUB_OUTPUT"
-          TARGET_NAME=$(echo "${{ matrix.target }}" | sed 's|.*:||')
+          TARGET_NAME=$(echo "${{ matrix.target }}" | sed 's|.*:||' | tr '_' '-')
           echo "artifact_name=${TARGET_NAME}-image" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifact
@@ -246,7 +258,7 @@ jobs:
           echo "Build output: $OUTPUT"
           echo "Output directory: $OUTPUT_DIR"
           echo "output_dir=$OUTPUT_DIR" >> "$GITHUB_OUTPUT"
-          TARGET_NAME=$(echo "${{ matrix.target }}" | sed 's|.*:||')
+          TARGET_NAME=$(echo "${{ matrix.target }}" | sed 's|.*:||' | tr '_' '-')
           echo "artifact_name=${TARGET_NAME}-image" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifact
@@ -297,7 +309,7 @@ jobs:
           echo "Build output: $OUTPUT"
           echo "Output directory: $OUTPUT_DIR"
           echo "output_dir=$OUTPUT_DIR" >> "$GITHUB_OUTPUT"
-          TARGET_NAME=$(echo "${{ matrix.target }}" | sed 's|.*:||')
+          TARGET_NAME=$(echo "${{ matrix.target }}" | sed 's|.*:||' | tr '_' '-')
           echo "artifact_name=${TARGET_NAME}-image" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifact

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -59,6 +59,15 @@ jobs:
 
           echo "base_commit=$BASE_COMMIT" >> "$GITHUB_OUTPUT"
 
+          # Check if this workflow or the shared parser script changed.
+          # These aren't buck2 inputs so BTD won't detect them, but they
+          # can affect simulation runs (toolchain versions, env vars).
+          if git diff --name-only "$BASE_COMMIT" HEAD | grep -qE '\.github/workflows/simulation\.yml|\.github/scripts/'; then
+            echo "ci_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ci_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Generate base snapshot
         run: |
           git checkout ${{ steps.changed-files.outputs.base_commit }}
@@ -121,9 +130,12 @@ jobs:
         run: |
           mkdir -p /tmp/btd_results
 
-          # Run parser script; --fallback means BTD failed so run everything
+          # Run parser script; --fallback means run everything
           FALLBACK_FLAG=""
           if [ "${{ steps.btd.outputs.succeeded }}" != "true" ]; then
+            FALLBACK_FLAG="--fallback"
+          elif [ "${{ steps.changed-files.outputs.ci_changed }}" = "true" ]; then
+            echo "CI workflow changed — re-running all simulation targets"
             FALLBACK_FLAG="--fallback"
           fi
 

--- a/tools/fpga_releaser/archive_parser.py
+++ b/tools/fpga_releaser/archive_parser.py
@@ -15,7 +15,7 @@ def get_relevant_files_from_buck_zip(fpga_name, zip):
             continue
         if item.filename.endswith(".bz2"):
             zip_names.append(item.filename)
-        if "/maps/" in item.filename and (item.filename.endswith(".json") or item.filename.endswith(".html")):
+        if "maps/" in item.filename and (item.filename.endswith(".json") or item.filename.endswith(".html")):
             zip_names.append(item.filename)
         if item.filename.endswith("nextpnr.log"):
            zip_names.append(item.filename)


### PR DESCRIPTION
We adjusted how the build artifacts are uploaded, so this fixes the fpga releaser.

I also noticed that ci workflow changes aren't known by buck2 so didn't trip change detection, this change also make sure we re-build images and re-run sims when their ci workflow file changes even if the buck2 targets didn't change.