### PR TITLE
Bump vunit version

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -2,7 +2,7 @@ systemrdl-compiler == 1.23.0
 click == 8.1.2
 Jinja2 == 3.1.6
 inflection == 0.5.1
-vunit_hdl == 5.0.0.dev5
+vunit_hdl == 5.0.0.dev9
 tomli-w == 1.2.0
 tomli == 2.2.1
 crc == 7.0.0

--- a/tools/vunit_gen/templates/run_py.jinja2
+++ b/tools/vunit_gen/templates/run_py.jinja2
@@ -50,7 +50,6 @@ vu = VUnit.from_argv()
 # For now, add everything here so it's always available
 vu.add_vhdl_builtins()
 vu.add_com()
-vu.add_json4vhdl()
 vu.add_osvvm()
 vu.add_random()
 vu.add_verification_components()


### PR DESCRIPTION
As is the `tools/requirements.txt` does not work on a fresh Ubuntu 24.04 install due to the deprecation and removal of `pkg_resources`. This fixes the issue and removes unused `json4vhdl` feature that is now handled differently in `vunit`.