### PR TITLE
Fix calculation bug in dcfifo_mixed_xpm

### DIFF
--- a/hdl/ip/vhd/fifos/dcfifo_mixed_xpm.vhd
+++ b/hdl/ip/vhd/fifos/dcfifo_mixed_xpm.vhd
@@ -64,12 +64,22 @@ entity dcfifo_mixed_xpm is
 end entity;
 
 architecture xpm of dcfifo_mixed_xpm is
-    constant read_depth : natural := wfifo_write_depth * wdata_width / rdata_width;
-
     constant read_mode         : string  := sel(showahead_mode, "fwft", "std");
     constant read_latency      : integer := sel(showahead_mode, 0, 1);
     constant prog_empty_thresh : integer := sel(showahead_mode, 3 + 2, 3);
-    constant prog_full_thresh  : integer := sel(showahead_mode, 3 + 2*(wfifo_write_depth/read_depth) + cdc_stages, 3 + cdc_stages);
+
+    -- XPM wants PROG_FULL_THRESH inside roughly
+    -- [5 + cdc_stages, wfifo_write_depth - 5 - cdc_stages] for a show-ahead async
+    -- FIFO, and rejects anything outside it at synthesis.
+    --
+    -- This used to scale headroom by wfifo_write_depth/read_depth. That is fine
+    -- while the read side is the narrower one, but when the read port is narrower
+    -- than the write port read_depth is the larger number and the integer division
+    -- is simply zero, leaving a threshold of 5 that XPM refuses. Nothing here
+    -- consumes prog_full, it is mapped to open below, so the value only has to be
+    -- legal rather than meaningful: half the write depth always is, for every
+    -- depth the generic permits.
+    constant prog_full_thresh : integer := wfifo_write_depth / 2;
 
 begin
 


### PR DESCRIPTION
As described in the comments certain choices with the default calculation would cause Vivado to error out. We typically don't use this parameter so this fix makes something that will always be legal. Should we decide to wire this out differently eventually we'll have to re-address the calculation for all the math cases. Note that the Xilinx docs are rather poor on the totality of the limits here

The current text of this parameter doc says the following:

> Specifies the minimum number of read words in the FIFO at or below which prog_empty asserts.
> 
> Min_Value = 3 + (READ_MODE_VAL*2)
> Max_Value = (FIFO_WRITE_DEPTH-3) - (READ_MODE_VAL*2)
> If READ_MODE = "std", then READ_MODE_VAL = 0; Otherwise READ_MODE_VAL = 1.
> 
> NOTE: The default threshold value depends on default FIFO_WRITE_DEPTH value. If FIFO_WRITE_DEPTH value changes, verify the threshold value is within the valid range though the programmable flags are not used.

There are presumably some additional rules here for the read < write, but rather than trying to divine them we just pick something that is legal and the implementation of this function is stubbed out anyway, since we don't use prog_full in this wrapper.