### PR TITLE
rdl: fix improperly configured field sw access

### DIFF
--- a/hdl/ip/vhd/espi/sys_regs/espi_regs.rdl
+++ b/hdl/ip/vhd/espi/sys_regs/espi_regs.rdl
@@ -21,8 +21,8 @@ addrmap espi_regs {
         desc = "";
 
         field {
-            default sw = woclr;
             desc = "Sticky bit for alert, set to 1 when alert is needed, cleared by writing 1";
+            woclr = true;
         } alert[0:0] =  0;
     } flags;
 
@@ -49,9 +49,9 @@ addrmap espi_regs {
     reg {
         name = "Status Register";
         desc = "";
+        default sw = r;
 
         field {
-            default sw = r;
             desc = "Set to one to 1 when hw is running the spi transaction, no new transactions
             may be issued until it is finished. Technically represents cs_n being low.";
         } busy[0:0] =  0;
@@ -61,14 +61,14 @@ addrmap espi_regs {
     reg {
         name = "Fifo Status Register";
         desc = "";
+        default sw = r;
+
         field {
-            default sw = r;
             desc = "Show used words in command FIFO (word = 32bits/4 bytes),
             1024 words so 4kB";
         } cmd_used_wds[31:16] =  0;
 
         field {
-            default sw = r;
             desc = "Show used FIFO words in response FIFO (word = 32bits/4 bytes),
             1024 words so 4kB";
         } resp_used_wds[15:0] =  0;
@@ -127,52 +127,38 @@ addrmap espi_regs {
     reg {
         name = "Post Code Monitor";
         desc = "Monitor and set flags based on certain incoming post codes. This is useful for testing and debug to trigger certain actions based on post codes seen from the host.";
+        default sw = r;
+        default hw = w;
 
         field {
-            default sw = r;
-            default hw = w;
             desc = "0x1de90001 - PHBLhello. Sticky: set when post code is seen, cleared by hardware on new boot.";
         } phbl_hello[7:7] = 0;
 
         field {
-            default sw = r;
-            default hw = w;
             desc = "0xee1000bb - BL_SUCCESS_BIOS_LOAD_COMPLETE. Sticky: set when post code is seen, cleared by hardware on new boot.";
         } bl_success_bios_load_complete[6:6] = 0;
 
         field {
-            default sw = r;
-            default hw = w;
             desc = "0xea00e0c9 - TpAbl4Apob. Sticky: set when post code is seen, cleared by hardware on new boot.";
         } tp_abl4_apob[5:5] = 0;
 
         field {
-            default sw = r;
-            default hw = w;
             desc = "0xea00e055 - TpProcCpuOptimizedBootStart. Sticky: set when post code is seen, cleared by hardware on new boot.";
         } tp_proc_cpu_optimized_boot_start[4:4] = 0;
 
         field {
-            default sw = r;
-            default hw = w;
             desc = "0xea00e340 - TpAblMemoryDdrTrainingStart - seen instead of TpAbl7ResumeInitialization when no eMCR. Sticky: set when post code is seen, cleared by hardware on new boot.";
         } tp_abl_memory_ddr_training_start[3:3] = 0;
 
         field {
-            default sw = r;
-            default hw = w;
             desc = "0xea00e101 - TpAbl7ResumeInitialization - eMCR starting (not seen if no eMCR). Sticky: set when post code is seen, cleared by hardware on new boot.";
         } tp_abl7_resume_initialization[2:2] = 0;
 
         field {
-            default sw = r;
-            default hw = w;
             desc = "0xea00e046 - TpProcMemAfterMemDataInit - memory data initialised. Sticky: set when post code is seen, cleared by hardware on new boot.";
         } tp_proc_mem_after_mem_data_init[1:1] = 0;
 
         field {
-            default sw = r;
-            default hw = w;
             desc = "0xee1000a0 - BL_SUCCESS_C_MAIN - Successfully entered Main. Sticky: set when post code is seen, cleared by hardware on new boot.";
         } bl_success_c_main[0:0] = 0;
 
@@ -189,8 +175,8 @@ addrmap espi_regs {
     reg {
         name = "IPCC_HOST_TO_SP_USEDWDS";
         desc = "Count of used words in the host-to-SP IPCC RX FIFO";
+        default sw = r;
         field {
-            default sw = r;
             desc = "";
         } count[31:0] = 0;
     } ipcc_host_to_sp_usedwds;
@@ -311,7 +297,7 @@ addrmap espi_regs {
         name = "OOB_FREE_SAW_FULL";
         desc = "Sticky bit: set to 1 if oob_free ever went low (RX FIFO nearly full) since last eSPI reset. Cleared only by eSPI reset.";
         field {
-            default sw = r;
+            sw = r;
             desc = "";
         } saw_full[0:0] = 0;
     } oob_free_saw_full;

--- a/hdl/ip/vhd/info/info_regs.rdl
+++ b/hdl/ip/vhd/info/info_regs.rdl
@@ -11,9 +11,9 @@ addrmap info_regs {
     reg {
         name = "Identity";
         desc = "";
+        default sw = r;
 
         field {
-            default sw = r;
             desc = "Read-only bits showing 0x1de";
         } data[32] =  0x1de;
     } identity;
@@ -21,9 +21,9 @@ addrmap info_regs {
     reg {
         name = "Hubris Compatibility Straps";
         desc = "";
+        default sw = r;
 
         field {
-            default sw = r;
             desc = "Read-only bits showing resistor strapping for hubris compatibility value";
         } data[32] =  0;
     } hubris_compat;
@@ -31,9 +31,9 @@ addrmap info_regs {
     reg {
         name = "GIT SHORT SHA";
         desc = "";
+        default sw = r;
 
         field {
-             default sw = r;
             desc = "Read-only bits showing the 4byte short-sha of the git commit";
         } sha[32] =  0;
     } git_info;

--- a/hdl/ip/vhd/spi_nor_controller/spi_nor_regs.rdl
+++ b/hdl/ip/vhd/spi_nor_controller/spi_nor_regs.rdl
@@ -34,35 +34,28 @@ addrmap spi_nor_regs {
     reg {
         name = "SPI Status Register";
         desc = "";
+        default sw = r;
         field {
-            default sw = r;
             desc = "Show used FIFO words in TX_FIFO (word = 32bits/4 bytes),
             max of 256 bytes, so 64 words";
         } tx_used_wds[30:24] =  0;
         field {
-            default sw = r;
             desc = "Set to one to 1 when TX FIFO is full";
         } tx_full[23:23] =  0;
          field {
-            default sw = r;
             desc = "Set to one to 1 when TX FIFO is empty";
         } tx_empty[22:22] =  0;
         field {
-            default sw = r;
             desc = "Show used FIFO words in RX_FIFO (word = 32bits/4 bytes),
             max of 256 bytes, so 64 words";
         } rx_used_wds[14:8] =  0;
         field {
-            default sw = r;
             desc = "Set to one to 1 when RX FIFO is full";
         } rx_full[7:7] =  0;
          field {
-            default sw = r;
             desc = "Set to one to 1 when RX FIFO is empty";
         } rx_empty[6:6] =  0;
-
         field {
-            default sw = r;
             desc = "Set to one to 1 when hw is running the spi transaction, no new transactions
             may be issued until it is finished. Technically represents cs_n being low.";
         } busy[0:0] =  0;

--- a/hdl/projects/cosmo_hp/hp_subsystem/hp_debug_regs.rdl
+++ b/hdl/projects/cosmo_hp/hp_subsystem/hp_debug_regs.rdl
@@ -10,49 +10,39 @@ addrmap hp_debug_regs {
  reg {
         name = "clk_en_force";
         desc = "";
+        default sw = r;
 
         field {
-            default sw = r;
             desc = "Set to 1 to force on the UFL clock buffer";
         } ufl_clk_buf_force_on[10:10] =  0;
         field {
-            default sw = r;
             desc = "Set to 1 to force on the CEM(n) clock buffer";
         } cema_clk_buf_force_on[9:9] =  0;
          field {
-            default sw = r;
             desc = "Set to 1 to force on the CEM(n) clock buffer";
         } cemb_clk_buf_force_on[8:8] =  0;
          field {
-            default sw = r;
             desc = "Set to 1 to force on the CEM(n) clock buffer";
         } cemc_clk_buf_force_on[7:7] =  0;
          field {
-            default sw = r;
             desc = "Set to 1 to force on the CEM(n) clock buffer";
         } cemd_clk_buf_force_on[6:6] =  0;
          field {
-            default sw = r;
             desc = "Set to 1 to force on the CEM(n) clock buffer";
         } ceme_clk_buf_force_on[5:5] =  0;
          field {
-            default sw = r;
             desc = "Set to 1 to force on the CEM(n) clock buffer";
         } cemf_clk_buf_force_on[4:4] =  0;
          field {
-            default sw = r;
             desc = "Set to 1 to force on the CEM(n) clock buffer";
         } cemg_clk_buf_force_on[3:3] =  0;
          field {
-            default sw = r;
             desc = "Set to 1 to force on the CEM(n) clock buffer";
         } cemh_clk_buf_force_on[2:2] =  0;
          field {
-            default sw = r;
             desc = "Set to 1 to force on the CEM(n) clock buffer";
         } cemi_clk_buf_force_on[1:1] =  0;
         field {
-            default sw = r;
             desc = "Set to 1 to force on the CEM(n) clock buffer";
         } cemj_clk_buf_force_on[0:0] =  0;
     } clk_buf_force;


### PR DESCRIPTION
In SystemRDL, the `default` keyword only applies to children within the scope it is declared. This means when it is used within a `field` (which can't have children), nothing happens. Additionally, it does not set the property locally (that is, on the `field`), so all the places where `default $property = $value` exist within a field don't actually do anything. This PR fixes all the occurrences where we did this within our RDL definitions.

Fixes #507 