### PR TITLE
Fix a missing set of registers in cosmo-hp

### DIFF
--- a/hdl/projects/cosmo_hp/BUCK
+++ b/hdl/projects/cosmo_hp/BUCK
@@ -6,6 +6,7 @@ rdl_file(
     name = "cosmo_hp_top_rdl",
     src = "cosmo_hp_top.rdl",
     deps = [
+        ":hp_debug_regs_rdl",
         "//hdl/ip/vhd/info:info_regs_rdl",
         "//hdl/ip/vhd/i2c/io_expanders/PCA9506ish:pca9506_regs_rdl",
     ],

--- a/hdl/projects/cosmo_hp/cosmo_hp_top.rdl
+++ b/hdl/projects/cosmo_hp/cosmo_hp_top.rdl
@@ -15,4 +15,5 @@ addrmap cosmo_hp_top {
     info_regs info @ 0x0;
     pca9506_axi_regs cemAtoE_hotplug @ 0x0100;
     pca9506_axi_regs cemFtoJ_hotplug @ 0x0200;
+    hp_debug_regs debug @ 0x0300;
 };


### PR DESCRIPTION
These were implemented in hardware but not picked up by the top level rdl so they didn't show up in the fully saturated top level map.