### PR TITLE
.buckconfig.local instructions

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -28,6 +28,6 @@ disk_cache_dir_max_size = 10737418240
 mode = sqlite
 
 [bsv]
-# BSV library directory - reads from BSV_LIB_DIR environment variable
-# Falls back to /opt/bsc-2022.01/lib if not set (GitHub Actions standard path)
-libdir = ${env.BSV_LIB_DIR:/opt/bsc-2022.01/lib}
+# /opt/bsc-2022.01/lib (GitHub Actions standard path)
+# use a .buckconfig.local to override for local development if needed
+libdir = /opt/bsc-2022.01/lib

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__
 
 # Buck2 ignores
 /buck-out
+.buckconfig.local
 
 # VUnit ignores
 /vunit_out

--- a/BSV_BUCK2_GUIDE.md
+++ b/BSV_BUCK2_GUIDE.md
@@ -64,8 +64,9 @@ which bsc
 # Python packages for RDL
 pip install -r tools/requirements.txt
 
-# Optional: Set custom Bluespec library directory
-# export BSV_LIB_DIR=/path/to/bluespec/lib
+# Optional: Set custom Bluespec library directory in .buckconfig.local
+# [bsv]
+# libdir = /path/to/bluespec/lib
 # (See "Toolchain Configuration" in Advanced Topics for details)
 ```
 
@@ -709,30 +710,26 @@ bsv_library(
 
 #### BSV Library Directory
 
-The BSV toolchain can be configured to use a custom Bluespec library directory via the `BSV_LIB_DIR` environment variable:
+The BSV toolchain reads the Bluespec library path from the `[bsv] libdir` key in `.buckconfig`. The default is `/opt/bsc-2022.01/lib` (matching the CI runner environment). To override it locally, create a `.buckconfig.local` (which is gitignored):
+
+```ini
+# .buckconfig.local
+[bsv]
+libdir = /opt/bluespec/lib
+```
+
+You can also override on the command line:
 
 ```bash
-# Set custom Bluespec library path
-export BSV_LIB_DIR=/path/to/custom/bluespec/lib
-
-# Build with custom library path
-buck2 build //hdl/ip/bsv:YourModule
+buck2 build -c bsv.libdir=/opt/bluespec/lib //hdl/ip/bsv:YourModule
 ```
 
 **Configuration Details:**
 
-- **Environment Variable**: `BSV_LIB_DIR`
-- **Default Value**: `/usr/local/bluespec/lib` (if not set)
-- **Config Location**: `.buckconfig` section `[bsv]`
+- **Config Key**: `[bsv] libdir`
+- **Default Value**: `/opt/bsc-2022.01/lib`
+- **Config Location**: `.buckconfig` (override in `.buckconfig.local`)
 - **Toolchain File**: `toolchains/bsv_toolchain.bzl`
-
-The toolchain reads this value through Buck2's configuration system:
-
-```ini
-# .buckconfig
-[bsv]
-libdir = ${env.BSV_LIB_DIR:/opt/bsc-2022.01/lib}
-```
 
 **Override in BUCK files** (if needed):
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,12 +49,10 @@ buck2 run //hdl/ip/bsv:MyTests_mkTestName
 # Generate Verilog for synthesis
 buck2 build //hdl/ip/bsv:my_verilog
 
-# Optional: Set custom Bluespec library directory
-export BSV_LIB_DIR=/path/to/bluespec/lib
+# Optional: Set custom Bluespec library directory in .buckconfig.local
+# [bsv]
+# libdir = /path/to/bluespec/lib
 ```
-
-**Environment Variables:**
-- `BSV_LIB_DIR` - Custom Bluespec library directory (defaults to `/usr/local/lib/bluespec`)
 
 **Documentation:**
 - [BSV_BUCK2_GUIDE.md](BSV_BUCK2_GUIDE.md) - Complete Buck2 BSV build system reference

--- a/vnd/bluespec/BUCK
+++ b/vnd/bluespec/BUCK
@@ -1,8 +1,8 @@
 # Bluespec Verilog primitives
 
+_BSV_LIBDIR = read_config("bsv", "libdir", "/opt/bsc-2022.01/lib")
+
 # Concatenate Bluespec Verilog library files into single Verilog.v
-# BSC library path is read from BSV_LIB_DIR environment variable
-# Defaults to /opt/bsc-2022.01/lib if not set (GitHub Actions standard path)
 # Exclude files with issues for synthesis:
 #   - Non-standard port syntax (InoutConnect, MakeReset*, ProbeHook, SyncFIFOLevel*, SyncRegister)
 #   - Testbench template (main.v)
@@ -11,7 +11,10 @@ genrule(
     name = "Verilog",
     visibility = ["PUBLIC"],
     out = "Verilog.v",
-    bash = 'find "${BSV_LIB_DIR:-/opt/bsc-2022.01/lib}/Verilog/" -name \'*.v\' ! -name \'InoutConnect.v\' ! -name \'MakeResetA.v\' ! -name \'MakeReset.v\' ! -name \'ProbeHook.v\' ! -name \'SyncFIFOLevel0.v\' ! -name \'SyncFIFOLevel.v\' ! -name \'SyncRegister.v\' ! -name \'main.v\' ! -name \'BRAM1BELoad.v\' ! -name \'BRAM1Load.v\' ! -name \'BRAM2BELoad.v\' ! -name \'BRAM2Load.v\' ! -name \'RegFileLoad.v\' -exec cat {} \\; > $OUT',
+    env = {
+        "BSV_LIB_DIR": _BSV_LIBDIR,
+    },
+    bash = 'find "$BSV_LIB_DIR/Verilog/" -name \'*.v\' ! -name \'InoutConnect.v\' ! -name \'MakeResetA.v\' ! -name \'MakeReset.v\' ! -name \'ProbeHook.v\' ! -name \'SyncFIFOLevel0.v\' ! -name \'SyncFIFOLevel.v\' ! -name \'SyncRegister.v\' ! -name \'main.v\' ! -name \'BRAM1BELoad.v\' ! -name \'BRAM1Load.v\' ! -name \'BRAM2BELoad.v\' ! -name \'BRAM2Load.v\' ! -name \'RegFileLoad.v\' -exec cat {} \\; > $OUT',
 )
 
 # Export basicinout.pl for Verilog filtering


### PR DESCRIPTION
it turns out, variable substitution doesn't work magically in .buckconfig.  This change fixes the default to match the ci env, and provides instructions for overriding it. This also changes the bsv gen rules to use the variable from the .buckconfig vs attempting to grab the variable via bash which appears fragile in a number of ways.