### PR TITLE
fpga-releaser: fix --skip-gh and inverted needs_gh check

### DIFF
--- a/tools/fpga_releaser/cli.py
+++ b/tools/fpga_releaser/cli.py
@@ -48,8 +48,14 @@ def main():
     if args.zip:
         project_info.local = True
 
-    # Only require a GitHub token when we actually need to talk to GitHub
-    needs_gh = not (args.skip_gh or args.zip is None)
+    if args.skip_gh and args.zip is None:
+        print("--skip-gh requires --zip or --local to supply a build archive")
+        sys.exit(1)
+
+    # Only require a GitHub token when we actually need to talk to GitHub.
+    # With --skip-gh we have a local archive (enforced above) and won't push a
+    # release, so the API client stays unused.
+    needs_gh = not args.skip_gh
     api = None
     if needs_gh:
         if args.token is not None:


### PR DESCRIPTION
#500 broke the normal release flow due to a logic bug that makes a normal run with no --skip-gh and no --zip fail:

The change in #500 is equivalent to `not args.skip_gh and args.zip is not None`, so for the default invocation (no --skip-gh, no --zip) needs_gh evaluated to False, meaning the `api` stayed None, and `get_latest_artifact_info` blew up dereferencing that None.

In the original intention of this code, skip-gh really meant skip-gh-*release*.  Even when fixing the bug above, the system still accessed the github api when skip-gh was set so this PR actually fixes that problem also so skip-gh really does skip github now, releases and APIs.