### PR TITLE
Ndh/copyright cleanup

### DIFF
--- a/hdl/ip/bsv/CommonFunctions.bsv
+++ b/hdl/ip/bsv/CommonFunctions.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/CommonInterfaces.bsv
+++ b/hdl/ip/bsv/CommonInterfaces.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/Countdown.bsv
+++ b/hdl/ip/bsv/Countdown.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/Debouncer.bsv
+++ b/hdl/ip/bsv/Debouncer.bsv
@@ -1,4 +1,3 @@
-// Copyright 2023 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/Deserializer8b10b.bsv
+++ b/hdl/ip/bsv/Deserializer8b10b.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/Encoding8b10b.bsv
+++ b/hdl/ip/bsv/Encoding8b10b.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public License,
 // v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/hdl/ip/bsv/I2C/I2CBitController.bsv
+++ b/hdl/ip/bsv/I2C/I2CBitController.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/I2C/I2CCore.bsv
+++ b/hdl/ip/bsv/I2C/I2CCore.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/I2C/test/I2CCoreTests.bsv
+++ b/hdl/ip/bsv/I2C/test/I2CCoreTests.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/I2C/test/I2CPeripheralModel.bsv
+++ b/hdl/ip/bsv/I2C/test/I2CPeripheralModel.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/InitialReset.bsv
+++ b/hdl/ip/bsv/InitialReset.bsv
@@ -1,4 +1,3 @@
-// Copyright 2021 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/InitialReset.v
+++ b/hdl/ip/bsv/InitialReset.v
@@ -1,4 +1,3 @@
-// Copyright 2021 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/MDIO/MDIO.bsv
+++ b/hdl/ip/bsv/MDIO/MDIO.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/MDIO/test/MDIOPeripheralModel.bsv
+++ b/hdl/ip/bsv/MDIO/test/MDIOPeripheralModel.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/MDIO/test/MDIOTests.bsv
+++ b/hdl/ip/bsv/MDIO/test/MDIOTests.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/PLL.bsv
+++ b/hdl/ip/bsv/PLL.bsv
@@ -1,4 +1,3 @@
-// Copyright 2021 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/SchmittReg.bsv
+++ b/hdl/ip/bsv/SchmittReg.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/Serializer8b10b.bsv
+++ b/hdl/ip/bsv/Serializer8b10b.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/Strobe.bsv
+++ b/hdl/ip/bsv/Strobe.bsv
@@ -1,4 +1,3 @@
-// Copyright 2021 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/TestUtils.bsv
+++ b/hdl/ip/bsv/TestUtils.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/WriteOnceReg.bsv
+++ b/hdl/ip/bsv/WriteOnceReg.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/examples/TestPatternVideoSource.bsv
+++ b/hdl/ip/bsv/examples/TestPatternVideoSource.bsv
@@ -1,4 +1,3 @@
-// Copyright 2021 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/examples/test_pattern_video_source.cc
+++ b/hdl/ip/bsv/examples/test_pattern_video_source.cc
@@ -1,4 +1,3 @@
-// Copyright 2021 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/ignition/ignition_controller.rdl
+++ b/hdl/ip/bsv/ignition/ignition_controller.rdl
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/interfaces/ECP5.bsv
+++ b/hdl/ip/bsv/interfaces/ECP5.bsv
@@ -1,4 +1,3 @@
-// Copyright 2021 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/interfaces/ECP5PLL.v
+++ b/hdl/ip/bsv/interfaces/ECP5PLL.v
@@ -1,4 +1,3 @@
-// Copyright 2021 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/interfaces/ICE40.bsv
+++ b/hdl/ip/bsv/interfaces/ICE40.bsv
@@ -1,4 +1,3 @@
-// Copyright 2021 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/interfaces/SPI.bsv
+++ b/hdl/ip/bsv/interfaces/SPI.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/interfaces/video/TMDS.bsv
+++ b/hdl/ip/bsv/interfaces/video/TMDS.bsv
@@ -1,4 +1,3 @@
-// Copyright 2021 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/interfaces/video/TestPatternGenerator.bsv
+++ b/hdl/ip/bsv/interfaces/video/TestPatternGenerator.bsv
@@ -1,4 +1,3 @@
-// Copyright 2021 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/interfaces/video/Timing.bsv
+++ b/hdl/ip/bsv/interfaces/video/Timing.bsv
@@ -1,4 +1,3 @@
-// Copyright 2021 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/interfaces/video/Transmitter.bsv
+++ b/hdl/ip/bsv/interfaces/video/Transmitter.bsv
@@ -1,4 +1,3 @@
-// Copyright 2021 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/interfaces/video/video_source_validation.cc
+++ b/hdl/ip/bsv/interfaces/video/video_source_validation.cc
@@ -1,4 +1,3 @@
-// Copyright 2021 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/interfaces/video/video_source_validation.h
+++ b/hdl/ip/bsv/interfaces/video/video_source_validation.h
@@ -1,4 +1,3 @@
-// Copyright 2021 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/power_rail/PowerRail.bsv
+++ b/hdl/ip/bsv/power_rail/PowerRail.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/test/Encoding8b10bTests.bsv
+++ b/hdl/ip/bsv/test/Encoding8b10bTests.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/bsv/test_buck2/Countdown.bsv
+++ b/hdl/ip/bsv/test_buck2/Countdown.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/ip/vhd/8b10b/helper_8b10b_pkg.vhd
+++ b/hdl/ip/vhd/8b10b/helper_8b10b_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/arb_mux_demux/arbiter.vhd
+++ b/hdl/ip/vhd/arb_mux_demux/arbiter.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- Note: Documentation can be rendered in VSCode using the TerosHDL
 -- plugin: https://terostechnology.github.io/terosHDLdoc/

--- a/hdl/ip/vhd/arb_mux_demux/arbiter_pkg.vhd
+++ b/hdl/ip/vhd/arb_mux_demux/arbiter_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 --! Common shared information for arbiters
 package arbiter_pkg is

--- a/hdl/ip/vhd/arb_mux_demux/sims/arbiter_sim_pkg.vhd
+++ b/hdl/ip/vhd/arb_mux_demux/sims/arbiter_sim_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/arb_mux_demux/sims/arbiter_tb.vhd
+++ b/hdl/ip/vhd/arb_mux_demux/sims/arbiter_tb.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/arb_mux_demux/sims/arbiter_th.vhd
+++ b/hdl/ip/vhd/arb_mux_demux/sims/arbiter_th.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/axi_blocks/axil8_resizer.vhd
+++ b/hdl/ip/vhd/axi_blocks/axil8_resizer.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 
 library ieee;

--- a/hdl/ip/vhd/axi_blocks/axil_common_pkg.vhd
+++ b/hdl/ip/vhd/axi_blocks/axil_common_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/axi_blocks/axil_interconnect.vhd
+++ b/hdl/ip/vhd/axi_blocks/axil_interconnect.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 
 library ieee;

--- a/hdl/ip/vhd/axi_blocks/axil_interconnect_2k8.vhd
+++ b/hdl/ip/vhd/axi_blocks/axil_interconnect_2k8.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 
 library ieee;

--- a/hdl/ip/vhd/axi_blocks/axil_target_txn.vhd
+++ b/hdl/ip/vhd/axi_blocks/axil_target_txn.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company 
  
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/axi_blocks/axilite_if_2k19_helper_pkg.vhd
+++ b/hdl/ip/vhd/axi_blocks/axilite_if_2k19_helper_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 
 library ieee;

--- a/hdl/ip/vhd/axi_blocks/axilite_if_2k19_pkg.vhd
+++ b/hdl/ip/vhd/axi_blocks/axilite_if_2k19_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 
 library ieee;

--- a/hdl/ip/vhd/axi_blocks/axilite_if_2k8_pkg.vhd
+++ b/hdl/ip/vhd/axi_blocks/axilite_if_2k8_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 
 library ieee;

--- a/hdl/ip/vhd/axi_blocks/axist_if_2k19_pkg.vhd
+++ b/hdl/ip/vhd/axi_blocks/axist_if_2k19_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 
 library ieee;

--- a/hdl/ip/vhd/common/countdown/countdown.vhd
+++ b/hdl/ip/vhd/common/countdown/countdown.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- A general purpose counter block which counts down from a supplied `count` to zero. `done is not
 -- registered and will be asserted immediately when the internal count is at zero. Control priority

--- a/hdl/ip/vhd/common/countdown/sims/countdown_tb.vhd
+++ b/hdl/ip/vhd/common/countdown/sims/countdown_tb.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/common/countdown/sims/countdown_th.vhd
+++ b/hdl/ip/vhd/common/countdown/sims/countdown_th.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/common/interfaces/tristate_if_pkg.vhd
+++ b/hdl/ip/vhd/common/interfaces/tristate_if_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- This package relies on the VHDL 2019 feature for "interfaces"
 

--- a/hdl/ip/vhd/common/strobe/sims/strobe_tb.vhd
+++ b/hdl/ip/vhd/common/strobe/sims/strobe_tb.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/common/strobe/sims/strobe_th.vhd
+++ b/hdl/ip/vhd/common/strobe/sims/strobe_th.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/common/strobe/strobe.vhd
+++ b/hdl/ip/vhd/common/strobe/strobe.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- A small block that will generate a single `clk` pulse on `strobe` every `TICKS` cycles of `clk`.
 

--- a/hdl/ip/vhd/common/utils/calc_pkg.vhd
+++ b/hdl/ip/vhd/common/utils/calc_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- Note: Documentation can be rendered in VSCode using the TerosHDL
 -- plugin: https://terostechnology.github.io/terosHDLdoc/

--- a/hdl/ip/vhd/common/utils/sims/utilities_tb.vhd
+++ b/hdl/ip/vhd/common/utils/sims/utilities_tb.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/common/utils/time_pkg.vhd
+++ b/hdl/ip/vhd/common/utils/time_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- Note: Documentation can be rendered in VSCode using the TerosHDL
 -- plugin: https://terostechnology.github.io/terosHDLdoc/

--- a/hdl/ip/vhd/common/utils/transforms_pkg.vhd
+++ b/hdl/ip/vhd/common/utils/transforms_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 
 library ieee;

--- a/hdl/ip/vhd/crc/crc8atm_8wide.vhd
+++ b/hdl/ip/vhd/crc/crc8atm_8wide.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/crc/crc8autostar_8wide.vhd
+++ b/hdl/ip/vhd/crc/crc8autostar_8wide.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/crc/crc_sim_pkg.vhd
+++ b/hdl/ip/vhd/crc/crc_sim_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 -- As a reminder when making these:
 --  Highest term is xor'd with next input bit and result is fed back into the 

--- a/hdl/ip/vhd/espi/espi_spec_regs.rdl
+++ b/hdl/ip/vhd/espi/espi_spec_regs.rdl
@@ -1,4 +1,3 @@
-// Copyright 2024 Oxide Computer Company
 // This is SystemRDL description of the sw-accesible registers in the Gimlet
 // Sequencer FPGA.
 

--- a/hdl/ip/vhd/espi/espi_spec_regs.vhd
+++ b/hdl/ip/vhd/espi/espi_spec_regs.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 -- Note: Documentation can be rendered in VSCode using the TerosHDL
 -- plugin: https://terostechnology.github.io/terosHDLdoc/

--- a/hdl/ip/vhd/espi/espi_target_top.vhd
+++ b/hdl/ip/vhd/espi/espi_target_top.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- Top level of the eSPI target block. This block is responsible for
 -- basic synchronization of the eSPI signals, and instantiation of the

--- a/hdl/ip/vhd/espi/flash_channel/flash_channel.vhd
+++ b/hdl/ip/vhd/espi/flash_channel/flash_channel.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- This block provides the transaction queueing and management for the flash
 -- channel. It is responsible for queueing up transactions, issuing commands to

--- a/hdl/ip/vhd/espi/flash_channel/flash_channel_pkg.vhd
+++ b/hdl/ip/vhd/espi/flash_channel/flash_channel_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/espi/link_layer/alert_gen.vhd
+++ b/hdl/ip/vhd/espi/link_layer/alert_gen.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- This block manages the state machine for the in-band alert mechanism.
 -- Logic in the slow domain monitors when an alert is needed and this block

--- a/hdl/ip/vhd/espi/link_layer/cmd_sizer.vhd
+++ b/hdl/ip/vhd/espi/link_layer/cmd_sizer.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- In the fast domain, before we've done full packet parsing, we need
 -- some basic parsing to determine the size of the packet and when the

--- a/hdl/ip/vhd/espi/link_layer/dbg_link_faker.vhd
+++ b/hdl/ip/vhd/espi/link_layer/dbg_link_faker.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- This block allows an SP-interface to issue eSPI commands to the transaction
 -- layer and receive responses. It is used for debugging and testing purposes

--- a/hdl/ip/vhd/espi/link_layer/link_layer.vhd
+++ b/hdl/ip/vhd/espi/link_layer/link_layer.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- The main qspi link layer block for this target, including the 
 -- link-layer transaction management and FIFO interfaces to/from

--- a/hdl/ip/vhd/espi/link_layer/link_layer_pkg.vhd
+++ b/hdl/ip/vhd/espi/link_layer/link_layer_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/espi/link_layer/qspi_link_layer_pkg.vhd
+++ b/hdl/ip/vhd/espi/link_layer/qspi_link_layer_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/espi/peripheral_channel/uart_channel_pkg.vhd
+++ b/hdl/ip/vhd/espi/peripheral_channel/uart_channel_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/espi/peripheral_channel/uart_channel_top.vhd
+++ b/hdl/ip/vhd/espi/peripheral_channel/uart_channel_top.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- This block provides the transaction queueing and management for the peripheral
 -- channel. It is responsible for queueing up transactions, issuing bytes to

--- a/hdl/ip/vhd/espi/sims/espi_tb.vhd
+++ b/hdl/ip/vhd/espi/sims/espi_tb.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/espi/sims/espi_tb_pkg.vhd
+++ b/hdl/ip/vhd/espi/sims/espi_tb_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- This package contains types and helper functions for building testbenches
 -- around the espi protocol. Functions and procedures in this block are "generic"

--- a/hdl/ip/vhd/espi/sims/espi_th.vhd
+++ b/hdl/ip/vhd/espi/sims/espi_th.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/espi/sims/models/espi_controller_vc_pkg.vhd
+++ b/hdl/ip/vhd/espi/sims/models/espi_controller_vc_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- Note: Documentation can be rendered in VSCode using the TerosHDL
 -- plugin: https://terostechnology.github.io/terosHDLdoc/

--- a/hdl/ip/vhd/espi/sims/models/espi_dbg_vc_pkg.vhd
+++ b/hdl/ip/vhd/espi/sims/models/espi_dbg_vc_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/espi/sims/models/fake_flash_txn_mgr.vhd
+++ b/hdl/ip/vhd/espi/sims/models/fake_flash_txn_mgr.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- This is a fake flash transaction manager used to test the ESPI interface.
 -- Rather than pulling in a whole flash controller for sim, we just mock the

--- a/hdl/ip/vhd/espi/sys_regs/espi_regs.rdl
+++ b/hdl/ip/vhd/espi/sys_regs/espi_regs.rdl
@@ -1,4 +1,3 @@
-// Copyright 2024 Oxide Computer Company
 // This is SystemRDL description of the sw-accessible registers in the Gimlet
 // Sequencer FPGA.
 

--- a/hdl/ip/vhd/espi/sys_regs/espi_regs.vhd
+++ b/hdl/ip/vhd/espi/sys_regs/espi_regs.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 -- SP-accessible registers for the eSPI block
 

--- a/hdl/ip/vhd/espi/sys_regs/espi_spec_regs_view_pkg.vhd
+++ b/hdl/ip/vhd/espi/sys_regs/espi_spec_regs_view_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 -- Composite record and views for exposing eSPI spec register
 -- values as a read-only interface in the sys_regs address space.

--- a/hdl/ip/vhd/espi/sys_regs/sp5_post_code_pkg.vhd
+++ b/hdl/ip/vhd/espi/sys_regs/sp5_post_code_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2026 Oxide Computer Company
 
 -- Composite record and views for exposing eSPI spec register
 -- values as a read-only interface in the sys_regs address space.

--- a/hdl/ip/vhd/espi/txn_layer/command_processor.vhd
+++ b/hdl/ip/vhd/espi/txn_layer/command_processor.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- Main command parser and processing for the eSPI transaction layer.
 -- Pulls from a FIFO from the link layer or debug layer and processes

--- a/hdl/ip/vhd/espi/txn_layer/espi_base_types_pkg.vhd
+++ b/hdl/ip/vhd/espi/txn_layer/espi_base_types_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/espi/txn_layer/espi_protocol_pkg.vhd
+++ b/hdl/ip/vhd/espi/txn_layer/espi_protocol_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/espi/txn_layer/link_to_txn_bridge.vhd
+++ b/hdl/ip/vhd/espi/txn_layer/link_to_txn_bridge.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- Provides clock-crossing between the link layer and transaction layer
 -- and provides the debug mux for disconnecting the link layer and using

--- a/hdl/ip/vhd/espi/txn_layer/response_processor.vhd
+++ b/hdl/ip/vhd/espi/txn_layer/response_processor.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- Determine and coordinate responses back to the link layer depending on the
 -- current command opcode and availablilty of data to send back.

--- a/hdl/ip/vhd/espi/txn_layer/txn_layer_top.vhd
+++ b/hdl/ip/vhd/espi/txn_layer/txn_layer_top.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- Structural wrapper for the transaction layer and the various channel blocks
 

--- a/hdl/ip/vhd/espi/vwire_channel/vwire_block.vhd
+++ b/hdl/ip/vhd/espi/vwire_channel/vwire_block.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- eSPI Virtual Wire Channel implementation
 -- While we do nothing with this today, the mask-rom in the SP5

--- a/hdl/ip/vhd/espi/vwire_channel/vwire_regs.rdl
+++ b/hdl/ip/vhd/espi/vwire_channel/vwire_regs.rdl
@@ -1,4 +1,3 @@
-// Copyright 2024 Oxide Computer Company
 // This is SystemRDL description of the sw-accesible registers in the Gimlet
 // Sequencer FPGA.
 

--- a/hdl/ip/vhd/fifos/sims/fifos_sim_pkg.vhd
+++ b/hdl/ip/vhd/fifos/sims/fifos_sim_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/fifos/sims/fifos_tb.vhd
+++ b/hdl/ip/vhd/fifos/sims/fifos_tb.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/fifos/sims/fifos_th.vhd
+++ b/hdl/ip/vhd/fifos/sims/fifos_th.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/fmc_if/model/stm32h7_fmc_model.vhd
+++ b/hdl/ip/vhd/fmc_if/model/stm32h7_fmc_model.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 --! FMC controller model based on ST's RM0433 rev8
 --! figures 115 and 116 for simulation of the

--- a/hdl/ip/vhd/fmc_if/model/stm32h7_fmc_sim_pkg.vhd
+++ b/hdl/ip/vhd/fmc_if/model/stm32h7_fmc_sim_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 --! Bus master model based on ST's RM0433
 --! figures 115 and 116

--- a/hdl/ip/vhd/fmc_if/sims/fmc_tb.vhd
+++ b/hdl/ip/vhd/fmc_if/sims/fmc_tb.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/fmc_if/sims/fmc_tb_pkg.vhd
+++ b/hdl/ip/vhd/fmc_if/sims/fmc_tb_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 --! Bus master model based on ST's RM0433
 --! figures 115 and 116

--- a/hdl/ip/vhd/fmc_if/sims/fmc_th.vhd
+++ b/hdl/ip/vhd/fmc_if/sims/fmc_th.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/fmc_if/stm32h7_fmc_target.vhd
+++ b/hdl/ip/vhd/fmc_if/stm32h7_fmc_target.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 --! This block provides an FMC target interface from the STM32H7's
 --! local bus, crosses clock domains into the FPGA's core logic

--- a/hdl/ip/vhd/fmc_if/stm32h7_fmc_target_pkg.vhd
+++ b/hdl/ip/vhd/fmc_if/stm32h7_fmc_target_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/common/i2c_common_pkg.vhd
+++ b/hdl/ip/vhd/i2c/common/i2c_common_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/common/i2c_glitch_filter.vhd
+++ b/hdl/ip/vhd/i2c/common/i2c_glitch_filter.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- Simple i2c glitch filtering for targets  I2C spec
 -- This block incurs a delay of 1 sync cycle and n filter cycles

--- a/hdl/ip/vhd/i2c/controller/i2c_ctrl_top.vhd
+++ b/hdl/ip/vhd/i2c/controller/i2c_ctrl_top.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/controller/link_layer/i2c_ctrl_link_layer.vhd
+++ b/hdl/ip/vhd/i2c/controller/link_layer/i2c_ctrl_link_layer.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 -- I2C Control Link Layer
 --

--- a/hdl/ip/vhd/i2c/controller/regs/i2c_ctrl_regs.rdl
+++ b/hdl/ip/vhd/i2c/controller/regs/i2c_ctrl_regs.rdl
@@ -1,4 +1,3 @@
-// Copyright 2024 Oxide Computer Company
 // This is a SystemRDL description of the SW-accessible registers for the I2C controller.
 
 addrmap i2c_ctrl_regs {

--- a/hdl/ip/vhd/i2c/controller/regs/i2c_ctrl_regs.vhd
+++ b/hdl/ip/vhd/i2c/controller/regs/i2c_ctrl_regs.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- AXI-accessible registers for the I2C block
 

--- a/hdl/ip/vhd/i2c/controller/txn_layer/i2c_ctrl_txn_layer.vhd
+++ b/hdl/ip/vhd/i2c/controller/txn_layer/i2c_ctrl_txn_layer.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 -- I2C Controller Transaction Layer
 --

--- a/hdl/ip/vhd/i2c/controller/txn_layer/sims/i2c_ctrl_txn_layer_tb.vhd
+++ b/hdl/ip/vhd/i2c/controller/txn_layer/sims/i2c_ctrl_txn_layer_tb.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/controller/txn_layer/sims/i2c_ctrl_txn_layer_th.vhd
+++ b/hdl/ip/vhd/i2c/controller/txn_layer/sims/i2c_ctrl_txn_layer_th.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/pca9506_function.vhd
+++ b/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/pca9506_function.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/pca9506_pkg.vhd
+++ b/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/pca9506_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/pca9506_regs.rdl
+++ b/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/pca9506_regs.rdl
@@ -1,4 +1,3 @@
-// Copyright 2025 Oxide Computer Company
 // This is SystemRDL description of emulated i2c mux registers
 regfile pca9506_raw_regs #(longint unsigned SIZE = 8) {
     default regwidth = SIZE;

--- a/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/pca9506_regs.vhd
+++ b/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/pca9506_regs.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/pca9506_top.vhd
+++ b/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/pca9506_top.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 -- This provides an I/O expander sw-compatible with the PCA9506 memory map
 -- upper level logic will decide whether or not to use the tri-state signals

--- a/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/sims/i2c_pca9506ish_sim_pkg.vhd
+++ b/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/sims/i2c_pca9506ish_sim_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/sims/i2c_pca9506ish_tb.vhd
+++ b/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/sims/i2c_pca9506ish_tb.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/sims/i2c_pca9506ish_th.vhd
+++ b/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/sims/i2c_pca9506ish_th.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/muxes/PCA9545ish/emulated_pca9545_regs.rdl
+++ b/hdl/ip/vhd/i2c/muxes/PCA9545ish/emulated_pca9545_regs.rdl
@@ -1,4 +1,3 @@
-// Copyright 2025 Oxide Computer Company
 // This is SystemRDL description of emulated i2c mux registers
 
 addrmap emulated_pca9545_regs {

--- a/hdl/ip/vhd/i2c/muxes/PCA9545ish/pca9545_pkg.vhd
+++ b/hdl/ip/vhd/i2c/muxes/PCA9545ish/pca9545_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;

--- a/hdl/ip/vhd/i2c/muxes/PCA9545ish/pca9545ish_function.vhd
+++ b/hdl/ip/vhd/i2c/muxes/PCA9545ish/pca9545ish_function.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 -- This block provides the logic and control register for the i2c mux
 -- as well as the response logic for interfacing with the i2c_target_phy block

--- a/hdl/ip/vhd/i2c/muxes/PCA9545ish/pca9545ish_top.vhd
+++ b/hdl/ip/vhd/i2c/muxes/PCA9545ish/pca9545ish_top.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 -- This provides the digital portion of a 4 channel i2c mux, based on the software interface
 -- of a PCA9545.  Currently no interrupts are supported as we don't need them so those

--- a/hdl/ip/vhd/i2c/muxes/PCA9545ish/sims/i2c_pca9545ish_sim_pkg.vhd
+++ b/hdl/ip/vhd/i2c/muxes/PCA9545ish/sims/i2c_pca9545ish_sim_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/muxes/PCA9545ish/sims/i2c_pca9545ish_tb.vhd
+++ b/hdl/ip/vhd/i2c/muxes/PCA9545ish/sims/i2c_pca9545ish_tb.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/muxes/PCA9545ish/sims/i2c_pca9545ish_th.vhd
+++ b/hdl/ip/vhd/i2c/muxes/PCA9545ish/sims/i2c_pca9545ish_th.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/muxes/oximux16/oximux16_function.vhd
+++ b/hdl/ip/vhd/i2c/muxes/oximux16/oximux16_function.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 -- This block provides the logic and control register for the i2c mux
 -- as well as the response logic for interfacing with the i2c_target_phy block

--- a/hdl/ip/vhd/i2c/muxes/oximux16/oximux16_regs.rdl
+++ b/hdl/ip/vhd/i2c/muxes/oximux16/oximux16_regs.rdl
@@ -1,4 +1,3 @@
-// Copyright 2025 Oxide Computer Company
 // This is SystemRDL description of emulated i2c mux registers
 
 addrmap oximux16_regs {

--- a/hdl/ip/vhd/i2c/muxes/oximux16/oximux16_top.vhd
+++ b/hdl/ip/vhd/i2c/muxes/oximux16/oximux16_top.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 -- This provides the digital portion of a 4 channel i2c mux, based on the software interface
 -- of a PCA9545.  Currently no interrupts are supported as we don't need them so those

--- a/hdl/ip/vhd/i2c/muxes/oximux16/sims/oximux16_sim_pkg.vhd
+++ b/hdl/ip/vhd/i2c/muxes/oximux16/sims/oximux16_sim_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/muxes/oximux16/sims/oximux16_tb.vhd
+++ b/hdl/ip/vhd/i2c/muxes/oximux16/sims/oximux16_tb.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/muxes/oximux16/sims/oximux16_th.vhd
+++ b/hdl/ip/vhd/i2c/muxes/oximux16/sims/oximux16_th.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/target/i2c_base_types_pkg.vhd
+++ b/hdl/ip/vhd/i2c/target/i2c_base_types_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- Shared base types for i2c components
 

--- a/hdl/ip/vhd/i2c/target/i2c_phy_consolidator.vhd
+++ b/hdl/ip/vhd/i2c/target/i2c_phy_consolidator.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/target/i2c_target_phy.vhd
+++ b/hdl/ip/vhd/i2c/target/i2c_target_phy.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 -- This block provides an i2c-compliant "phy" for use with additional logic
 -- to create i2c target functions. It is intended to be generic and shareable

--- a/hdl/ip/vhd/i2c/target/sims/i2c_target_phy_sim_pkg.vhd
+++ b/hdl/ip/vhd/i2c/target/sims/i2c_target_phy_sim_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/target/sims/i2c_target_phy_tb.vhd
+++ b/hdl/ip/vhd/i2c/target/sims/i2c_target_phy_tb.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/target/sims/i2c_target_phy_th.vhd
+++ b/hdl/ip/vhd/i2c/target/sims/i2c_target_phy_th.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/ice40primitives/ice40_pkg.vhd
+++ b/hdl/ip/vhd/ice40primitives/ice40_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/ignition/target/ibc_control.vhd
+++ b/hdl/ip/vhd/ignition/target/ibc_control.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 
 -- Ignition is pretty simple.  It can can turn on the IBC

--- a/hdl/ip/vhd/ignition/target/ignition_io.vhd
+++ b/hdl/ip/vhd/ignition/target/ignition_io.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/ignition/target/ignition_pkg.vhd
+++ b/hdl/ip/vhd/ignition/target/ignition_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/ignition/target/ignition_status.vhd
+++ b/hdl/ip/vhd/ignition/target/ignition_status.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/ignition/target/ignition_target_common.vhd
+++ b/hdl/ip/vhd/ignition/target/ignition_target_common.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/ignition/target/rx_path/ignit_rx_pipe.vhd
+++ b/hdl/ip/vhd/ignition/target/rx_path/ignit_rx_pipe.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 
 library ieee;

--- a/hdl/ip/vhd/ignition/target/rx_path/pkt_parsing.vhd
+++ b/hdl/ip/vhd/ignition/target/rx_path/pkt_parsing.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/ignition/target/sims/ignition_controller_model.vhd
+++ b/hdl/ip/vhd/ignition/target/sims/ignition_controller_model.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 -- want to take a streaming interface with data (9bit, 8 data + control)
 -- generate IDLE sequences unless packets in-bound then send those

--- a/hdl/ip/vhd/ignition/target/sims/ignition_sim_pkg.vhd
+++ b/hdl/ip/vhd/ignition/target/sims/ignition_sim_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/ignition/target/sims/ignition_tgt_sim_tb.vhd
+++ b/hdl/ip/vhd/ignition/target/sims/ignition_tgt_sim_tb.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/ignition/target/sims/ignition_tgt_sim_th.vhd
+++ b/hdl/ip/vhd/ignition/target/sims/ignition_tgt_sim_th.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/ignition/target/tx_path/ignition_tx.vhd
+++ b/hdl/ip/vhd/ignition/target/tx_path/ignition_tx.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/info/info.vhd
+++ b/hdl/ip/vhd/info/info.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- 2019-compatible wrapper for basic board information registers
 

--- a/hdl/ip/vhd/info/info_2k8.vhd
+++ b/hdl/ip/vhd/info/info_2k8.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- Common register block for basic board information
 

--- a/hdl/ip/vhd/info/info_regs.rdl
+++ b/hdl/ip/vhd/info/info_regs.rdl
@@ -1,4 +1,3 @@
-// Copyright 2024 Oxide Computer Company
 // This is SystemRDL description of the sw-accessible common board-info registers
 
 addrmap info_regs {

--- a/hdl/ip/vhd/irq/irq_block.vhd
+++ b/hdl/ip/vhd/irq/irq_block.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2026 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/ls_xcvr/aligner_10bk28_5.vhd
+++ b/hdl/ip/vhd/ls_xcvr/aligner_10bk28_5.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/ls_xcvr/ls_serdes.vhd
+++ b/hdl/ip/vhd/ls_xcvr/ls_serdes.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/memories/mixed_width_simple_dpr.vhd
+++ b/hdl/ip/vhd/memories/mixed_width_simple_dpr.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/memories/sims/memories_sim_pkg.vhd
+++ b/hdl/ip/vhd/memories/sims/memories_sim_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/memories/sims/memories_tb.vhd
+++ b/hdl/ip/vhd/memories/sims/memories_tb.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/memories/sims/memories_th.vhd
+++ b/hdl/ip/vhd/memories/sims/memories_th.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/pipeline/skidbuffer.vhd
+++ b/hdl/ip/vhd/pipeline/skidbuffer.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 -- inspired by https://zipcpu.com/blog/2019/05/22/skidbuffer.html
 

--- a/hdl/ip/vhd/sgpio/sgpio_shift_in.vhd
+++ b/hdl/ip/vhd/sgpio/sgpio_shift_in.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/sgpio/sgpio_shift_out.vhd
+++ b/hdl/ip/vhd/sgpio/sgpio_shift_out.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/sgpio/sgpio_top.vhd
+++ b/hdl/ip/vhd/sgpio/sgpio_top.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/sgpio/sims/sgpio_th.vhd
+++ b/hdl/ip/vhd/sgpio/sims/sgpio_th.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/spi/axi_controller/sims/spi_axi_tb.vhd
+++ b/hdl/ip/vhd/spi/axi_controller/sims/spi_axi_tb.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/spi/axi_controller/sims/spi_axi_tb_pkg.vhd
+++ b/hdl/ip/vhd/spi/axi_controller/sims/spi_axi_tb_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/spi/axi_controller/sims/spi_axi_th.vhd
+++ b/hdl/ip/vhd/spi/axi_controller/sims/spi_axi_th.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/spi/axi_controller/spi_axi_controller_top.vhd
+++ b/hdl/ip/vhd/spi/axi_controller/spi_axi_controller_top.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 -- Acting as a SPI peripheral, turn specially formed transactions into
 -- AXI-lite memory read/write transactions

--- a/hdl/ip/vhd/spi/axi_controller/spi_axi_pkg.vhd
+++ b/hdl/ip/vhd/spi/axi_controller/spi_axi_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/spi/axi_controller/spi_to_axi.vhd
+++ b/hdl/ip/vhd/spi/axi_controller/spi_to_axi.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 -- Acting as a SPI peripheral, turn specially formed transactions into
 -- AXI-lite memory read/write transactions

--- a/hdl/ip/vhd/spi/spi_target_phy/spi_target_phy.vhd
+++ b/hdl/ip/vhd/spi/spi_target_phy/spi_target_phy.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 -- Simple SPI shifter PHY
 -- shifts on sclk edges (post synchronizer) when chipselect is asserted low

--- a/hdl/ip/vhd/spi_nor_controller/espi_txn/espi_flash_txn_mgr.vhd
+++ b/hdl/ip/vhd/spi_nor_controller/espi_txn/espi_flash_txn_mgr.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2026 Oxide Computer Company
 
 
 library ieee;

--- a/hdl/ip/vhd/spi_nor_controller/link/spi_clk_gen.vhd
+++ b/hdl/ip/vhd/spi_nor_controller/link/spi_clk_gen.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/spi_nor_controller/link/spi_link.vhd
+++ b/hdl/ip/vhd/spi_nor_controller/link/spi_link.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/spi_nor_controller/mixed_width_adaptor.vhd
+++ b/hdl/ip/vhd/spi_nor_controller/mixed_width_adaptor.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/spi_nor_controller/sims/spi_nor_tb.vhd
+++ b/hdl/ip/vhd/spi_nor_controller/sims/spi_nor_tb.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/spi_nor_controller/sims/spi_nor_tb_pkg.vhd
+++ b/hdl/ip/vhd/spi_nor_controller/sims/spi_nor_tb_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/spi_nor_controller/sims/spi_nor_th.vhd
+++ b/hdl/ip/vhd/spi_nor_controller/sims/spi_nor_th.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/spi_nor_controller/spi_nor_pkg.vhd
+++ b/hdl/ip/vhd/spi_nor_controller/spi_nor_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company;
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/spi_nor_controller/spi_nor_regs.rdl
+++ b/hdl/ip/vhd/spi_nor_controller/spi_nor_regs.rdl
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// Copyright 2024 Oxide Computer Company
 //
 // This is SystemRDL description of the sw-accesible registers in the
 // grapefruit dev board FPGA.

--- a/hdl/ip/vhd/spi_nor_controller/spi_nor_regs.vhd
+++ b/hdl/ip/vhd/spi_nor_controller/spi_nor_regs.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/spi_nor_controller/spi_nor_top.vhd
+++ b/hdl/ip/vhd/spi_nor_controller/spi_nor_top.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/spi_nor_controller/spi_txn/spi_txn_mgr.vhd
+++ b/hdl/ip/vhd/spi_nor_controller/spi_txn/spi_txn_mgr.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/synchronizers/async_reset_bridge.vhd
+++ b/hdl/ip/vhd/synchronizers/async_reset_bridge.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- Note: Documentation can be rendered in VSCode using the TerosHDL
 -- plugin: https://terostechnology.github.io/terosHDLdoc/

--- a/hdl/ip/vhd/synchronizers/bacd.vhd
+++ b/hdl/ip/vhd/synchronizers/bacd.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- Note: Documentation can be rendered in VSCode using the TerosHDL
 -- plugin: https://terostechnology.github.io/terosHDLdoc/

--- a/hdl/ip/vhd/synchronizers/meta_sync.vhd
+++ b/hdl/ip/vhd/synchronizers/meta_sync.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- Note: Documentation can be rendered in VSCode using the TerosHDL
 -- plugin: https://terostechnology.github.io/terosHDLdoc/

--- a/hdl/ip/vhd/synchronizers/sims/synchronizers_tb.vhd
+++ b/hdl/ip/vhd/synchronizers/sims/synchronizers_tb.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/synchronizers/sims/synchronizers_th.vhd
+++ b/hdl/ip/vhd/synchronizers/sims/synchronizers_th.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/synchronizers/tacd.vhd
+++ b/hdl/ip/vhd/synchronizers/tacd.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- Note: Documentation can be rendered in VSCode using the TerosHDL
 -- plugin: https://terostechnology.github.io/terosHDLdoc/

--- a/hdl/ip/vhd/uart/base_uart/axi_st_uart.vhd
+++ b/hdl/ip/vhd/uart/base_uart/axi_st_uart.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- A very simple UART that streams rx'd bytes out an axi streaming port
 -- and transmits bytes from an input axi streaming port, no buffering

--- a/hdl/ip/vhd/uart/fifo_uart/axi_fifo_st_uart.vhd
+++ b/hdl/ip/vhd/uart/fifo_uart/axi_fifo_st_uart.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 
 library ieee;

--- a/hdl/ip/vhd/uart/sims/uart_tb.vhd
+++ b/hdl/ip/vhd/uart/sims/uart_tb.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/uart/sims/uart_tb_pkg.vhd
+++ b/hdl/ip/vhd/uart/sims/uart_tb_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/uart/sims/uart_th.vhd
+++ b/hdl/ip/vhd/uart/sims/uart_th.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/vunit_components/I2c_cmd/i2c_cmd_vc.vhd
+++ b/hdl/ip/vhd/vunit_components/I2c_cmd/i2c_cmd_vc.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/vunit_components/I2c_cmd/i2c_cmd_vc_pkg.vhd
+++ b/hdl/ip/vhd/vunit_components/I2c_cmd/i2c_cmd_vc_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/vunit_components/basic_stream/basic_sink.vhd
+++ b/hdl/ip/vhd/vunit_components/basic_stream/basic_sink.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 --
 -- A basic sink for streamed data that can apply backpressure.
 

--- a/hdl/ip/vhd/vunit_components/basic_stream/basic_source.vhd
+++ b/hdl/ip/vhd/vunit_components/basic_stream/basic_source.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 --
 -- A basic source of streamed data that respects backpressure.
 

--- a/hdl/ip/vhd/vunit_components/basic_stream/basic_stream_pkg.vhd
+++ b/hdl/ip/vhd/vunit_components/basic_stream/basic_stream_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/vunit_components/basic_stream/sims/th_basic_stream.vhd
+++ b/hdl/ip/vhd/vunit_components/basic_stream/sims/th_basic_stream.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/vunit_components/gpio/gpio_msg_pkg.vhd
+++ b/hdl/ip/vhd/vunit_components/gpio/gpio_msg_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/vunit_components/gpio/sim_gpio.vhd
+++ b/hdl/ip/vhd/vunit_components/gpio/sim_gpio.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- Note: Documentation can be rendered in VSCode using the TerosHDL
 -- plugin: https://terostechnology.github.io/terosHDLdoc/

--- a/hdl/ip/vhd/vunit_components/i2c_controller/i2c_ctrlr_vc.vhd
+++ b/hdl/ip/vhd/vunit_components/i2c_controller/i2c_ctrlr_vc.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 -- Note: Documentation can be rendered in VSCode using the TerosHDL
 -- plugin: https://terostechnology.github.io/terosHDLdoc/

--- a/hdl/ip/vhd/vunit_components/i2c_controller/i2c_ctrlr_vc_pkg.vhd
+++ b/hdl/ip/vhd/vunit_components/i2c_controller/i2c_ctrlr_vc_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/vunit_components/i2c_target/i2c_target_vc.vhd
+++ b/hdl/ip/vhd/vunit_components/i2c_target/i2c_target_vc.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/vunit_components/i2c_target/i2c_target_vc_pkg.vhd
+++ b/hdl/ip/vhd/vunit_components/i2c_target/i2c_target_vc_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/vunit_components/qspi_controller/qspi_controller_vc.vhd
+++ b/hdl/ip/vhd/vunit_components/qspi_controller/qspi_controller_vc.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- Note: Documentation can be rendered in VSCode using the TerosHDL
 -- plugin: https://terostechnology.github.io/terosHDLdoc/

--- a/hdl/ip/vhd/vunit_components/qspi_controller/qspi_vc_pkg.vhd
+++ b/hdl/ip/vhd/vunit_components/qspi_controller/qspi_vc_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/vunit_components/sim_gpio.vhd
+++ b/hdl/ip/vhd/vunit_components/sim_gpio.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- Note: Documentation can be rendered in VSCode using the TerosHDL
 -- plugin: https://terostechnology.github.io/terosHDLdoc/

--- a/hdl/projects/cosmo_hp/cosmo_hp_top.vhd
+++ b/hdl/projects/cosmo_hp/cosmo_hp_top.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 -- Cosmo Ignition FPGA top targeting an ice40 HX8k
 

--- a/hdl/projects/cosmo_hp/hp_subsystem/cem_hp_io_pkg.vhd
+++ b/hdl/projects/cosmo_hp/hp_subsystem/cem_hp_io_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_hp/hp_subsystem/cem_sync.vhd
+++ b/hdl/projects/cosmo_hp/hp_subsystem/cem_sync.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 -- Take an array of records from each of the 10 CEMs and generate
 -- input synchronizers for each of them, and give back an output

--- a/hdl/projects/cosmo_hp/hp_subsystem/hp_debug_regs.rdl
+++ b/hdl/projects/cosmo_hp/hp_subsystem/hp_debug_regs.rdl
@@ -1,4 +1,3 @@
-// Copyright 2025 Oxide Computer Company
 // This is SystemRDL description of the sw-accessible common board-info registers
 
 addrmap hp_debug_regs {

--- a/hdl/projects/cosmo_hp/hp_subsystem/hp_debug_regs.vhd
+++ b/hdl/projects/cosmo_hp/hp_subsystem/hp_debug_regs.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_hp/hp_subsystem/hp_logic.vhd
+++ b/hdl/projects/cosmo_hp/hp_subsystem/hp_logic.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_hp/hp_subsystem/hp_subystem_top.vhd
+++ b/hdl/projects/cosmo_hp/hp_subsystem/hp_subystem_top.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 -- Cosmo Front Hot-plug FPGA targeting an ice40 HX8k
 

--- a/hdl/projects/cosmo_hp/hp_subsystem/sims/cem_hp_sim_tb.vhd
+++ b/hdl/projects/cosmo_hp/hp_subsystem/sims/cem_hp_sim_tb.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_hp/hp_subsystem/sims/cem_hp_sim_th.vhd
+++ b/hdl/projects/cosmo_hp/hp_subsystem/sims/cem_hp_sim_th.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_hp/hp_subsystem/sims/cem_model.vhd
+++ b/hdl/projects/cosmo_hp/hp_subsystem/sims/cem_model.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_hp/hp_subsystem/sims/cem_sim_pkg.vhd
+++ b/hdl/projects/cosmo_hp/hp_subsystem/sims/cem_sim_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_ignition/cosmo_ignition_a_top.vhd
+++ b/hdl/projects/cosmo_ignition/cosmo_ignition_a_top.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 -- Cosmo Front Hot-plug FPGA targeting an ice40 HX8k
 

--- a/hdl/projects/cosmo_ignition/cosmo_ignition_top.vhd
+++ b/hdl/projects/cosmo_ignition/cosmo_ignition_top.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 -- Cosmo Front Hot-plug FPGA targeting an ice40 HX8k
 

--- a/hdl/projects/cosmo_seq/black_box_entities/cosmo_pll.vhd
+++ b/hdl/projects/cosmo_seq/black_box_entities/cosmo_pll.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 -- A no synth, no sim, black entity to make analysis happy
 

--- a/hdl/projects/cosmo_seq/board_support/board_support_top.vhd
+++ b/hdl/projects/cosmo_seq/board_support/board_support_top.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/board_support/reset_sync.vhd
+++ b/hdl/projects/cosmo_seq/board_support/reset_sync.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 
 library ieee;

--- a/hdl/projects/cosmo_seq/chip2chip_if/chip2chip_top.vhd
+++ b/hdl/projects/cosmo_seq/chip2chip_if/chip2chip_top.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/cosmo_seq_top.vhd
+++ b/hdl/projects/cosmo_seq/cosmo_seq_top.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 -- Cosmo Sequencer FPGA targeting the Spartan-7
 

--- a/hdl/projects/cosmo_seq/debug_module/debug_header.vhd
+++ b/hdl/projects/cosmo_seq/debug_module/debug_header.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 
 library ieee;

--- a/hdl/projects/cosmo_seq/debug_module/debug_module_top.vhd
+++ b/hdl/projects/cosmo_seq/debug_module/debug_module_top.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 
 library ieee;

--- a/hdl/projects/cosmo_seq/debug_module/debug_regs.rdl
+++ b/hdl/projects/cosmo_seq/debug_module/debug_regs.rdl
@@ -1,4 +1,3 @@
-// Copyright 2025 Oxide Computer Company
 // This is SystemRDL description of the sw-accessible registers in the Cosmo
 // Debug Control FPGA block.
 

--- a/hdl/projects/cosmo_seq/sequencer/a1_a0_seq.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/a1_a0_seq.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sequencer/nic_seq.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/nic_seq.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sequencer/seq_sync.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/seq_sync.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sequencer/sequencer_io_pkg.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sequencer_io_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sequencer/sequencer_regs.rdl
+++ b/hdl/projects/cosmo_seq/sequencer/sequencer_regs.rdl
@@ -1,4 +1,3 @@
-// Copyright 2025 Oxide Computer Company
 // This is SystemRDL description of the sw-accessible registers in the Cosmo
 // Sequencer FPGA block.
 

--- a/hdl/projects/cosmo_seq/sequencer/sequencer_regs.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sequencer_regs.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sequencer/sims/cascade_rail_model.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sims/cascade_rail_model.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sequencer/sims/nic_model.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sims/nic_model.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sequencer/sims/nic_model_msg_pkg.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sims/nic_model_msg_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sequencer/sims/rail_model.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sims/rail_model.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sequencer/sims/rail_model_msg_pkg.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sims/rail_model_msg_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sequencer/sims/sp5_seq_sim_tb.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sims/sp5_seq_sim_tb.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sequencer/sims/sp5_seq_sim_th.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sims/sp5_seq_sim_th.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sequencer/sims/sp5_sim.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sims/sp5_sim.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sequencer/sp5_sequencer.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sp5_sequencer.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sp5_espi_flash_subsystem/sp5_espi_flash_subsystem.vhd
+++ b/hdl/projects/cosmo_seq/sp5_espi_flash_subsystem/sp5_espi_flash_subsystem.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sp5_hotplug_subsystem/perst_oneshot.vhd
+++ b/hdl/projects/cosmo_seq/sp5_hotplug_subsystem/perst_oneshot.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sp5_hotplug_subsystem/sp5_hotplug_subsystem.vhd
+++ b/hdl/projects/cosmo_seq/sp5_hotplug_subsystem/sp5_hotplug_subsystem.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 -- Cosmo Sequencer FPGA targeting the Spartan-7
 

--- a/hdl/projects/cosmo_seq/sp5_uart_subsystem/sp5_uart_subsystem.vhd
+++ b/hdl/projects/cosmo_seq/sp5_uart_subsystem/sp5_uart_subsystem.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sp5_uart_subsystem/sp5_uart_subsystem_pkg.vhd
+++ b/hdl/projects/cosmo_seq/sp5_uart_subsystem/sp5_uart_subsystem_pkg.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sp_i2c_subsystem/sp_i2c_regs.rdl
+++ b/hdl/projects/cosmo_seq/sp_i2c_subsystem/sp_i2c_regs.rdl
@@ -1,4 +1,3 @@
-// Copyright 2025 Oxide Computer Company
 // This is SystemRDL description of the sw-accessible registers in the Cosmo
 // Sequencer FPGA block.
 

--- a/hdl/projects/cosmo_seq/sp_i2c_subsystem/sp_i2c_subsystem.vhd
+++ b/hdl/projects/cosmo_seq/sp_i2c_subsystem/sp_i2c_subsystem.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 -- Cosmo Sequencer FPGA targeting the Spartan-7
 

--- a/hdl/projects/cosmo_seq/sp_i2c_subsystem/sp_i2c_subsystem_regs.vhd
+++ b/hdl/projects/cosmo_seq/sp_i2c_subsystem/sp_i2c_subsystem_regs.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/ecp5_evn/Board.bsv
+++ b/hdl/projects/ecp5_evn/Board.bsv
@@ -1,4 +1,3 @@
-// Copyright 2021 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/projects/gimlet/sequencer/Fans.bsv
+++ b/hdl/projects/gimlet/sequencer/Fans.bsv
@@ -1,4 +1,3 @@
-// Copyright 2021 Oxide Computer Company
 
 package Fans;
 

--- a/hdl/projects/gimlet/sequencer/GimletSeqTop.bsv
+++ b/hdl/projects/gimlet/sequencer/GimletSeqTop.bsv
@@ -1,4 +1,3 @@
-// Copyright 2021 Oxide Computer Company
 
 package GimletSeqTop;
 

--- a/hdl/projects/gimlet/sequencer/gimlet_seq_fpga_regs.rdl
+++ b/hdl/projects/gimlet/sequencer/gimlet_seq_fpga_regs.rdl
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 // This is SystemRDL description of the sw-accesible registers in the Gimlet
 // Sequencer FPGA.
 

--- a/hdl/projects/grapefruit/base_regs/gfruit_regs.rdl
+++ b/hdl/projects/grapefruit/base_regs/gfruit_regs.rdl
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// Copyright 2024 Oxide Computer Company
 //
 // This is SystemRDL description of the sw-accesible registers in the
 // grapefruit dev board FPGA.

--- a/hdl/projects/grapefruit/base_regs/registers.vhd
+++ b/hdl/projects/grapefruit/base_regs/registers.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 
 library ieee;

--- a/hdl/projects/grapefruit/black_box_entities/gfruit_pll.vhd
+++ b/hdl/projects/grapefruit/black_box_entities/gfruit_pll.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2025 Oxide Computer Company
 
 -- A no synth, no sim, black entity to make analysis happy
 

--- a/hdl/projects/grapefruit/grapefruit_top.vhd
+++ b/hdl/projects/grapefruit/grapefruit_top.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 
 library ieee;

--- a/hdl/projects/grapefruit/integration/drivers/espi_dbg.py
+++ b/hdl/projects/grapefruit/integration/drivers/espi_dbg.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2024 Oxide Computer Company
 
 from crc import Calculator, Crc8
 

--- a/hdl/projects/grapefruit/integration/drivers/spi_nor.py
+++ b/hdl/projects/grapefruit/integration/drivers/spi_nor.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2024 Oxide Computer Company
 import time
 
 op_page_program = 0x02

--- a/hdl/projects/grapefruit/sgpio/gfruit_sgpio.rdl
+++ b/hdl/projects/grapefruit/sgpio/gfruit_sgpio.rdl
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// Copyright 2024 Oxide Computer Company
 //
 // This is SystemRDL description of the sw-accesible registers in the
 // grapefruit dev board FPGA.

--- a/hdl/projects/grapefruit/sgpio/gfruit_sgpio.vhd
+++ b/hdl/projects/grapefruit/sgpio/gfruit_sgpio.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 -- Grapefruit is meant to serve as a BMC replacement in AMD's Ruby
 -- reference platform for cosmo dev.  As such, there are some functions

--- a/hdl/projects/grapefruit/sgpio/gfruit_sgpio_regs.rdl
+++ b/hdl/projects/grapefruit/sgpio/gfruit_sgpio_regs.rdl
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// Copyright 2024 Oxide Computer Company
 //
 // This is SystemRDL description of the sw-accesible registers in the
 // grapefruit dev board FPGA.

--- a/hdl/projects/grapefruit/sgpio/sgpio_regs.vhd
+++ b/hdl/projects/grapefruit/sgpio/sgpio_regs.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2024 Oxide Computer Company
 
 
 library ieee;

--- a/hdl/projects/icestick/Board.bsv
+++ b/hdl/projects/icestick/Board.bsv
@@ -1,4 +1,3 @@
-// Copyright 2021 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/projects/icestick/Examples.bsv
+++ b/hdl/projects/icestick/Examples.bsv
@@ -1,4 +1,3 @@
-// Copyright 2021 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/projects/ignitionlet/Examples.bsv
+++ b/hdl/projects/ignitionlet/Examples.bsv
@@ -1,4 +1,3 @@
-// Copyright 2021 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/projects/minibar/MinibarController.bsv
+++ b/hdl/projects/minibar/MinibarController.bsv
@@ -1,4 +1,3 @@
-// Copyright 2025 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/projects/minibar/MinibarMiscRegs.bsv
+++ b/hdl/projects/minibar/MinibarMiscRegs.bsv
@@ -1,4 +1,3 @@
-// Copyright 2025 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/projects/minibar/MinibarPcie.bsv
+++ b/hdl/projects/minibar/MinibarPcie.bsv
@@ -1,4 +1,3 @@
-// Copyright 2025 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/projects/minibar/MinibarSpiServer.bsv
+++ b/hdl/projects/minibar/MinibarSpiServer.bsv
@@ -1,4 +1,3 @@
-// Copyright 2025 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/projects/minibar/MinibarTop.bsv
+++ b/hdl/projects/minibar/MinibarTop.bsv
@@ -1,4 +1,3 @@
-// Copyright 2025 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/projects/minibar/minibar_controller.rdl
+++ b/hdl/projects/minibar/minibar_controller.rdl
@@ -1,4 +1,3 @@
-// Copyright 2025 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/projects/observer_ignition/observer_ignition_top.vhd
+++ b/hdl/projects/observer_ignition/observer_ignition_top.vhd
@@ -2,7 +2,6 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --
--- Copyright 2026 Oxide Computer Company
 
 -- Observer power shelf controller FPGA targeting an ice40 HX8k
 

--- a/hdl/projects/sidecar/mainboard/PCIeEndpointController.bsv
+++ b/hdl/projects/sidecar/mainboard/PCIeEndpointController.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/projects/sidecar/mainboard/SidecarMainboardMiscSequencers.bsv
+++ b/hdl/projects/sidecar/mainboard/SidecarMainboardMiscSequencers.bsv
@@ -1,4 +1,3 @@
-// Copyright 2023 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/projects/sidecar/mainboard/Tofino2Sequencer.bsv
+++ b/hdl/projects/sidecar/mainboard/Tofino2Sequencer.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/projects/sidecar/mainboard/sidecar_mainboard_controller.rdl
+++ b/hdl/projects/sidecar/mainboard/sidecar_mainboard_controller.rdl
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/projects/sidecar/mainboard/test/Tofino2SequencerTests.bsv
+++ b/hdl/projects/sidecar/mainboard/test/Tofino2SequencerTests.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/projects/sidecar/qsfp_x32/QSFPModule/QsfpModuleController.bsv
+++ b/hdl/projects/sidecar/qsfp_x32/QSFPModule/QsfpModuleController.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/projects/sidecar/qsfp_x32/QSFPModule/QsfpModulesTop.bsv
+++ b/hdl/projects/sidecar/qsfp_x32/QSFPModule/QsfpModulesTop.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/projects/sidecar/qsfp_x32/QSFPModule/qsfp_modules_top.rdl
+++ b/hdl/projects/sidecar/qsfp_x32/QSFPModule/qsfp_modules_top.rdl
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/projects/sidecar/qsfp_x32/QSFPModule/test/QsfpModuleControllerTests.bsv
+++ b/hdl/projects/sidecar/qsfp_x32/QSFPModule/test/QsfpModuleControllerTests.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/projects/sidecar/qsfp_x32/QsfpX32Controller.bsv
+++ b/hdl/projects/sidecar/qsfp_x32/QsfpX32Controller.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/projects/sidecar/qsfp_x32/QsfpX32ControllerSpiServer.bsv
+++ b/hdl/projects/sidecar/qsfp_x32/QsfpX32ControllerSpiServer.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/projects/sidecar/qsfp_x32/QsfpX32ControllerTop.bsv
+++ b/hdl/projects/sidecar/qsfp_x32/QsfpX32ControllerTop.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/projects/sidecar/qsfp_x32/QsfpX32ControllerTopRegs.bsv
+++ b/hdl/projects/sidecar/qsfp_x32/QsfpX32ControllerTopRegs.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/projects/sidecar/qsfp_x32/VSC8562/VSC8562.bsv
+++ b/hdl/projects/sidecar/qsfp_x32/VSC8562/VSC8562.bsv
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/projects/sidecar/qsfp_x32/VSC8562/test/VSC8562Tests.bsv
+++ b/hdl/projects/sidecar/qsfp_x32/VSC8562/test/VSC8562Tests.bsv
@@ -1,4 +1,3 @@
-// Copyright 2023 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/projects/sidecar/qsfp_x32/VSC8562/vsc8562.rdl
+++ b/hdl/projects/sidecar/qsfp_x32/VSC8562/vsc8562.rdl
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/projects/sidecar/qsfp_x32/qsfp_x32_controller.rdl
+++ b/hdl/projects/sidecar/qsfp_x32/qsfp_x32_controller.rdl
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hdl/projects/ulx3s/Board.bsv
+++ b/hdl/projects/ulx3s/Board.bsv
@@ -1,4 +1,3 @@
-// Copyright 2021 Oxide Computer Company
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/toolchains/vivado_toolchain.bzl
+++ b/toolchains/vivado_toolchain.bzl
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2024 Oxide Computer Company
 
 _VIVADO = select({
     "DEFAULT": "vivado",

--- a/toolchains/vsg_toolchain.bzl
+++ b/toolchains/vsg_toolchain.bzl
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2024 Oxide Computer Company
 
 _VSG = select({
     "DEFAULT": "vsg",

--- a/tools/bsv-tests.bxl
+++ b/tools/bsv-tests.bxl
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2026 Oxide Computer Company
 
 # BXL script to discover and list all BSV Bluesim test targets
 # Usage: buck2 bxl //tools/bsv-tests.bxl:bsv_test_gen

--- a/tools/bsv.bzl
+++ b/tools/bsv.bzl
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2026 Oxide Computer Company
 
 # BSV (Bluespec SystemVerilog) build rules
 

--- a/tools/bsv_bluescan/bluescan_wrapper.py
+++ b/tools/bsv_bluescan/bluescan_wrapper.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 #
-# Copyright 2026 Oxide Computer Company
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/tools/bsv_common.bzl
+++ b/tools/bsv_common.bzl
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2026 Oxide Computer Company
 
 # BSV (Bluespec SystemVerilog) build system providers and types
 # This file contains provider definitions for the BSV buck2 build system

--- a/tools/bz2compress/bz2compress.py
+++ b/tools/bz2compress/bz2compress.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2024 Oxide Computer Company
 
 import argparse
 import bz2

--- a/tools/hdl.bzl
+++ b/tools/hdl.bzl
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2024 Oxide Computer Company
 
 load(
     "@prelude//python:toolchain.bzl",

--- a/tools/hdl_common.bzl
+++ b/tools/hdl_common.bzl
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2024 Oxide Computer Company
 
 # This stuff is factored here because it is used potentially in multiple bzl files
 # and we don't want deal with possible circular dependencies

--- a/tools/multitool/multitool_cli.py
+++ b/tools/multitool/multitool_cli.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2024 Oxide Computer Company
 
 import argparse
 import json

--- a/tools/rdl.bzl
+++ b/tools/rdl.bzl
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2024 Oxide Computer Company
 
 # RDL files can have 0 or more dependencies on other RDL files
 # This block provides the following providers:

--- a/tools/site_cobble/bluescan.py
+++ b/tools/site_cobble/bluescan.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 #
-# Copyright 2021 Oxide Computer Company
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/tools/site_cobble/bluespec.py
+++ b/tools/site_cobble/bluespec.py
@@ -1,4 +1,3 @@
-# Copyright 2021 Oxide Computer Company
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/tools/site_cobble/bsv_fpga_version.py
+++ b/tools/site_cobble/bsv_fpga_version.py
@@ -1,4 +1,3 @@
-# Copyright 2021 Oxide Computer Company
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/tools/site_cobble/nextpnr.py
+++ b/tools/site_cobble/nextpnr.py
@@ -1,4 +1,3 @@
-# Copyright 2021 Oxide Computer Company
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/tools/site_cobble/rdl.py
+++ b/tools/site_cobble/rdl.py
@@ -1,4 +1,3 @@
-# Copyright 2021 Oxide Computer Company
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/tools/site_cobble/rdl_pkg/demo.rdl
+++ b/tools/site_cobble/rdl_pkg/demo.rdl
@@ -1,4 +1,3 @@
-// Copyright 2022 Oxide Computer Company
 // This is an example SystemRDL description of the sw-accesible registers
 
 regfile a_reg_block {

--- a/tools/site_cobble/rdl_pkg/exporter.py
+++ b/tools/site_cobble/rdl_pkg/exporter.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2024 Oxide Computer Company
 
 from pathlib import Path
 from os import PathLike

--- a/tools/site_cobble/rdl_pkg/json_dump.py
+++ b/tools/site_cobble/rdl_pkg/json_dump.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2024 Oxide Computer Company
 
 # Note: This code is a lightly modified version of the systemRDL example JSON dumper
 # https://systemrdl-compiler.readthedocs.io/en/latest/examples/json_exporter.html

--- a/tools/site_cobble/rdl_pkg/listeners.py
+++ b/tools/site_cobble/rdl_pkg/listeners.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2024 Oxide Computer Company
 
 from systemrdl import RDLListener, AddrmapNode, RegfileNode, RegNode, FieldNode, MemNode
 

--- a/tools/site_cobble/rdl_pkg/models.py
+++ b/tools/site_cobble/rdl_pkg/models.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2024 Oxide Computer Company
 
 import copy
 from typing import List, Tuple

--- a/tools/site_cobble/rdl_pkg/rdl_cli.py
+++ b/tools/site_cobble/rdl_pkg/rdl_cli.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2024 Oxide Computer Company
 
 import sys
 import argparse

--- a/tools/site_cobble/rdl_pkg/utils.py
+++ b/tools/site_cobble/rdl_pkg/utils.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2024 Oxide Computer Company
 
 import inflection
 

--- a/tools/site_cobble/shell.py
+++ b/tools/site_cobble/shell.py
@@ -1,4 +1,3 @@
-# Copyright 2021 Oxide Computer Company
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/tools/site_cobble/yosys.py
+++ b/tools/site_cobble/yosys.py
@@ -1,4 +1,3 @@
-# Copyright 2021 Oxide Computer Company
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/tools/speeker/espi_mux.py
+++ b/tools/speeker/espi_mux.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2024 Oxide Computer Company
 
 # Control ruby power from gfruit over sgpio
 

--- a/tools/speeker/example.py
+++ b/tools/speeker/example.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2024 Oxide Computer Company
 
 # Super simple read/write example
 

--- a/tools/speeker/gfruit_mux.py
+++ b/tools/speeker/gfruit_mux.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2024 Oxide Computer Company
 
 # Super simple read/write example
 

--- a/tools/speeker/ruby_power.py
+++ b/tools/speeker/ruby_power.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2024 Oxide Computer Company
 
 # Control ruby power from gfruit over sgpio
 

--- a/tools/speeker/udp_if.py
+++ b/tools/speeker/udp_if.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2024 Oxide Computer Company
 
 # This implements a simple UDP peek/poke interface that conforms to the
 # protocol specified here: 

--- a/tools/vhdl-ls.bxl
+++ b/tools/vhdl-ls.bxl
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2024 Oxide Computer Company
 
 # This function queries the build graph and finds rules starting
 # with vhdl ie (vhdl_unit) getting the sources and libraries

--- a/tools/vivado.bzl
+++ b/tools/vivado.bzl
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2025 Oxide Computer Company
 
 load(
     "@prelude//python:toolchain.bzl",

--- a/tools/vivado_gen/vivado_gen.py
+++ b/tools/vivado_gen/vivado_gen.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2024 Oxide Computer Company
 
 import argparse
 import json

--- a/tools/vsg-format.bxl
+++ b/tools/vsg-format.bxl
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2024 Oxide Computer Company
 
 # This function queries the build graph and finds rules starting
 # with vhdl ie (vhdl_unit) getting the sources for any of our

--- a/tools/vunit-sims.bxl
+++ b/tools/vunit-sims.bxl
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2024 Oxide Computer Company
 
 # This function queries the build graph and targets that are
 # simulation targets and runs them

--- a/tools/vunit_gen/vunit_com_codec_gen.py
+++ b/tools/vunit_gen/vunit_com_codec_gen.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2024 Oxide Computer Company
 
 import argparse
 from pathlib import Path

--- a/tools/vunit_gen/vunit_gen_cli.py
+++ b/tools/vunit_gen/vunit_gen_cli.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2024 Oxide Computer Company
 
 import argparse
 from pathlib import Path

--- a/tools/yosys_gen/yosys_gen_cli.py
+++ b/tools/yosys_gen/yosys_gen_cli.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright 2024 Oxide Computer Company
 
 import argparse
 import json


### PR DESCRIPTION
Per our open source policy, the year/assignment is optional and we get a lot of text churn fixing these things along and along so we're going to bulk remove them in one go.