### PR TITLE
Add lfsr scrambler implementation

### DIFF
--- a/hdl/ip/vhd/lfsr/BUCK
+++ b/hdl/ip/vhd/lfsr/BUCK
@@ -1,0 +1,22 @@
+load("//tools:hdl.bzl", "vhdl_unit")
+
+vhdl_unit(
+    name = "lfsr8_pkg",
+    srcs = ["lfsr8_pkg.vhd"],
+    visibility = ['PUBLIC'],
+)
+
+vhdl_unit(
+    name = "scrambler_lfsr8",
+    srcs = ["scrambler_lfsr8.vhd"],
+    deps = [":lfsr8_pkg"],
+    visibility = ['PUBLIC'],
+)
+
+vhdl_unit(
+    name = "lfsr_tb",
+    is_tb = True,
+    srcs = glob(["sims/*.vhd"]),
+    deps = [":scrambler_lfsr8"],
+    visibility = ['PUBLIC'],
+)

--- a/hdl/ip/vhd/lfsr/lfsr8_pkg.vhd
+++ b/hdl/ip/vhd/lfsr/lfsr8_pkg.vhd
@@ -1,0 +1,70 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+-- Galois LFSR bits for the 8-bit additive scrambler, polynomial
+-- x^8 + x^6 + x^5 + x^4 + 1. Bit i holds the coefficient of x^i, so bit 0 is
+-- the LSB. We keep these as pure functions so the same code can be the golden
+-- model in a testbench and the synthesizable next-state logic in
+-- scrambler_lfsr8.
+package lfsr8_pkg is
+
+    -- The low 8 bits of the polynomial, x^6 + x^5 + x^4 + 1. The x^8 term is
+    -- the implicit feedback bit so it doesn't show up here.
+    constant lfsr8_poly : std_logic_vector(7 downto 0) := X"71";
+
+    -- Cold-start seed, used on a link reset. Any non-zero value works: the
+    -- step below is one-to-one and all-zeros maps to itself, so starting from
+    -- a non-zero state we can never walk into the all-zero lock-up.
+    constant lfsr8_seed : std_logic_vector(7 downto 0) := X"FF";
+
+    -- One Galois step, ie multiply the register by x modulo the polynomial.
+    -- Shift left and fold lfsr8_poly back in when the bit falling off the top
+    -- was set.
+    function lfsr8_step (
+        state : std_logic_vector(7 downto 0)
+    ) return std_logic_vector;
+
+    -- Advance the state for one scrambled character, one Galois step per data
+    -- bit. The loop unrolls at elaboration so this is a flat XOR network once
+    -- synthesized.
+    function lfsr8_next_char (
+        state : std_logic_vector(7 downto 0)
+    ) return std_logic_vector;
+
+end package;
+
+package body lfsr8_pkg is
+
+    function lfsr8_step (
+        state : std_logic_vector(7 downto 0)
+    ) return std_logic_vector is
+        variable shifted : std_logic_vector(7 downto 0);
+    begin
+        shifted := state(6 downto 0) & '0';
+
+        if state(7) = '1' then
+            shifted := shifted xor lfsr8_poly;
+        end if;
+
+        return shifted;
+    end function;
+
+    function lfsr8_next_char (
+        state : std_logic_vector(7 downto 0)
+    ) return std_logic_vector is
+        variable next_state : std_logic_vector(7 downto 0) := state;
+    begin
+        for i in 1 to 8 loop
+            next_state := lfsr8_step(next_state);
+        end loop;
+
+        return next_state;
+    end function;
+
+end package body;

--- a/hdl/ip/vhd/lfsr/scrambler_lfsr8.vhd
+++ b/hdl/ip/vhd/lfsr/scrambler_lfsr8.vhd
@@ -1,0 +1,89 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+use work.lfsr8_pkg.all;
+
+-- 8-bit additive scrambler built on a Galois LFSR, polynomial
+-- x^8 + x^6 + x^5 + x^4 + 1 (taps at bits 6, 5 and 4, with x^8 as the
+-- implicit feedback bit).
+--
+-- We XOR each non-control character with the current register state, then
+-- advance the register eight Galois steps, one per data bit, to get the state
+-- for the next character. De-scrambling is the identical operation so we use
+-- this same entity on both the transmit and receive sides.
+--
+-- The LFSR free-runs: it advances on every character we see with data_valid
+-- asserted, inter-packet filler included, and we don't reset it per packet or
+-- per IDLE. The polynomial is primitive so we get the full 255 state period
+-- out of it before the sequence repeats.
+--
+-- data_out is combinational in data_in so scrambling costs the character
+-- stream no latency, only the register state is clocked.
+entity scrambler_lfsr8 is
+    generic (
+        -- Cold-start value loaded on either reset. Must be non-zero, see
+        -- lfsr8_seed.
+        seed : std_logic_vector(7 downto 0) := lfsr8_seed
+    );
+    port (
+        clk : in    std_logic;
+        -- Asynchronous, active-high. Restores seed.
+        reset : in    std_logic;
+        -- Synchronous, active-high. Restores seed. This is the one a link
+        -- reset would normally drive.
+        sync_reset : in    std_logic;
+        -- Load load_data into the register on the next clock. Beats
+        -- data_valid, so a character in the same cycle still gets scrambled
+        -- with the pre-load state but we throw its advance away.
+        load_valid : in    std_logic;
+        load_data : in    std_logic_vector(7 downto 0);
+        -- Current register state, ie the keystream byte we're applying to
+        -- data_in this cycle. Brought out for monitoring.
+        lfsr_state : out   std_logic_vector(7 downto 0);
+        -- Plaintext byte when scrambling, ciphertext byte when de-scrambling.
+        data_in : in    std_logic_vector(7 downto 0);
+        -- Assert for every scrambled character to advance the register.
+        -- De-assert for control characters, which pass through unscrambled
+        -- and leave the register alone.
+        data_valid : in    std_logic;
+        data_out : out   std_logic_vector(7 downto 0)
+    );
+end entity;
+
+architecture rtl of scrambler_lfsr8 is
+
+begin
+
+    assert seed /= X"00"
+        report "scrambler_lfsr8: seed must be non-zero, all-zeros is the LFSR lock-up state"
+        severity failure;
+
+    lfsr_reg: process(clk, reset)
+    begin
+        if reset then
+            lfsr_state <= seed;
+        elsif rising_edge(clk) then
+            if sync_reset then
+                lfsr_state <= seed;
+            elsif load_valid then
+                lfsr_state <= load_data;
+            elsif data_valid then
+                lfsr_state <= lfsr8_next_char(lfsr_state);
+            end if;
+        end if;
+    end process;
+
+    -- Additive scrambler, so scramble and de-scramble are the same XOR. We
+    -- don't gate this with data_valid since whoever consumes it already knows
+    -- which characters it marked as scrambled, and gating would just be more
+    -- logic.
+    data_out <= data_in xor lfsr_state;
+
+end rtl;

--- a/hdl/ip/vhd/lfsr/scrambler_lfsr8.vhd
+++ b/hdl/ip/vhd/lfsr/scrambler_lfsr8.vhd
@@ -44,16 +44,16 @@ entity scrambler_lfsr8 is
         -- with the pre-load state but we throw its advance away.
         load_valid : in    std_logic;
         load_data : in    std_logic_vector(7 downto 0);
-        -- Current register state, ie the keystream byte we're applying to
-        -- data_in this cycle. Brought out for monitoring.
-        lfsr_state : out   std_logic_vector(7 downto 0);
         -- Plaintext byte when scrambling, ciphertext byte when de-scrambling.
         data_in : in    std_logic_vector(7 downto 0);
         -- Assert for every scrambled character to advance the register.
         -- De-assert for control characters, which pass through unscrambled
         -- and leave the register alone.
         data_valid : in    std_logic;
-        data_out : out   std_logic_vector(7 downto 0)
+        data_out : out   std_logic_vector(7 downto 0);
+        -- Current register state, ie the keystream byte we're applying to
+        -- data_in this cycle. Brought out for monitoring or debugging.
+        lfsr_state : out   std_logic_vector(7 downto 0)
     );
 end entity;
 
@@ -73,7 +73,15 @@ begin
             if sync_reset then
                 lfsr_state <= seed;
             elsif load_valid then
-                lfsr_state <= load_data;
+                -- We disallow loading the all-zeros state, which is the LFSR lock-up state. The
+                -- LFSR will never advance out of it, so we swap in the seed here. This should
+                -- produce failures that are somewhat easier to debug than a silent lock-up,
+                -- and the user shouldn't have issued this in the first place.
+                if load_data = X"00" then
+                    lfsr_state <= seed;
+                else
+                    lfsr_state <= load_data;
+                end if;
             elsif data_valid then
                 lfsr_state <= lfsr8_next_char(lfsr_state);
             end if;

--- a/hdl/ip/vhd/lfsr/sims/lfsr_tb.vhd
+++ b/hdl/ip/vhd/lfsr/sims/lfsr_tb.vhd
@@ -1,0 +1,196 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library vunit_lib;
+    context vunit_lib.com_context;
+    context vunit_lib.vunit_context;
+
+use work.lfsr8_pkg.all;
+
+entity lfsr_tb is
+    generic (
+        runner_cfg : string
+    );
+end entity;
+
+architecture tb of lfsr_tb is
+
+    -- The scrambler runs 255 characters before the state repeats.
+    constant char_period : natural := 255;
+
+    -- Hand-computed from the spec: seed 0xFF, eight Galois steps per
+    -- character, reduction constant 0x71.
+    type state_array_t is array (natural range <>) of std_logic_vector(7 downto 0);
+
+    constant expected_states : state_array_t(0 to 7) :=
+    (
+        X"FF", X"7E", X"CE", X"55", X"2A", X"95", X"33", X"C9"
+    );
+
+begin
+
+    th: entity work.lfsr_th;
+
+    bench: process
+        -- Note: external names are broken in GHDL llvm backends
+        -- https://github.com/ghdl/ghdl/issues/2610 so this sim wants nvc.
+        alias clk        is << signal th.clk : std_logic >>;
+        alias reset      is << signal th.reset : std_logic >>;
+        alias sync_reset is << signal th.sync_reset : std_logic >>;
+
+        alias load_valid is << signal th.load_valid : std_logic >>;
+        alias load_data  is << signal th.load_data : std_logic_vector(7 downto 0) >>;
+
+        alias data_valid is << signal th.data_valid : std_logic >>;
+        alias plain_data is << signal th.plain_data : std_logic_vector(7 downto 0) >>;
+
+        alias tx_state       is << signal th.tx_state : std_logic_vector(7 downto 0) >>;
+        alias rx_state       is << signal th.rx_state : std_logic_vector(7 downto 0) >>;
+        alias scrambled_data is << signal th.scrambled_data : std_logic_vector(7 downto 0) >>;
+        alias recovered_data is << signal th.recovered_data : std_logic_vector(7 downto 0) >>;
+
+        variable model_state : std_logic_vector(7 downto 0);
+        variable held_state  : std_logic_vector(7 downto 0);
+        variable payload     : std_logic_vector(7 downto 0);
+
+        -- Present a character and step the reference model alongside the DUT.
+        -- We apply on the falling edge and check before the next rising edge
+        -- eats it so that the checks see the state that actually got XORed
+        -- into this byte. The register hasn't advanced when we return, it does
+        -- that on the next rising edge, and we leave data_valid asserted for
+        -- the caller to drop.
+        procedure send_char (
+            byte : std_logic_vector(7 downto 0)
+        ) is
+        begin
+            wait until falling_edge(clk);
+            plain_data <= force byte;
+            data_valid <= force '1';
+            wait for 1 ns;
+            check_equal(tx_state, model_state, "Scrambler state diverged from the reference model");
+            check_equal(scrambled_data, byte xor model_state, "Scrambled byte is not plaintext xor state");
+            check_equal(recovered_data, byte, "De-scrambler did not recover the plaintext");
+            model_state := lfsr8_next_char(model_state);
+        end procedure;
+    begin
+        test_runner_setup(runner, runner_cfg);
+
+        -- The harness holds reset for the first 200 ns, well past the first
+        -- clock edges, so getting past this wait means the async reset already
+        -- did its job.
+        wait until reset = '0';
+        wait for 100 ns;
+
+        model_state := lfsr8_seed;
+
+        while test_suite loop
+            if run("cold_start_seed") then
+                check_equal(tx_state, lfsr8_seed, "Scrambler did not come out of reset at the seed");
+                check_equal(rx_state, lfsr8_seed, "De-scrambler did not come out of reset at the seed");
+            elsif run("state_sequence_matches_spec") then
+                -- Check the first few states against the hand-computed values
+                -- before we start trusting the model for the long runs.
+                for i in expected_states'range loop
+                    wait until falling_edge(clk);
+                    check_equal(tx_state, expected_states(i), "Unexpected state at character " & to_string(i));
+                    plain_data <= force X"00";
+                    data_valid <= force '1';
+                end loop;
+            elsif run("free_running_period") then
+                -- Walk a full lap of the sequence, checking the model the
+                -- whole way, and make sure we land back on the seed without
+                -- repeating early or touching the lock-up state.
+                for i in 0 to char_period - 1 loop
+                    payload := std_logic_vector(to_unsigned(i mod 256, 8));
+                    send_char(payload);
+                    check(tx_state /= X"00", "Scrambler reached the all-zero lock-up state");
+
+                    if i > 0 then
+                        check(tx_state /= lfsr8_seed, "Sequence repeated before the full 255 character period");
+                    end if;
+                end loop;
+
+                -- The 255th character's advance lands on the next rising edge.
+                wait until falling_edge(clk);
+                data_valid <= force '0';
+                check_equal(tx_state, lfsr8_seed, "Scrambler did not return to the seed after 255 characters");
+            elsif run("holds_when_not_valid") then
+                -- Control characters de-assert data_valid and must not
+                -- disturb the register.
+                send_char(X"A5");
+                wait until falling_edge(clk);
+                data_valid <= force '0';
+                held_state := tx_state;
+
+                for i in 0 to 9 loop
+                    wait until falling_edge(clk);
+                    check_equal(tx_state, held_state, "State advanced while data_valid was de-asserted");
+                end loop;
+            elsif run("external_load") then
+                send_char(X"5A");
+                wait until falling_edge(clk);
+                data_valid <= force '0';
+                load_data  <= force X"3C";
+                load_valid <= force '1';
+                wait until falling_edge(clk);
+                load_valid <= force '0';
+                check_equal(tx_state, std_logic_vector'(X"3C"), "External load did not take");
+                check_equal(rx_state, std_logic_vector'(X"3C"), "External load did not reach the de-scrambler");
+
+                -- A load in the same cycle as a character wins and we throw
+                -- the character's advance away.
+                model_state := X"3C";
+                send_char(X"11");
+                wait until falling_edge(clk);
+                load_data  <= force X"80";
+                load_valid <= force '1';
+                data_valid <= force '1';
+                wait until falling_edge(clk);
+                load_valid <= force '0';
+                data_valid <= force '0';
+                check_equal(tx_state, std_logic_vector'(X"80"), "Load did not take priority over a valid character");
+            elsif run("sync_reset_restores_seed") then
+                for i in 0 to 4 loop
+                    send_char(X"C3");
+                end loop;
+
+                check(tx_state /= lfsr8_seed, "State should have moved off the seed by now");
+                wait until falling_edge(clk);
+                data_valid <= force '0';
+                sync_reset <= force '1';
+                wait until falling_edge(clk);
+                sync_reset <= force '0';
+                check_equal(tx_state, lfsr8_seed, "Sync reset did not restore the seed");
+            elsif run("async_reset_restores_seed") then
+                for i in 0 to 4 loop
+                    send_char(X"C3");
+                end loop;
+
+                wait until falling_edge(clk);
+                data_valid <= force '0';
+                check(tx_state /= lfsr8_seed, "State should have moved off the seed by now");
+
+                -- Assert reset well away from a clock edge so we can show the
+                -- seed comes back without waiting for one.
+                wait for 1 ns;
+                reset <= force '1';
+                wait for 1 ns;
+                check_equal(tx_state, lfsr8_seed, "Async reset did not restore the seed without a clock edge");
+                reset <= release;
+            end if;
+        end loop;
+
+        wait for 1 us;
+        test_runner_cleanup(runner);
+        wait;
+    end process;
+
+    test_runner_watchdog(runner, 10 ms);
+
+end tb;

--- a/hdl/ip/vhd/lfsr/sims/lfsr_th.vhd
+++ b/hdl/ip/vhd/lfsr/sims/lfsr_th.vhd
@@ -1,0 +1,66 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+-- Test harness for the 8-bit additive scrambler. We wire two identical
+-- instances back to back, the first scrambling and the second de-scrambling,
+-- to show that scramble and de-scramble really are the same operation. Both
+-- get the same reset and load controls so they stay in lock-step, which is
+-- what a real link has to arrange for itself.
+entity lfsr_th is
+end entity;
+
+architecture th of lfsr_th is
+
+    signal clk        : std_logic := '0';
+    signal reset      : std_logic := '1';
+    signal sync_reset : std_logic := '0';
+
+    signal load_valid : std_logic                    := '0';
+    signal load_data  : std_logic_vector(7 downto 0) := (others => '0');
+
+    signal data_valid : std_logic                    := '0';
+    signal plain_data : std_logic_vector(7 downto 0) := (others => '0');
+
+    signal tx_state       : std_logic_vector(7 downto 0);
+    signal rx_state       : std_logic_vector(7 downto 0);
+    signal scrambled_data : std_logic_vector(7 downto 0);
+    signal recovered_data : std_logic_vector(7 downto 0);
+
+begin
+
+    clk   <= not clk after 4 ns;
+    reset <= '0' after 200 ns;
+
+    scrambler_inst: entity work.scrambler_lfsr8
+        port map (
+            clk        => clk,
+            reset      => reset,
+            sync_reset => sync_reset,
+            load_valid => load_valid,
+            load_data  => load_data,
+            lfsr_state => tx_state,
+            data_in    => plain_data,
+            data_valid => data_valid,
+            data_out   => scrambled_data
+        );
+
+    descrambler_inst: entity work.scrambler_lfsr8
+        port map (
+            clk        => clk,
+            reset      => reset,
+            sync_reset => sync_reset,
+            load_valid => load_valid,
+            load_data  => load_data,
+            lfsr_state => rx_state,
+            data_in    => scrambled_data,
+            data_valid => data_valid,
+            data_out   => recovered_data
+        );
+
+end th;


### PR DESCRIPTION
This adds an 8bit Galois LFSR bits for the 8-bit additive scrambler for doing link scrambling, and associated test cases. Not currently implemented anywhere but a building block for future links.