### PR TITLE
Fix up-sequence when DDR hotswap is misbehaving

### DIFF
--- a/hdl/projects/cosmo_seq/sequencer/a1_a0_seq.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/a1_a0_seq.vhd
@@ -237,10 +237,9 @@ begin
                 if seq_r.cnts = ONE_SECOND then
                     v.cnts := (others => '0');
                     v.state := RSM_RST_DEASSERT;
-                    -- we enable fault monitoring here on the group A rails and DDR, until we de-sequence
+                    -- we enable fault monitoring here on the group A rails until we de-sequence
                     -- these are expected to remain up.
                     v.group_a_expected := '1';  
-                    v.ddr_bulk_expected := '1';
                 end if;
             --  Release RSM_RST_L
             when RSM_RST_DEASSERT =>
@@ -269,6 +268,9 @@ begin
                    slp_s5_l_final = '1' and
                    is_power_good(ddr_bulk) then
                     v.state := GROUP_B_EN;
+                    v.ddr_bulk_expected := '1';
+                    -- DDR bulk is now expected to remain up, so we can enable fault monitoring on it. 
+                    --If it's not, we'll hang here until hubris aborts.
                 end if;
             -- Enable Group B supplies
             -- TODO: We need a pause/sync with hubris here after they have checked

--- a/hdl/projects/cosmo_seq/sequencer/sims/sp5_seq_sim_tb.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sims/sp5_seq_sim_tb.vhd
@@ -15,7 +15,7 @@ library vunit_lib;
 
 use work.sp5_seq_sim_pkg.all;
 use work.sequencer_regs_pkg.all;
-use work.rail_model_msg_pkg.all;
+use work.rail_model_msg_pkg;
 use work.nic_model_msg_pkg.all;
 
 
@@ -37,8 +37,10 @@ begin
         alias sp5_t6_perst_l is << signal th.sp5_t6_perst_l : std_logic >>;
         variable read_data       : std_logic_vector(31 downto 0);
         variable seq_state       : seq_api_status_a0_sm;
-        constant grpa_v3p3_actor : actor_t := find("grpa_v3p3_sp5_a1");
-        constant nic_actor       : actor_t := find("nic_model");
+        constant grpa_v3p3_actor  : actor_t := find("grpa_v3p3_sp5_a1");
+        constant nic_actor        : actor_t := find("nic_model");
+        constant ddr_abcdef_actor : actor_t := find("rail_ddr_abcdef_hsc");
+        constant ddr_ghijkl_actor : actor_t := find("rail_ddr_ghijkl_hsc");
         variable nic_state : nic_api_status_nic_sm;
     begin
         -- Always the first thing in the process, set up things for the VUnit test runner
@@ -186,6 +188,35 @@ begin
                 read_bus(net, bus_handle, To_StdLogicVector(NIC_API_STATUS_OFFSET, bus_handle.p_address_length), read_data);
                 nic_state := encode(read_data(7 downto 0));
                 check_equal(nic_state = DONE, true, "Expected nic sequencer to return to DONE state after SP5 recovery");
+            elsif run("ddr_bulk_no_pg_abcdef_hsc") then
+                -- DDR bulk PG absent during sequencing stalls the SM at SLP_CHECKPOINT
+                -- (ddr_bulk_expected is only armed when SLP_CHECKPOINT advances, so no MAPO fires).
+                rail_model_msg_pkg.disable_power_good(net, ddr_abcdef_actor);
+                write_bus(net, bus_handle, To_StdLogicVector(POWER_CTRL_OFFSET, bus_handle.p_address_length), POWER_CTRL_A0_EN_MASK);
+                poll_for_seq_state(net, SP5_EARLY_CHECKPOINT);
+                read_bus(net, bus_handle, To_StdLogicVector(IFR_OFFSET, bus_handle.p_address_length), read_data);
+                check_equal((read_data and IFR_A0MAPO_MASK) = x"00000000", true,
+                    "Expected no A0MAPO: absent DDR bulk PG should stall at SLP_CHECKPOINT, not fault");
+                read_bus(net, bus_handle, To_StdLogicVector(SEQ_API_STATUS_OFFSET, bus_handle.p_address_length), read_data);
+                seq_state := encode(read_data(7 downto 0));
+                check_equal(seq_state = SP5_EARLY_CHECKPOINT, true,
+                    "Expected sequencer stalled at SP5_EARLY_CHECKPOINT");
+                -- Restore PG and verify the sequence completes normally
+                rail_model_msg_pkg.enable_power_good(net, ddr_abcdef_actor);
+                poll_for_seq_state(net, DONE);
+            elsif run("ddr_bulk_no_pg_ghijkl_hsc") then
+                rail_model_msg_pkg.disable_power_good(net, ddr_ghijkl_actor);
+                write_bus(net, bus_handle, To_StdLogicVector(POWER_CTRL_OFFSET, bus_handle.p_address_length), POWER_CTRL_A0_EN_MASK);
+                poll_for_seq_state(net, SP5_EARLY_CHECKPOINT);
+                read_bus(net, bus_handle, To_StdLogicVector(IFR_OFFSET, bus_handle.p_address_length), read_data);
+                check_equal((read_data and IFR_A0MAPO_MASK) = x"00000000", true,
+                    "Expected no A0MAPO: absent DDR bulk PG should stall at SLP_CHECKPOINT, not fault");
+                read_bus(net, bus_handle, To_StdLogicVector(SEQ_API_STATUS_OFFSET, bus_handle.p_address_length), read_data);
+                seq_state := encode(read_data(7 downto 0));
+                check_equal(seq_state = SP5_EARLY_CHECKPOINT, true,
+                    "Expected sequencer stalled at SP5_EARLY_CHECKPOINT");
+                rail_model_msg_pkg.enable_power_good(net, ddr_ghijkl_actor);
+                poll_for_seq_state(net, DONE);
             elsif run("nic_force_mapo") then
                 info("Starting normal A0 power sequence");
                 write_bus(net, bus_handle, To_StdLogicVector(POWER_CTRL_OFFSET, bus_handle.p_address_length), POWER_CTRL_A0_EN_MASK);


### PR DESCRIPTION
Fixes #504 

We add a test case for this, and move the expected check to the point in the statemachine that hubris expects. With no other hubris changes, the board failing in #504 provides this (correct!) diagnosis with this FPGA patch:

```
...
  83  455        4        1 Startup { early_power_rdbks: EarlyPowerRdbksView { fan_fail: false, fan_hsc_east_pg: true, fan_hsc_central_pg: true, fan_hsc_west_pg: true, fan_hsc_east_disable: false, fan_hsc_central_disable: false, fan_hsc_west_disable: false } }
  84  458        4        1 SetState { prev: None, next: A2, why: InitialPowerOn, now: 0x32f9 }
  85  516        4        1 SetState { prev: Some(A2), next: A0, why: Other, now: 0xa994 }
  86  490        4       80 RegStateValues { seq_api_status: SeqApiStatusView { a0_sm: Ok(EnableGrpA) }, seq_raw_status: SeqRawStatusView { hw_sm: Ok(GroupAPgAndWait) }, nic_api_status: NicApiStatusView { nic_sm: Ok(Idle) }, nic_raw_status: NicRawStatusView { hw_sm: Ok(Idle) } }
  87  490        4       17 RegStateValues { seq_api_status: SeqApiStatusView { a0_sm: Ok(EnableGrpA) }, seq_raw_status: SeqRawStatusView { hw_sm: Ok(RtcClkWait) }, nic_api_status: NicApiStatusView { nic_sm: Ok(Idle) }, nic_raw_status: NicRawStatusView { hw_sm: Ok(Idle) } }
  88  490        4      104 RegStateValues { seq_api_status: SeqApiStatusView { a0_sm: Ok(Sp5EarlyCheckpoint) }, seq_raw_status: SeqRawStatusView { hw_sm: Ok(SlpCheckpoint) }, nic_api_status: NicApiStatusView { nic_sm: Ok(Idle) }, nic_raw_status: NicRawStatusView { hw_sm: Ok(Idle) } }
  89  504        4        1 RegPgValues { rail_pgs: RailPgsView { abcdef_hsc: false, ghijkl_hsc: true, v1p5_rtc: true, v3p3_sp5: true, v1p8_sp5: true, v1p1_sp5: false, vddio_sp5: false, vddcr_cpu1: false, vddcr_cpu0: false, vddcr_soc: false, nic_hsc_12v: false, nic_hsc_5v: false, v1p5_nic_a0hp: false, v1p2_nic_pcie_a0hp: false, v1p2_nic_enet_a0hp: false, v3p3_nic_a0hp: false, v1p1_nic_a0hp: false, v1p4_nic_a0hp: false, v0p96_nic_vdd_a0hp: false }, rail_pgs_max_hold: RailPgsMaxHoldView { abcdef_hsc: false, ghijkl_hsc: false, v1p5_rtc: false, v3p3_sp5: false, v1p8_sp5: false, v1p1_sp5: false, vddio_sp5: false, vddcr_cpu1: false, vddcr_cpu0: false, vddcr_soc: false, nic_hsc_12v: false, nic_hsc_5v: false, v1p5_nic_a0hp: false, v1p2_nic_pcie_a0hp: false, v1p2_nic_enet_a0hp: false, v3p3_nic_a0hp: false, v1p1_nic_a0hp: false, v1p4_nic_a0hp: false, v0p96_nic_vdd_a0hp: false } }
humility: ring buffer drv_cosmo_seq_server::diagnose::RAW in cosmo_seq:
 NDX LINE      GEN    COUNT PAYLOAD
   0  267        1        1 Registers { now: 0xb22c, reason: FailedToSequence, values: RegisterDump { seq_api_status: SeqApiStatusView { a0_sm: Ok(Sp5EarlyCheckpoint) }, seq_raw_status: SeqRawStatusView { hw_sm: Ok(SlpCheckpoint) }, early_power_rdbks: EarlyPowerRdbksView { fan_fail: false, fan_hsc_east_pg: true, fan_hsc_central_pg: true, fan_hsc_west_pg: true, fan_hsc_east_disable: false, fan_hsc_central_disable: false, fan_hsc_west_disable: false }, ifr: IfrView { fanfault: false, thermtrip: false, smerr_assert: false, a0mapo: false, nicmapo: false, amd_pwrok_fedge: false, amd_rstn_fedge: false, fan_central_hsc_alert: true, fan_east_hsc_alert: true, fan_west_hsc_alert: true, ibc_alert: false, m2_hsc_alert: false, nic_hsc_alert: false, v12_ddr5_abcdef_hsc_alert: false, v12_ddr5_ghijkl_hsc_alert: false, v12_mcio_a0hp_hsc_alert: false, main_hsc_alert: false, vr_v1p8_sys_to_fpga1_alert: false, vr_v3p3_sys_to_fpga1_alert: false, vr_v5p0_sys_to_fpga1_alert: false, v0p96_nic_to_fpga1_alert: false, pwr_cont1_to_fpga1_alert: false, pwr_cont2_to_fpga1_alert: false, pwr_cont3_to_fpga1_alert: false }, debug_enables: DebugEnablesView { ignore_sp5: false, nic_override: false, force_nic_reset: false, force_mfg_mode: false }, power_ctrl: PowerCtrlView { a0_en: true }, rail_enables: RailEnablesView { abcdef_hsc: true, ghijkl_hsc: true, v1p5_rtc: true, v3p3_sp5: true, v1p8_sp5: true, v1p1_sp5: false, vddio_sp5: false, vddcr_cpu1: false, vddcr_cpu0: false, vddcr_soc: false, nic_hsc_12v: false, nic_hsc_5v: false, v1p5_nic_a0hp: false, v1p2_nic_pcie_a0hp: false, v1p2_nic_enet_a0hp: false, v3p3_nic_a0hp: false, v1p1_nic_a0hp: false, v1p4_nic_a0hp: false, v0p96_nic_vdd_a0hp: false }, rail_pgs: RailPgsView { abcdef_hsc: false, ghijkl_hsc: true, v1p5_rtc: true, v3p3_sp5: true, v1p8_sp5: true, v1p1_sp5: false, vddio_sp5: false, vddcr_cpu1: false, vddcr_cpu0: false, vddcr_soc: false, nic_hsc_12v: false, nic_hsc_5v: false, v1p5_nic_a0hp: false, v1p2_nic_pcie_a0hp: false, v1p2_nic_enet_a0hp: false, v3p3_nic_a0hp: false, v1p1_nic_a0hp: false, v1p4_nic_a0hp: false, v0p96_nic_vdd_a0hp: false }, rail_pgs_max_hold: RailPgsMaxHoldView { abcdef_hsc: false, ghijkl_hsc: false, v1p5_rtc: false, v3p3_sp5: false, v1p8_sp5: false, v1p1_sp5: false, vddio_sp5: false, vddcr_cpu1: false, vddcr_cpu0: false, vddcr_soc: false, nic_hsc_12v: false, nic_hsc_5v: false, v1p5_nic_a0hp: false, v1p2_nic_pcie_a0hp: false, v1p2_nic_enet_a0hp: false, v3p3_nic_a0hp: false, v1p1_nic_a0hp: false, v1p4_nic_a0hp: false, v0p96_nic_vdd_a0hp: false }, sp5_readbacks: Sp5ReadbacksView { smerr_l: true, thermtrip_l: true, reset_l: false, pwr_ok: false, slp_s3_l: true, slp_s5_l: true, rsmrst_l: true, pwr_btn_l: true, pwr_good: false, pwrgd_out: false }, status: StatusView { fanpwrok: false, a0pwrok: false, nicpwrok: false, int_pend: false } } }
humility: ring buffer drv_cosmo_seq_server::diagnose::__RINGBUF in cosmo_seq:
   TOTAL VARIANT
       1 Diagnosis(WaitingForSlpCheckpoint(RailIssue(NotPowerGood)))
 NDX LINE      GEN    COUNT PAYLOAD
   0  565        1        1 Diagnosis { now: 0xb22c, reason: FailedToSequence, details: WaitingForSlpCheckpoint { why: RailIssue(NotPowerGood, DDR5_ABCDEF) } }
```