### PR TITLE
Make copyright headers consistent

### DIFF
--- a/hdl/ip/vhd/8b10b/helper_8b10b_pkg.vhd
+++ b/hdl/ip/vhd/8b10b/helper_8b10b_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/arb_mux_demux/arbiter.vhd
+++ b/hdl/ip/vhd/arb_mux_demux/arbiter.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Note: Documentation can be rendered in VSCode using the TerosHDL
 -- plugin: https://terostechnology.github.io/terosHDLdoc/

--- a/hdl/ip/vhd/arb_mux_demux/arbiter_pkg.vhd
+++ b/hdl/ip/vhd/arb_mux_demux/arbiter_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 --! Common shared information for arbiters
 package arbiter_pkg is

--- a/hdl/ip/vhd/arb_mux_demux/sims/arbiter_sim_pkg.vhd
+++ b/hdl/ip/vhd/arb_mux_demux/sims/arbiter_sim_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/arb_mux_demux/sims/arbiter_tb.vhd
+++ b/hdl/ip/vhd/arb_mux_demux/sims/arbiter_tb.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/arb_mux_demux/sims/arbiter_th.vhd
+++ b/hdl/ip/vhd/arb_mux_demux/sims/arbiter_th.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/axi_blocks/axil8_resizer.vhd
+++ b/hdl/ip/vhd/axi_blocks/axil8_resizer.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 
 library ieee;

--- a/hdl/ip/vhd/axi_blocks/axil_common_pkg.vhd
+++ b/hdl/ip/vhd/axi_blocks/axil_common_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/axi_blocks/axil_interconnect.vhd
+++ b/hdl/ip/vhd/axi_blocks/axil_interconnect.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 
 library ieee;

--- a/hdl/ip/vhd/axi_blocks/axil_interconnect_2k8.vhd
+++ b/hdl/ip/vhd/axi_blocks/axil_interconnect_2k8.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 
 library ieee;

--- a/hdl/ip/vhd/axi_blocks/axil_target_txn.vhd
+++ b/hdl/ip/vhd/axi_blocks/axil_target_txn.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
  
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/axi_blocks/axilite_if_2k19_helper_pkg.vhd
+++ b/hdl/ip/vhd/axi_blocks/axilite_if_2k19_helper_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 
 library ieee;

--- a/hdl/ip/vhd/axi_blocks/axilite_if_2k19_pkg.vhd
+++ b/hdl/ip/vhd/axi_blocks/axilite_if_2k19_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 
 library ieee;

--- a/hdl/ip/vhd/axi_blocks/axilite_if_2k8_pkg.vhd
+++ b/hdl/ip/vhd/axi_blocks/axilite_if_2k8_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 
 library ieee;

--- a/hdl/ip/vhd/axi_blocks/axist_if_2k19_pkg.vhd
+++ b/hdl/ip/vhd/axi_blocks/axist_if_2k19_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 
 library ieee;

--- a/hdl/ip/vhd/common/countdown/countdown.vhd
+++ b/hdl/ip/vhd/common/countdown/countdown.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- A general purpose counter block which counts down from a supplied `count` to zero. `done is not
 -- registered and will be asserted immediately when the internal count is at zero. Control priority

--- a/hdl/ip/vhd/common/countdown/sims/countdown_tb.vhd
+++ b/hdl/ip/vhd/common/countdown/sims/countdown_tb.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/common/countdown/sims/countdown_th.vhd
+++ b/hdl/ip/vhd/common/countdown/sims/countdown_th.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/common/interfaces/tristate_if_pkg.vhd
+++ b/hdl/ip/vhd/common/interfaces/tristate_if_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- This package relies on the VHDL 2019 feature for "interfaces"
 

--- a/hdl/ip/vhd/common/strobe/sims/strobe_tb.vhd
+++ b/hdl/ip/vhd/common/strobe/sims/strobe_tb.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/common/strobe/sims/strobe_th.vhd
+++ b/hdl/ip/vhd/common/strobe/sims/strobe_th.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/common/strobe/strobe.vhd
+++ b/hdl/ip/vhd/common/strobe/strobe.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- A small block that will generate a single `clk` pulse on `strobe` every `TICKS` cycles of `clk`.
 

--- a/hdl/ip/vhd/common/utils/calc_pkg.vhd
+++ b/hdl/ip/vhd/common/utils/calc_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Note: Documentation can be rendered in VSCode using the TerosHDL
 -- plugin: https://terostechnology.github.io/terosHDLdoc/

--- a/hdl/ip/vhd/common/utils/sims/utilities_tb.vhd
+++ b/hdl/ip/vhd/common/utils/sims/utilities_tb.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/common/utils/time_pkg.vhd
+++ b/hdl/ip/vhd/common/utils/time_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Note: Documentation can be rendered in VSCode using the TerosHDL
 -- plugin: https://terostechnology.github.io/terosHDLdoc/

--- a/hdl/ip/vhd/common/utils/transforms_pkg.vhd
+++ b/hdl/ip/vhd/common/utils/transforms_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 
 library ieee;

--- a/hdl/ip/vhd/crc/crc8atm_8wide.vhd
+++ b/hdl/ip/vhd/crc/crc8atm_8wide.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/crc/crc8autostar_8wide.vhd
+++ b/hdl/ip/vhd/crc/crc8autostar_8wide.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/crc/crc_sim_pkg.vhd
+++ b/hdl/ip/vhd/crc/crc_sim_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- As a reminder when making these:
 --  Highest term is xor'd with next input bit and result is fed back into the 

--- a/hdl/ip/vhd/espi/espi_spec_regs.vhd
+++ b/hdl/ip/vhd/espi/espi_spec_regs.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Note: Documentation can be rendered in VSCode using the TerosHDL
 -- plugin: https://terostechnology.github.io/terosHDLdoc/

--- a/hdl/ip/vhd/espi/espi_target_top.vhd
+++ b/hdl/ip/vhd/espi/espi_target_top.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Top level of the eSPI target block. This block is responsible for
 -- basic synchronization of the eSPI signals, and instantiation of the

--- a/hdl/ip/vhd/espi/flash_channel/flash_channel.vhd
+++ b/hdl/ip/vhd/espi/flash_channel/flash_channel.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- This block provides the transaction queueing and management for the flash
 -- channel. It is responsible for queueing up transactions, issuing commands to

--- a/hdl/ip/vhd/espi/flash_channel/flash_channel_pkg.vhd
+++ b/hdl/ip/vhd/espi/flash_channel/flash_channel_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/espi/link_layer/alert_gen.vhd
+++ b/hdl/ip/vhd/espi/link_layer/alert_gen.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- This block manages the state machine for the in-band alert mechanism.
 -- Logic in the slow domain monitors when an alert is needed and this block

--- a/hdl/ip/vhd/espi/link_layer/cmd_sizer.vhd
+++ b/hdl/ip/vhd/espi/link_layer/cmd_sizer.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- In the fast domain, before we've done full packet parsing, we need
 -- some basic parsing to determine the size of the packet and when the

--- a/hdl/ip/vhd/espi/link_layer/dbg_link_faker.vhd
+++ b/hdl/ip/vhd/espi/link_layer/dbg_link_faker.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- This block allows an SP-interface to issue eSPI commands to the transaction
 -- layer and receive responses. It is used for debugging and testing purposes

--- a/hdl/ip/vhd/espi/link_layer/link_layer.vhd
+++ b/hdl/ip/vhd/espi/link_layer/link_layer.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- The main qspi link layer block for this target, including the 
 -- link-layer transaction management and FIFO interfaces to/from

--- a/hdl/ip/vhd/espi/link_layer/link_layer_pkg.vhd
+++ b/hdl/ip/vhd/espi/link_layer/link_layer_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/espi/link_layer/qspi_link_layer_pkg.vhd
+++ b/hdl/ip/vhd/espi/link_layer/qspi_link_layer_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/espi/peripheral_channel/uart_channel_pkg.vhd
+++ b/hdl/ip/vhd/espi/peripheral_channel/uart_channel_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/espi/peripheral_channel/uart_channel_top.vhd
+++ b/hdl/ip/vhd/espi/peripheral_channel/uart_channel_top.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- This block provides the transaction queueing and management for the peripheral
 -- channel. It is responsible for queueing up transactions, issuing bytes to

--- a/hdl/ip/vhd/espi/sims/espi_tb.vhd
+++ b/hdl/ip/vhd/espi/sims/espi_tb.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/espi/sims/espi_tb_pkg.vhd
+++ b/hdl/ip/vhd/espi/sims/espi_tb_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- This package contains types and helper functions for building testbenches
 -- around the espi protocol. Functions and procedures in this block are "generic"

--- a/hdl/ip/vhd/espi/sims/espi_th.vhd
+++ b/hdl/ip/vhd/espi/sims/espi_th.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/espi/sims/models/espi_controller_vc_pkg.vhd
+++ b/hdl/ip/vhd/espi/sims/models/espi_controller_vc_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Note: Documentation can be rendered in VSCode using the TerosHDL
 -- plugin: https://terostechnology.github.io/terosHDLdoc/

--- a/hdl/ip/vhd/espi/sims/models/espi_dbg_vc_pkg.vhd
+++ b/hdl/ip/vhd/espi/sims/models/espi_dbg_vc_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/espi/sims/models/fake_flash_txn_mgr.vhd
+++ b/hdl/ip/vhd/espi/sims/models/fake_flash_txn_mgr.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- This is a fake flash transaction manager used to test the ESPI interface.
 -- Rather than pulling in a whole flash controller for sim, we just mock the

--- a/hdl/ip/vhd/espi/sys_regs/espi_regs.vhd
+++ b/hdl/ip/vhd/espi/sys_regs/espi_regs.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- SP-accessible registers for the eSPI block
 

--- a/hdl/ip/vhd/espi/sys_regs/espi_spec_regs_view_pkg.vhd
+++ b/hdl/ip/vhd/espi/sys_regs/espi_spec_regs_view_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Composite record and views for exposing eSPI spec register
 -- values as a read-only interface in the sys_regs address space.

--- a/hdl/ip/vhd/espi/sys_regs/sp5_post_code_pkg.vhd
+++ b/hdl/ip/vhd/espi/sys_regs/sp5_post_code_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Composite record and views for exposing eSPI spec register
 -- values as a read-only interface in the sys_regs address space.

--- a/hdl/ip/vhd/espi/txn_layer/command_processor.vhd
+++ b/hdl/ip/vhd/espi/txn_layer/command_processor.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Main command parser and processing for the eSPI transaction layer.
 -- Pulls from a FIFO from the link layer or debug layer and processes

--- a/hdl/ip/vhd/espi/txn_layer/espi_base_types_pkg.vhd
+++ b/hdl/ip/vhd/espi/txn_layer/espi_base_types_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/espi/txn_layer/espi_protocol_pkg.vhd
+++ b/hdl/ip/vhd/espi/txn_layer/espi_protocol_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/espi/txn_layer/link_to_txn_bridge.vhd
+++ b/hdl/ip/vhd/espi/txn_layer/link_to_txn_bridge.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Provides clock-crossing between the link layer and transaction layer
 -- and provides the debug mux for disconnecting the link layer and using

--- a/hdl/ip/vhd/espi/txn_layer/response_processor.vhd
+++ b/hdl/ip/vhd/espi/txn_layer/response_processor.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Determine and coordinate responses back to the link layer depending on the
 -- current command opcode and availablilty of data to send back.

--- a/hdl/ip/vhd/espi/txn_layer/txn_layer_top.vhd
+++ b/hdl/ip/vhd/espi/txn_layer/txn_layer_top.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Structural wrapper for the transaction layer and the various channel blocks
 

--- a/hdl/ip/vhd/espi/vwire_channel/vwire_block.vhd
+++ b/hdl/ip/vhd/espi/vwire_channel/vwire_block.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- eSPI Virtual Wire Channel implementation
 -- While we do nothing with this today, the mask-rom in the SP5

--- a/hdl/ip/vhd/fifos/sims/fifos_sim_pkg.vhd
+++ b/hdl/ip/vhd/fifos/sims/fifos_sim_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/fifos/sims/fifos_tb.vhd
+++ b/hdl/ip/vhd/fifos/sims/fifos_tb.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/fifos/sims/fifos_th.vhd
+++ b/hdl/ip/vhd/fifos/sims/fifos_th.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/fmc_if/model/stm32h7_fmc_model.vhd
+++ b/hdl/ip/vhd/fmc_if/model/stm32h7_fmc_model.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 --! FMC controller model based on ST's RM0433 rev8
 --! figures 115 and 116 for simulation of the

--- a/hdl/ip/vhd/fmc_if/model/stm32h7_fmc_sim_pkg.vhd
+++ b/hdl/ip/vhd/fmc_if/model/stm32h7_fmc_sim_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 --! Bus master model based on ST's RM0433
 --! figures 115 and 116

--- a/hdl/ip/vhd/fmc_if/sims/fmc_tb.vhd
+++ b/hdl/ip/vhd/fmc_if/sims/fmc_tb.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/fmc_if/sims/fmc_tb_pkg.vhd
+++ b/hdl/ip/vhd/fmc_if/sims/fmc_tb_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 --! Bus master model based on ST's RM0433
 --! figures 115 and 116

--- a/hdl/ip/vhd/fmc_if/sims/fmc_th.vhd
+++ b/hdl/ip/vhd/fmc_if/sims/fmc_th.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/fmc_if/stm32h7_fmc_target.vhd
+++ b/hdl/ip/vhd/fmc_if/stm32h7_fmc_target.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 --! This block provides an FMC target interface from the STM32H7's
 --! local bus, crosses clock domains into the FPGA's core logic

--- a/hdl/ip/vhd/fmc_if/stm32h7_fmc_target_pkg.vhd
+++ b/hdl/ip/vhd/fmc_if/stm32h7_fmc_target_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/common/i2c_common_pkg.vhd
+++ b/hdl/ip/vhd/i2c/common/i2c_common_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/common/i2c_glitch_filter.vhd
+++ b/hdl/ip/vhd/i2c/common/i2c_glitch_filter.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Simple i2c glitch filtering for targets  I2C spec
 -- This block incurs a delay of 1 sync cycle and n filter cycles

--- a/hdl/ip/vhd/i2c/controller/i2c_ctrl_top.vhd
+++ b/hdl/ip/vhd/i2c/controller/i2c_ctrl_top.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/controller/link_layer/i2c_ctrl_link_layer.vhd
+++ b/hdl/ip/vhd/i2c/controller/link_layer/i2c_ctrl_link_layer.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- I2C Control Link Layer
 --

--- a/hdl/ip/vhd/i2c/controller/regs/i2c_ctrl_regs.vhd
+++ b/hdl/ip/vhd/i2c/controller/regs/i2c_ctrl_regs.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- AXI-accessible registers for the I2C block
 

--- a/hdl/ip/vhd/i2c/controller/txn_layer/i2c_ctrl_txn_layer.vhd
+++ b/hdl/ip/vhd/i2c/controller/txn_layer/i2c_ctrl_txn_layer.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- I2C Controller Transaction Layer
 --

--- a/hdl/ip/vhd/i2c/controller/txn_layer/sims/i2c_ctrl_txn_layer_tb.vhd
+++ b/hdl/ip/vhd/i2c/controller/txn_layer/sims/i2c_ctrl_txn_layer_tb.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/controller/txn_layer/sims/i2c_ctrl_txn_layer_th.vhd
+++ b/hdl/ip/vhd/i2c/controller/txn_layer/sims/i2c_ctrl_txn_layer_th.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/pca9506_function.vhd
+++ b/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/pca9506_function.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/pca9506_pkg.vhd
+++ b/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/pca9506_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/pca9506_regs.vhd
+++ b/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/pca9506_regs.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/pca9506_top.vhd
+++ b/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/pca9506_top.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- This provides an I/O expander sw-compatible with the PCA9506 memory map
 -- upper level logic will decide whether or not to use the tri-state signals

--- a/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/sims/i2c_pca9506ish_sim_pkg.vhd
+++ b/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/sims/i2c_pca9506ish_sim_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/sims/i2c_pca9506ish_tb.vhd
+++ b/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/sims/i2c_pca9506ish_tb.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/sims/i2c_pca9506ish_th.vhd
+++ b/hdl/ip/vhd/i2c/io_expanders/PCA9506ish/sims/i2c_pca9506ish_th.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/muxes/PCA9545ish/pca9545_pkg.vhd
+++ b/hdl/ip/vhd/i2c/muxes/PCA9545ish/pca9545_pkg.vhd
@@ -1,7 +1,7 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
+
 library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;

--- a/hdl/ip/vhd/i2c/muxes/PCA9545ish/pca9545ish_function.vhd
+++ b/hdl/ip/vhd/i2c/muxes/PCA9545ish/pca9545ish_function.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- This block provides the logic and control register for the i2c mux
 -- as well as the response logic for interfacing with the i2c_target_phy block

--- a/hdl/ip/vhd/i2c/muxes/PCA9545ish/pca9545ish_top.vhd
+++ b/hdl/ip/vhd/i2c/muxes/PCA9545ish/pca9545ish_top.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- This provides the digital portion of a 4 channel i2c mux, based on the software interface
 -- of a PCA9545.  Currently no interrupts are supported as we don't need them so those

--- a/hdl/ip/vhd/i2c/muxes/PCA9545ish/sims/i2c_pca9545ish_sim_pkg.vhd
+++ b/hdl/ip/vhd/i2c/muxes/PCA9545ish/sims/i2c_pca9545ish_sim_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/muxes/PCA9545ish/sims/i2c_pca9545ish_tb.vhd
+++ b/hdl/ip/vhd/i2c/muxes/PCA9545ish/sims/i2c_pca9545ish_tb.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/muxes/PCA9545ish/sims/i2c_pca9545ish_th.vhd
+++ b/hdl/ip/vhd/i2c/muxes/PCA9545ish/sims/i2c_pca9545ish_th.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/muxes/oximux16/oximux16_function.vhd
+++ b/hdl/ip/vhd/i2c/muxes/oximux16/oximux16_function.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- This block provides the logic and control register for the i2c mux
 -- as well as the response logic for interfacing with the i2c_target_phy block

--- a/hdl/ip/vhd/i2c/muxes/oximux16/oximux16_top.vhd
+++ b/hdl/ip/vhd/i2c/muxes/oximux16/oximux16_top.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- This provides the digital portion of a 4 channel i2c mux, based on the software interface
 -- of a PCA9545.  Currently no interrupts are supported as we don't need them so those

--- a/hdl/ip/vhd/i2c/muxes/oximux16/sims/oximux16_sim_pkg.vhd
+++ b/hdl/ip/vhd/i2c/muxes/oximux16/sims/oximux16_sim_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/muxes/oximux16/sims/oximux16_tb.vhd
+++ b/hdl/ip/vhd/i2c/muxes/oximux16/sims/oximux16_tb.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/muxes/oximux16/sims/oximux16_th.vhd
+++ b/hdl/ip/vhd/i2c/muxes/oximux16/sims/oximux16_th.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/target/i2c_base_types_pkg.vhd
+++ b/hdl/ip/vhd/i2c/target/i2c_base_types_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Shared base types for i2c components
 

--- a/hdl/ip/vhd/i2c/target/i2c_phy_consolidator.vhd
+++ b/hdl/ip/vhd/i2c/target/i2c_phy_consolidator.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/target/i2c_target_phy.vhd
+++ b/hdl/ip/vhd/i2c/target/i2c_target_phy.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- This block provides an i2c-compliant "phy" for use with additional logic
 -- to create i2c target functions. It is intended to be generic and shareable

--- a/hdl/ip/vhd/i2c/target/sims/i2c_target_phy_sim_pkg.vhd
+++ b/hdl/ip/vhd/i2c/target/sims/i2c_target_phy_sim_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/target/sims/i2c_target_phy_tb.vhd
+++ b/hdl/ip/vhd/i2c/target/sims/i2c_target_phy_tb.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/i2c/target/sims/i2c_target_phy_th.vhd
+++ b/hdl/ip/vhd/i2c/target/sims/i2c_target_phy_th.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/ice40primitives/ice40_pkg.vhd
+++ b/hdl/ip/vhd/ice40primitives/ice40_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/ignition/target/ibc_control.vhd
+++ b/hdl/ip/vhd/ignition/target/ibc_control.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 
 -- Ignition is pretty simple.  It can can turn on the IBC

--- a/hdl/ip/vhd/ignition/target/ignition_io.vhd
+++ b/hdl/ip/vhd/ignition/target/ignition_io.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/ignition/target/ignition_pkg.vhd
+++ b/hdl/ip/vhd/ignition/target/ignition_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/ignition/target/ignition_status.vhd
+++ b/hdl/ip/vhd/ignition/target/ignition_status.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/ignition/target/ignition_target_common.vhd
+++ b/hdl/ip/vhd/ignition/target/ignition_target_common.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/ignition/target/rx_path/ignit_rx_pipe.vhd
+++ b/hdl/ip/vhd/ignition/target/rx_path/ignit_rx_pipe.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 
 library ieee;

--- a/hdl/ip/vhd/ignition/target/rx_path/pkt_parsing.vhd
+++ b/hdl/ip/vhd/ignition/target/rx_path/pkt_parsing.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/ignition/target/sims/ignition_controller_model.vhd
+++ b/hdl/ip/vhd/ignition/target/sims/ignition_controller_model.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- want to take a streaming interface with data (9bit, 8 data + control)
 -- generate IDLE sequences unless packets in-bound then send those

--- a/hdl/ip/vhd/ignition/target/sims/ignition_sim_pkg.vhd
+++ b/hdl/ip/vhd/ignition/target/sims/ignition_sim_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/ignition/target/sims/ignition_tgt_sim_tb.vhd
+++ b/hdl/ip/vhd/ignition/target/sims/ignition_tgt_sim_tb.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/ignition/target/sims/ignition_tgt_sim_th.vhd
+++ b/hdl/ip/vhd/ignition/target/sims/ignition_tgt_sim_th.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/ignition/target/tx_path/ignition_tx.vhd
+++ b/hdl/ip/vhd/ignition/target/tx_path/ignition_tx.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/info/info.vhd
+++ b/hdl/ip/vhd/info/info.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- 2019-compatible wrapper for basic board information registers
 

--- a/hdl/ip/vhd/info/info_2k8.vhd
+++ b/hdl/ip/vhd/info/info_2k8.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Common register block for basic board information
 

--- a/hdl/ip/vhd/irq/irq_block.vhd
+++ b/hdl/ip/vhd/irq/irq_block.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/lfsr/lfsr8_pkg.vhd
+++ b/hdl/ip/vhd/lfsr/lfsr8_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/lfsr/scrambler_lfsr8.vhd
+++ b/hdl/ip/vhd/lfsr/scrambler_lfsr8.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 
 library ieee;

--- a/hdl/ip/vhd/lfsr/sims/lfsr_tb.vhd
+++ b/hdl/ip/vhd/lfsr/sims/lfsr_tb.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/lfsr/sims/lfsr_th.vhd
+++ b/hdl/ip/vhd/lfsr/sims/lfsr_th.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/ls_xcvr/aligner_10bk28_5.vhd
+++ b/hdl/ip/vhd/ls_xcvr/aligner_10bk28_5.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/ls_xcvr/ls_serdes.vhd
+++ b/hdl/ip/vhd/ls_xcvr/ls_serdes.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/memories/mixed_width_simple_dpr.vhd
+++ b/hdl/ip/vhd/memories/mixed_width_simple_dpr.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/memories/sims/memories_sim_pkg.vhd
+++ b/hdl/ip/vhd/memories/sims/memories_sim_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/memories/sims/memories_tb.vhd
+++ b/hdl/ip/vhd/memories/sims/memories_tb.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/memories/sims/memories_th.vhd
+++ b/hdl/ip/vhd/memories/sims/memories_th.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/pipeline/skidbuffer.vhd
+++ b/hdl/ip/vhd/pipeline/skidbuffer.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- inspired by https://zipcpu.com/blog/2019/05/22/skidbuffer.html
 

--- a/hdl/ip/vhd/sgpio/sgpio_shift_in.vhd
+++ b/hdl/ip/vhd/sgpio/sgpio_shift_in.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/sgpio/sgpio_shift_out.vhd
+++ b/hdl/ip/vhd/sgpio/sgpio_shift_out.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/sgpio/sgpio_top.vhd
+++ b/hdl/ip/vhd/sgpio/sgpio_top.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/sgpio/sims/sgpio_tb.vhd
+++ b/hdl/ip/vhd/sgpio/sims/sgpio_tb.vhd
@@ -1,8 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
--- Copyright  Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/sgpio/sims/sgpio_th.vhd
+++ b/hdl/ip/vhd/sgpio/sims/sgpio_th.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/spi/axi_controller/sims/spi_axi_tb.vhd
+++ b/hdl/ip/vhd/spi/axi_controller/sims/spi_axi_tb.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/spi/axi_controller/sims/spi_axi_tb_pkg.vhd
+++ b/hdl/ip/vhd/spi/axi_controller/sims/spi_axi_tb_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/spi/axi_controller/sims/spi_axi_th.vhd
+++ b/hdl/ip/vhd/spi/axi_controller/sims/spi_axi_th.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/spi/axi_controller/spi_axi_controller_top.vhd
+++ b/hdl/ip/vhd/spi/axi_controller/spi_axi_controller_top.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Acting as a SPI peripheral, turn specially formed transactions into
 -- AXI-lite memory read/write transactions

--- a/hdl/ip/vhd/spi/axi_controller/spi_axi_pkg.vhd
+++ b/hdl/ip/vhd/spi/axi_controller/spi_axi_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/spi/axi_controller/spi_to_axi.vhd
+++ b/hdl/ip/vhd/spi/axi_controller/spi_to_axi.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Acting as a SPI peripheral, turn specially formed transactions into
 -- AXI-lite memory read/write transactions

--- a/hdl/ip/vhd/spi/spi_target_phy/spi_target_phy.vhd
+++ b/hdl/ip/vhd/spi/spi_target_phy/spi_target_phy.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Simple SPI shifter PHY
 -- shifts on sclk edges (post synchronizer) when chipselect is asserted low

--- a/hdl/ip/vhd/spi_nor_controller/espi_txn/espi_flash_txn_mgr.vhd
+++ b/hdl/ip/vhd/spi_nor_controller/espi_txn/espi_flash_txn_mgr.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 
 library ieee;

--- a/hdl/ip/vhd/spi_nor_controller/link/spi_clk_gen.vhd
+++ b/hdl/ip/vhd/spi_nor_controller/link/spi_clk_gen.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/spi_nor_controller/link/spi_link.vhd
+++ b/hdl/ip/vhd/spi_nor_controller/link/spi_link.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/spi_nor_controller/mixed_width_adaptor.vhd
+++ b/hdl/ip/vhd/spi_nor_controller/mixed_width_adaptor.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/spi_nor_controller/sims/spi_nor_tb.vhd
+++ b/hdl/ip/vhd/spi_nor_controller/sims/spi_nor_tb.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/spi_nor_controller/sims/spi_nor_tb_pkg.vhd
+++ b/hdl/ip/vhd/spi_nor_controller/sims/spi_nor_tb_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/spi_nor_controller/sims/spi_nor_th.vhd
+++ b/hdl/ip/vhd/spi_nor_controller/sims/spi_nor_th.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/spi_nor_controller/spi_nor_pkg.vhd
+++ b/hdl/ip/vhd/spi_nor_controller/spi_nor_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/spi_nor_controller/spi_nor_regs.vhd
+++ b/hdl/ip/vhd/spi_nor_controller/spi_nor_regs.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/spi_nor_controller/spi_nor_top.vhd
+++ b/hdl/ip/vhd/spi_nor_controller/spi_nor_top.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/spi_nor_controller/spi_txn/spi_txn_mgr.vhd
+++ b/hdl/ip/vhd/spi_nor_controller/spi_txn/spi_txn_mgr.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/synchronizers/async_reset_bridge.vhd
+++ b/hdl/ip/vhd/synchronizers/async_reset_bridge.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Note: Documentation can be rendered in VSCode using the TerosHDL
 -- plugin: https://terostechnology.github.io/terosHDLdoc/

--- a/hdl/ip/vhd/synchronizers/bacd.vhd
+++ b/hdl/ip/vhd/synchronizers/bacd.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Note: Documentation can be rendered in VSCode using the TerosHDL
 -- plugin: https://terostechnology.github.io/terosHDLdoc/

--- a/hdl/ip/vhd/synchronizers/meta_sync.vhd
+++ b/hdl/ip/vhd/synchronizers/meta_sync.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Note: Documentation can be rendered in VSCode using the TerosHDL
 -- plugin: https://terostechnology.github.io/terosHDLdoc/

--- a/hdl/ip/vhd/synchronizers/sims/synchronizers_tb.vhd
+++ b/hdl/ip/vhd/synchronizers/sims/synchronizers_tb.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/synchronizers/sims/synchronizers_th.vhd
+++ b/hdl/ip/vhd/synchronizers/sims/synchronizers_th.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/synchronizers/tacd.vhd
+++ b/hdl/ip/vhd/synchronizers/tacd.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Note: Documentation can be rendered in VSCode using the TerosHDL
 -- plugin: https://terostechnology.github.io/terosHDLdoc/

--- a/hdl/ip/vhd/uart/base_uart/axi_st_uart.vhd
+++ b/hdl/ip/vhd/uart/base_uart/axi_st_uart.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- A very simple UART that streams rx'd bytes out an axi streaming port
 -- and transmits bytes from an input axi streaming port, no buffering

--- a/hdl/ip/vhd/uart/fifo_uart/axi_fifo_st_uart.vhd
+++ b/hdl/ip/vhd/uart/fifo_uart/axi_fifo_st_uart.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 
 library ieee;

--- a/hdl/ip/vhd/uart/sims/uart_tb.vhd
+++ b/hdl/ip/vhd/uart/sims/uart_tb.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/uart/sims/uart_tb_pkg.vhd
+++ b/hdl/ip/vhd/uart/sims/uart_tb_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/uart/sims/uart_th.vhd
+++ b/hdl/ip/vhd/uart/sims/uart_th.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/vunit_components/I2c_cmd/i2c_cmd_vc.vhd
+++ b/hdl/ip/vhd/vunit_components/I2c_cmd/i2c_cmd_vc.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/vunit_components/I2c_cmd/i2c_cmd_vc_pkg.vhd
+++ b/hdl/ip/vhd/vunit_components/I2c_cmd/i2c_cmd_vc_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/vunit_components/basic_stream/basic_sink.vhd
+++ b/hdl/ip/vhd/vunit_components/basic_stream/basic_sink.vhd
@@ -1,8 +1,7 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
---
+
 -- A basic sink for streamed data that can apply backpressure.
 
 library ieee;

--- a/hdl/ip/vhd/vunit_components/basic_stream/basic_source.vhd
+++ b/hdl/ip/vhd/vunit_components/basic_stream/basic_source.vhd
@@ -1,8 +1,7 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
---
+
 -- A basic source of streamed data that respects backpressure.
 
 library ieee;

--- a/hdl/ip/vhd/vunit_components/basic_stream/basic_stream_pkg.vhd
+++ b/hdl/ip/vhd/vunit_components/basic_stream/basic_stream_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/vunit_components/basic_stream/sims/tb_basic_stream.vhd
+++ b/hdl/ip/vhd/vunit_components/basic_stream/sims/tb_basic_stream.vhd
@@ -1,8 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
--- Copyright  Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/vunit_components/basic_stream/sims/th_basic_stream.vhd
+++ b/hdl/ip/vhd/vunit_components/basic_stream/sims/th_basic_stream.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/vunit_components/gpio/gpio_msg_pkg.vhd
+++ b/hdl/ip/vhd/vunit_components/gpio/gpio_msg_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/vunit_components/gpio/sim_gpio.vhd
+++ b/hdl/ip/vhd/vunit_components/gpio/sim_gpio.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Note: Documentation can be rendered in VSCode using the TerosHDL
 -- plugin: https://terostechnology.github.io/terosHDLdoc/

--- a/hdl/ip/vhd/vunit_components/i2c_controller/i2c_ctrlr_vc.vhd
+++ b/hdl/ip/vhd/vunit_components/i2c_controller/i2c_ctrlr_vc.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Note: Documentation can be rendered in VSCode using the TerosHDL
 -- plugin: https://terostechnology.github.io/terosHDLdoc/

--- a/hdl/ip/vhd/vunit_components/i2c_controller/i2c_ctrlr_vc_pkg.vhd
+++ b/hdl/ip/vhd/vunit_components/i2c_controller/i2c_ctrlr_vc_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/vunit_components/i2c_target/i2c_target_vc.vhd
+++ b/hdl/ip/vhd/vunit_components/i2c_target/i2c_target_vc.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/vunit_components/i2c_target/i2c_target_vc_pkg.vhd
+++ b/hdl/ip/vhd/vunit_components/i2c_target/i2c_target_vc_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/vunit_components/qspi_controller/qspi_controller_vc.vhd
+++ b/hdl/ip/vhd/vunit_components/qspi_controller/qspi_controller_vc.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Note: Documentation can be rendered in VSCode using the TerosHDL
 -- plugin: https://terostechnology.github.io/terosHDLdoc/

--- a/hdl/ip/vhd/vunit_components/qspi_controller/qspi_vc_pkg.vhd
+++ b/hdl/ip/vhd/vunit_components/qspi_controller/qspi_vc_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/ip/vhd/vunit_components/sim_gpio.vhd
+++ b/hdl/ip/vhd/vunit_components/sim_gpio.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Note: Documentation can be rendered in VSCode using the TerosHDL
 -- plugin: https://terostechnology.github.io/terosHDLdoc/

--- a/hdl/projects/cosmo_hp/cosmo_hp_top.vhd
+++ b/hdl/projects/cosmo_hp/cosmo_hp_top.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Cosmo Ignition FPGA top targeting an ice40 HX8k
 

--- a/hdl/projects/cosmo_hp/hp_subsystem/cem_hp_io_pkg.vhd
+++ b/hdl/projects/cosmo_hp/hp_subsystem/cem_hp_io_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_hp/hp_subsystem/cem_sync.vhd
+++ b/hdl/projects/cosmo_hp/hp_subsystem/cem_sync.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Take an array of records from each of the 10 CEMs and generate
 -- input synchronizers for each of them, and give back an output

--- a/hdl/projects/cosmo_hp/hp_subsystem/hp_debug_regs.vhd
+++ b/hdl/projects/cosmo_hp/hp_subsystem/hp_debug_regs.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_hp/hp_subsystem/hp_logic.vhd
+++ b/hdl/projects/cosmo_hp/hp_subsystem/hp_logic.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_hp/hp_subsystem/hp_subystem_top.vhd
+++ b/hdl/projects/cosmo_hp/hp_subsystem/hp_subystem_top.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Cosmo Front Hot-plug FPGA targeting an ice40 HX8k
 

--- a/hdl/projects/cosmo_hp/hp_subsystem/sims/cem_hp_sim_tb.vhd
+++ b/hdl/projects/cosmo_hp/hp_subsystem/sims/cem_hp_sim_tb.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_hp/hp_subsystem/sims/cem_hp_sim_th.vhd
+++ b/hdl/projects/cosmo_hp/hp_subsystem/sims/cem_hp_sim_th.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_hp/hp_subsystem/sims/cem_model.vhd
+++ b/hdl/projects/cosmo_hp/hp_subsystem/sims/cem_model.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_hp/hp_subsystem/sims/cem_sim_pkg.vhd
+++ b/hdl/projects/cosmo_hp/hp_subsystem/sims/cem_sim_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_ignition/cosmo_ignition_a_top.vhd
+++ b/hdl/projects/cosmo_ignition/cosmo_ignition_a_top.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Cosmo Front Hot-plug FPGA targeting an ice40 HX8k
 

--- a/hdl/projects/cosmo_ignition/cosmo_ignition_top.vhd
+++ b/hdl/projects/cosmo_ignition/cosmo_ignition_top.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Cosmo Front Hot-plug FPGA targeting an ice40 HX8k
 

--- a/hdl/projects/cosmo_seq/black_box_entities/cosmo_pll.vhd
+++ b/hdl/projects/cosmo_seq/black_box_entities/cosmo_pll.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- A no synth, no sim, black entity to make analysis happy
 

--- a/hdl/projects/cosmo_seq/board_support/board_support_top.vhd
+++ b/hdl/projects/cosmo_seq/board_support/board_support_top.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/board_support/reset_sync.vhd
+++ b/hdl/projects/cosmo_seq/board_support/reset_sync.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 
 library ieee;

--- a/hdl/projects/cosmo_seq/chip2chip_if/chip2chip_top.vhd
+++ b/hdl/projects/cosmo_seq/chip2chip_if/chip2chip_top.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/cosmo_seq_top.vhd
+++ b/hdl/projects/cosmo_seq/cosmo_seq_top.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Cosmo Sequencer FPGA targeting the Spartan-7
 

--- a/hdl/projects/cosmo_seq/debug_module/debug_header.vhd
+++ b/hdl/projects/cosmo_seq/debug_module/debug_header.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 
 library ieee;

--- a/hdl/projects/cosmo_seq/debug_module/debug_module_top.vhd
+++ b/hdl/projects/cosmo_seq/debug_module/debug_module_top.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 
 library ieee;

--- a/hdl/projects/cosmo_seq/dimms_subsystem/dimms_subsystem_top.vhd
+++ b/hdl/projects/cosmo_seq/dimms_subsystem/dimms_subsystem_top.vhd
@@ -1,8 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/dimms_subsystem/proxy_channel/dimm_arb_mux.vhd
+++ b/hdl/projects/cosmo_seq/dimms_subsystem/proxy_channel/dimm_arb_mux.vhd
@@ -1,8 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
--- Copyright 2025 Oxide Computer Company
 
 -- 3 possible things trying to drive the DIMM i2c bus:
 -- 1) i2c transactions from the host CPU via slow i2c on a dedicated bus

--- a/hdl/projects/cosmo_seq/dimms_subsystem/proxy_channel/proxy_channel_top.vhd
+++ b/hdl/projects/cosmo_seq/dimms_subsystem/proxy_channel/proxy_channel_top.vhd
@@ -1,8 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/dimms_subsystem/proxy_channel/proxy_fpga_i2c_logic.vhd
+++ b/hdl/projects/cosmo_seq/dimms_subsystem/proxy_channel/proxy_fpga_i2c_logic.vhd
@@ -1,8 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/dimms_subsystem/proxy_channel/spd_cache.vhd
+++ b/hdl/projects/cosmo_seq/dimms_subsystem/proxy_channel/spd_cache.vhd
@@ -1,8 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/dimms_subsystem/proxy_channel/spd_sm.vhd
+++ b/hdl/projects/cosmo_seq/dimms_subsystem/proxy_channel/spd_sm.vhd
@@ -1,8 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/dimms_subsystem/regs/spd_regs.vhd
+++ b/hdl/projects/cosmo_seq/dimms_subsystem/regs/spd_regs.vhd
@@ -1,8 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/dimms_subsystem/regs/txn_buffer.vhd
+++ b/hdl/projects/cosmo_seq/dimms_subsystem/regs/txn_buffer.vhd
@@ -1,8 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/dimms_subsystem/regs/txn_sm.vhd
+++ b/hdl/projects/cosmo_seq/dimms_subsystem/regs/txn_sm.vhd
@@ -1,8 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/dimms_subsystem/sda_arbiter/sda_arbiter.vhd
+++ b/hdl/projects/cosmo_seq/dimms_subsystem/sda_arbiter/sda_arbiter.vhd
@@ -1,9 +1,7 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
--- Copyright 2025 Oxide Computer Company
---
+
 -- This block monitors two I2C SDA signals, `a` and `b`, with the intention that hey are
 -- essentially connected but proxied by the FPGA. It assumes the inactive state for the bus is high,
 -- and then monitors for `a` or `b` to pull the line low. It will then grant whichever side pulled

--- a/hdl/projects/cosmo_seq/dimms_subsystem/sda_arbiter/sims/sda_arbiter_tb.vhd
+++ b/hdl/projects/cosmo_seq/dimms_subsystem/sda_arbiter/sims/sda_arbiter_tb.vhd
@@ -1,8 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/dimms_subsystem/sims/dimm_arb_mux_tb.vhd
+++ b/hdl/projects/cosmo_seq/dimms_subsystem/sims/dimm_arb_mux_tb.vhd
@@ -1,8 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
--- Copyright 2025 Oxide Computer Company
 
 -- Unit-level testbench for dimm_arb_mux.
 --

--- a/hdl/projects/cosmo_seq/dimms_subsystem/sims/spd_proxy_tb_pkg.vhd
+++ b/hdl/projects/cosmo_seq/dimms_subsystem/sims/spd_proxy_tb_pkg.vhd
@@ -1,8 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/dimms_subsystem/sims/spd_proxy_top_tb.vhd
+++ b/hdl/projects/cosmo_seq/dimms_subsystem/sims/spd_proxy_top_tb.vhd
@@ -1,8 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/dimms_subsystem/sims/spd_proxy_top_th.vhd
+++ b/hdl/projects/cosmo_seq/dimms_subsystem/sims/spd_proxy_top_th.vhd
@@ -1,8 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/dimms_subsystem/spd_proxy_pkg.vhd
+++ b/hdl/projects/cosmo_seq/dimms_subsystem/spd_proxy_pkg.vhd
@@ -1,8 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
--- Copyright 2025 Oxide Computer Company
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sequencer/a1_a0_seq.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/a1_a0_seq.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sequencer/nic_seq.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/nic_seq.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sequencer/seq_sync.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/seq_sync.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sequencer/sequencer_io_pkg.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sequencer_io_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sequencer/sequencer_regs.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sequencer_regs.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sequencer/sims/cascade_rail_model.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sims/cascade_rail_model.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sequencer/sims/nic_model.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sims/nic_model.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sequencer/sims/nic_model_msg_pkg.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sims/nic_model_msg_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sequencer/sims/rail_model.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sims/rail_model.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sequencer/sims/rail_model_msg_pkg.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sims/rail_model_msg_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sequencer/sims/sp5_seq_sim_tb.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sims/sp5_seq_sim_tb.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sequencer/sims/sp5_seq_sim_th.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sims/sp5_seq_sim_th.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sequencer/sims/sp5_sim.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sims/sp5_sim.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sequencer/sp5_sequencer.vhd
+++ b/hdl/projects/cosmo_seq/sequencer/sp5_sequencer.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sp5_espi_flash_subsystem/sp5_espi_flash_subsystem.vhd
+++ b/hdl/projects/cosmo_seq/sp5_espi_flash_subsystem/sp5_espi_flash_subsystem.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sp5_hotplug_subsystem/perst_oneshot.vhd
+++ b/hdl/projects/cosmo_seq/sp5_hotplug_subsystem/perst_oneshot.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sp5_hotplug_subsystem/sp5_hotplug_subsystem.vhd
+++ b/hdl/projects/cosmo_seq/sp5_hotplug_subsystem/sp5_hotplug_subsystem.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Cosmo Sequencer FPGA targeting the Spartan-7
 

--- a/hdl/projects/cosmo_seq/sp5_uart_subsystem/sp5_uart_subsystem.vhd
+++ b/hdl/projects/cosmo_seq/sp5_uart_subsystem/sp5_uart_subsystem.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sp5_uart_subsystem/sp5_uart_subsystem_pkg.vhd
+++ b/hdl/projects/cosmo_seq/sp5_uart_subsystem/sp5_uart_subsystem_pkg.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/cosmo_seq/sp_i2c_subsystem/sp_i2c_subsystem.vhd
+++ b/hdl/projects/cosmo_seq/sp_i2c_subsystem/sp_i2c_subsystem.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Cosmo Sequencer FPGA targeting the Spartan-7
 

--- a/hdl/projects/cosmo_seq/sp_i2c_subsystem/sp_i2c_subsystem_regs.vhd
+++ b/hdl/projects/cosmo_seq/sp_i2c_subsystem/sp_i2c_subsystem_regs.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/hdl/projects/grapefruit/base_regs/registers.vhd
+++ b/hdl/projects/grapefruit/base_regs/registers.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 
 library ieee;

--- a/hdl/projects/grapefruit/black_box_entities/gfruit_pll.vhd
+++ b/hdl/projects/grapefruit/black_box_entities/gfruit_pll.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- A no synth, no sim, black entity to make analysis happy
 

--- a/hdl/projects/grapefruit/grapefruit_top.vhd
+++ b/hdl/projects/grapefruit/grapefruit_top.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 
 library ieee;

--- a/hdl/projects/grapefruit/sgpio/gfruit_sgpio.vhd
+++ b/hdl/projects/grapefruit/sgpio/gfruit_sgpio.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Grapefruit is meant to serve as a BMC replacement in AMD's Ruby
 -- reference platform for cosmo dev.  As such, there are some functions

--- a/hdl/projects/grapefruit/sgpio/sgpio_regs.vhd
+++ b/hdl/projects/grapefruit/sgpio/sgpio_regs.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 
 library ieee;

--- a/hdl/projects/observer_ignition/observer_ignition_top.vhd
+++ b/hdl/projects/observer_ignition/observer_ignition_top.vhd
@@ -1,7 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
---
 
 -- Observer power shelf controller FPGA targeting an ice40 HX8k
 

--- a/tools/fix_vhdl_headers.py
+++ b/tools/fix_vhdl_headers.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Normalize the MPL copyright header at the top of VHDL files.
+
+The canonical header is exactly the three MPL lines and nothing else:
+
+    -- This Source Code Form is subject to the terms of the Mozilla Public
+    -- License, v. 2.0. If a copy of the MPL was not distributed with this
+    -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+Historically some files also carried a bare `--` continuation line and/or a
+`-- Copyright <year> Oxide Computer Company` line. Both are dropped here.
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+MPL_LINES = (
+    "-- This Source Code Form is subject to the terms of the Mozilla Public",
+    "-- License, v. 2.0. If a copy of the MPL was not distributed with this",
+    "-- file, You can obtain one at https://mozilla.org/MPL/2.0/.",
+)
+
+# Skip generated output and third-party trees; their headers aren't ours to touch.
+SKIP_DIRS = {".git", ".jj", "buck-out", "vunit_out", "vnd", "build", "__pycache__"}
+
+# Only Oxide's own copyright line goes away. Third-party notices (e.g. the
+# 8b10b encoder) must stay intact, so match narrowly.
+OXIDE_COPYRIGHT_RE = re.compile(r"^--\s*Copyright\s+(\d{4}\s+)?Oxide Computer Company\s*$")
+BARE_COMMENT_RE = re.compile(r"^--\s*$")
+
+
+def clean(lines):
+    """Return the cleaned line list, or None if nothing needed changing."""
+    if [line.rstrip() for line in lines[: len(MPL_LINES)]] != list(MPL_LINES):
+        return None
+
+    i = len(MPL_LINES)
+    end = i
+    while end < len(lines):
+        line = lines[end]
+        if BARE_COMMENT_RE.match(line) or OXIDE_COPYRIGHT_RE.match(line):
+            end += 1
+        else:
+            break
+
+    if end == i:
+        return None
+
+    rest = lines[end:]
+    # Don't let code end up butted directly against the header.
+    if rest and rest[0].strip():
+        rest = ["\n"] + rest
+    return lines[:i] + rest
+
+
+def vhdl_files(roots):
+    for root in roots:
+        if root.is_file():
+            yield root
+            continue
+        for path in sorted(root.rglob("*")):
+            if path.suffix not in (".vhd", ".vhdl") or not path.is_file():
+                continue
+            if SKIP_DIRS & set(path.relative_to(root).parts):
+                continue
+            yield path
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", type=Path, default=[Path(".")],
+                        help="files or directories to process (default: cwd)")
+    parser.add_argument("--check", action="store_true",
+                        help="report files that need fixing without writing")
+    args = parser.parse_args()
+
+    changed = []
+    for path in vhdl_files(args.paths):
+        text = path.read_text()
+        lines = text.splitlines(keepends=True)
+        cleaned = clean(lines)
+        if cleaned is None:
+            continue
+        changed.append(path)
+        if not args.check:
+            path.write_text("".join(cleaned))
+
+    for path in changed:
+        print(path)
+    verb = "need fixing" if args.check else "fixed"
+    print(f"{len(changed)} file(s) {verb}", file=sys.stderr)
+    return 1 if (args.check and changed) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This is a comment format and whitespace-ony PR (if you ignore the script that did this work which is also included).

No functional HDL changes here this is all about making the copyright headers consistent.