### PR TITLE
Add SP5 T6 power control to the sequencer register

### DIFF
--- a/hdl/projects/cosmo_seq/sequencer/sequencer_regs.rdl
+++ b/hdl/projects/cosmo_seq/sequencer/sequencer_regs.rdl
@@ -440,6 +440,9 @@ This regulator controls V1P1_SP5_A0, V1P8_SP5_A0 and V3P3_SP5_A0 rails.";
         field {
             desc = "sp5_mfg_mode_l live status, (From SP5 to FPGA)";
         } sp5_mfg_mode_l[1];
+        field {
+            desc = "sp5_perst_l live status, (From SP5 hotplug to FPGA)";
+        } sp5_perst_l[1];
     } nic_readbacks;
 
     reg {

--- a/hdl/projects/cosmo_seq/sequencer/sp5_sequencer.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sp5_sequencer.vhd
@@ -241,6 +241,7 @@ begin
     nic_readbacks.ext_rst_l <= nic_seq.ext_rst_l;
     nic_readbacks.perst_l <= nic_seq.perst_l;
     nic_readbacks.cld_rst_l <= nic_seq.cld_rst_l;
+    nic_readbacks.sp5_perst_l <= sp5_t6_perst_l;
 
     fans_power_ok <= early_power_rdbks.fan_hsc_west_pg and 
                      early_power_rdbks.fan_hsc_central_pg and 


### PR DESCRIPTION
Add sp5_perst_l signal to the register so we can easily see the hot-plug i/o status from the SP5 in these registers as a one-stop-shop.

Fixes #475 