### PR TITLE
sidecar: use RDL-defined types in sequencer

### DIFF
--- a/hdl/projects/sidecar/mainboard/PCIeEndpointController.bsv
+++ b/hdl/projects/sidecar/mainboard/PCIeEndpointController.bsv
@@ -87,7 +87,7 @@ module mkPCIeEndpointController
         let sequencer_power_fault =
                 ctrl.present == 1 &&
                 ctrl.override_seq_power_fault == 0 &&
-                sequencer.registers.error.error != 0;
+                unpack(sequencer.registers.error.value) != None;
 
         power_fault <= (software_power_fault || sequencer_power_fault);
     endrule

--- a/hdl/projects/sidecar/mainboard/SidecarMainboardController.bsv
+++ b/hdl/projects/sidecar/mainboard/SidecarMainboardController.bsv
@@ -194,11 +194,15 @@ module mkMainboardController #(Parameters parameters)
 
     (* fire_when_enabled *)
     rule do_set_status;
+        // Binding the unpacked value to a typed signal to disambiguate `Init`,
+        // which is a member of both TofinoSeqStateValue and TofinoSeqStepValue.
+        TofinoSeqStateValue tofino_seq_state =
+            unpack(tofino_sequencer.registers.state.value);
+
         status_r <= Status {
             clk_1hz: (tick_2hz ? ~status_r.clk_1hz : status_r.clk_1hz),
-            tofino_sequencer_running:
-                tofino_sequencer.registers.state.state != 0,
-            tofino_in_a0: tofino_sequencer.registers.state.state == 2,
+            tofino_sequencer_running: tofino_seq_state != Init,
+            tofino_in_a0: tofino_seq_state == A0,
             pcie_present: pcie_endpoint.pins.present};
     endrule
 

--- a/hdl/projects/sidecar/mainboard/Tofino2Sequencer.bsv
+++ b/hdl/projects/sidecar/mainboard/Tofino2Sequencer.bsv
@@ -6,9 +6,6 @@
 package Tofino2Sequencer;
 
 export Parameters(..);
-export State(..);
-export Step(..);
-export Error(..);
 export Tofino2Resets(..);
 export Pins(..);
 export Registers(..);
@@ -69,49 +66,13 @@ instance DefaultValue#(Parameters);
             por_to_pcie_delay: 250};
 endinstance
 
-typedef enum {
-    Init                    = 0,
-    A2                      = 1,
-    A0                      = 2,
-    InPowerUp               = 3,
-    InPowerDown             = 4
-} State deriving (Eq, Bits, FShow);
-
-typedef enum {
-    Init                    = 0,
-    AwaitPowerUp            = 1,
-    AwaitVdd18PowerGood     = 2,
-    AwaitVddCorePowerGood   = 3,
-    AwaitVddPCIePowerGood   = 4,
-    AwaitVddtPowerGood      = 5,
-    AwaitVdda15PowerGood    = 6,
-    AwaitVdda18PowerGood    = 7,
-    AwaitPoR                = 8,
-    AwaitVidValid           = 9,
-    AwaitVidAck             = 10,
-    AwaitPowerUpComplete    = 11,
-    AwaitPowerDown          = 12,
-    AwaitPowerDownComplete  = 13
-} Step deriving (Eq, Bits, FShow);
-
-typedef enum {
-    None                    = 0,
-    PowerGoodTimeout        = 1,
-    PowerFault              = 2,
-    PowerVrHot              = 3,
-    PowerAbort              = 4,
-    SoftwareAbort           = 5,
-    VidAckTimeout           = 6,
-    ThermalAlert            = 7
-} Error deriving (Eq, Bits, FShow);
-
 interface Registers;
     interface Reg#(TofinoSeqCtrl) ctrl;
     interface ReadOnly#(TofinoSeqState) state;
     interface ReadOnly#(TofinoSeqStep) step;
     interface ReadOnly#(TofinoSeqError) error;
-    interface ReadOnly#(TofinoSeqErrorState) error_state;
-    interface ReadOnly#(TofinoSeqErrorStep) error_step;
+    interface ReadOnly#(TofinoSeqState) error_state;
+    interface ReadOnly#(TofinoSeqStep) error_step;
     interface ReadOnly#(PowerRailState) vdd18;
     interface ReadOnly#(PowerRailState) vddcore;
     interface ReadOnly#(PowerRailState) vddpcie;
@@ -260,13 +221,13 @@ module mkTofino2Sequencer #(Parameters parameters) (Tofino2Sequencer);
     mkConnection(asIfc(tick), asIfc(delay));
 
     // FSM state.
-    ConfigReg#(State) state <- mkConfigReg(Init);
-    ConfigReg#(Step) step <- mkConfigReg(Init);
-    ConfigReg#(Error) error <- mkConfigRegU();
+    ConfigReg#(TofinoSeqStateValue) state <- mkConfigReg(Init);
+    ConfigReg#(TofinoSeqStepValue) step <- mkConfigReg(Init);
+    ConfigReg#(TofinoSeqErrorValue) error <- mkConfigRegU();
     // Copies of the state and step registers which get set when an error occurs
     // so software can analyze these events.
-    ConfigReg#(State) error_state <- mkConfigRegU();
-    ConfigReg#(Step) error_step <- mkConfigRegU();
+    ConfigReg#(TofinoSeqStateValue) error_state <- mkConfigRegU();
+    ConfigReg#(TofinoSeqStepValue) error_step <- mkConfigRegU();
 
     ConfigReg#(Tofino2Resets) tofino_resets <- mkConfigRegU();
     ConfigReg#(Bool) tofino_clocks_enable <- mkConfigRegU();
@@ -303,7 +264,7 @@ module mkTofino2Sequencer #(Parameters parameters) (Tofino2Sequencer);
     // Helpers, implementing the details of sequencing steps.
     //
 
-    function Stmt enable_rail(PowerRail rail, Step s) =
+    function Stmt enable_rail(PowerRail rail, TofinoSeqStepValue s) =
         seq
             // Set the enable pin and the sequencing step.
             action
@@ -426,7 +387,7 @@ module mkTofino2Sequencer #(Parameters parameters) (Tofino2Sequencer);
         power_fault <= any(PowerRail::fault, power_rails);
         power_vrhot <= any(PowerRail::vrhot, power_rails);
 
-        // Generate VID ack timout when appropriate. This is done by monitoring
+        // Generate VID ack timeout when appropriate. This is done by monitoring
         // the PoR to PCIe delay counter which is running during the AwaitVidAck
         // step for the given limit. The static asserts at the beginning of this
         // module assure that this limit is valid.

--- a/hdl/projects/sidecar/mainboard/sidecar_mainboard_controller.rdl
+++ b/hdl/projects/sidecar/mainboard/sidecar_mainboard_controller.rdl
@@ -204,55 +204,84 @@ addrmap sidecar_mainboard_controller {
         } ACK_VID[1] = 0;
     } TOFINO_SEQ_CTRL @ 0x100;
 
-    reg {
+    reg tofino_seq_state {
         name = "Tofino Sequencer State";
         default sw = r;
         default hw = w;
 
+        enum seq_state {
+            Init = 3'd0 {desc = "Reset value";};
+            A2 = 3'd1 {desc = "Tofino 2 powered off";};
+            A0 = 3'd2 {desc = "Tofino 2 powered up";};
+            InPowerUp = 3'd3 {desc = "Tofino 2 powering up (transitory state)";};
+            InPowerDown = 3'd4 {desc = "Tofino 2 powering off (transitory state)";};
+        };
+
         field {
             desc = "Tofino Sequencer State";
-        } STATE[2:0] = 0;
-    } TOFINO_SEQ_STATE;
+            encode = seq_state;
+        } VALUE[2:0] = 0;
+    };
 
-    reg {
+    reg tofino_seq_step {
         name = "Tofino Sequencing Step";
         default sw = r;
         default hw = w;
 
+        enum seq_step {
+            Init = 4'd0 {desc = "Reset value";};
+            AwaitPowerUp = 4'd1 {desc = "Initial step";};
+            AwaitVdd18PowerGood = 4'd2 {desc = "Awaiting power good from VDD 1.8V rail";};
+            AwaitVddCorePowerGood = 4'd3 {desc = "Awaiting power good from VDD Core rail";};
+            AwaitVddPCIePowerGood = 4'd4 {desc = "Awaiting power good from VDD PCIe rail";};
+            AwaitVddtPowerGood = 4'd5 {desc = "Awaiting power good from VDDT rail";};
+            AwaitVdda15PowerGood = 4'd6 {desc = "Awaiting power good from VDDA 1.5V rail";};
+            AwaitVdda18PowerGood = 4'd7 {desc = "Awaiting power good from VDDA 1.8V rail";};
+            AwaitPoR = 4'd8 {desc = "Awaiting power on reset";};
+            AwaitVidValid = 4'd9 {desc = "Awaiting VID to become valid";};
+            AwaitVidAck = 4'd10 {desc = "Awaiting SP to ack VID after adjusting the VRs";};
+            AwaitPowerUpComplete = 4'd11 {desc = "Awaiting final power up sequencing delay";};
+            AwaitPowerDown = 4'd12 {desc = "Awaiting power down command";};
+            AwaitPowerDownComplete = 4'd13 {desc = "Awaiting power down sequencing to complete";};
+        };
+
         field {
             desc = "Sequencing Step";
-        } STEP[3:0] = 0;
-    } TOFINO_SEQ_STEP;
+            encode = seq_step;
+        } VALUE[3:0] = 0;
+    };
 
-    reg {
+    reg tofino_seq_error {
         name = "Tofino Sequencing Error";
         default sw = r;
         default hw = w;
 
+        enum seq_error {
+            None = 3'd0 {desc = "No error";};
+            PowerGoodTimeout = 3'd1 {desc = "Power Good ping for a rail was not asserted within the configured timeout.";};
+            PowerFault = 3'd2 {desc = "Fault pin for a rail was asserted.";};
+            PowerVrHot = 3'd3 {desc = "VR Hot pin was asserted for a rail.";};
+            PowerAbort = 3'd4 {desc = "Power Good pin for a rail was deasserted after having been asserted.";};
+            SoftwareAbort = 3'd5 {desc = "TOFINO_SEQ_CTRL::EN register was cleared by software.";};
+            VidAckTimeout = 3'd6 {desc = "TOFINO_SEQ_CTRL::ACK_VID was not set in time.";};
+            ThermalAlert = 3'd7 {desc = "Tofino die temp sensor (U64) asserted the tf_to_fpga_temp_therm_l net.";};
+        };
+
         field {
             desc = "Sequencing Error";
-        } ERROR[2:0] = 0;
-    } TOFINO_SEQ_ERROR;
+            encode = seq_error;
+        } VALUE[2:0] = 0;
+    };
 
-    reg {
-        name = "Tofino Sequencer Error State";
-        default sw = r;
-        default hw = w;
+    tofino_seq_state TOFINO_SEQ_STATE;
+    tofino_seq_step TOFINO_SEQ_STEP;
+    tofino_seq_error TOFINO_SEQ_ERROR;
 
-        field {
-            desc = "Sequencer state when error occured";
-        } STATE[2:0] = 0;
-    } TOFINO_SEQ_ERROR_STATE;
-
-    reg {
-        name = "Tofino Sequencing Error Step";
-        default sw = r;
-        default hw = w;
-
-        field {
-            desc = "Sequencing step when error occured";
-        } STEP[3:0] = 0;
-    } TOFINO_SEQ_ERROR_STEP;
+    // When an error does occur, snapshot where it happened
+    tofino_seq_state TOFINO_SEQ_ERROR_STATE;
+    TOFINO_SEQ_ERROR_STATE->name = "Tofino Sequencer State at Error";
+    tofino_seq_step TOFINO_SEQ_ERROR_STEP;
+    TOFINO_SEQ_ERROR_STEP->name = "Tofino Sequencer Step at Error";
 
     power_rail_state TOFINO_POWER_VDD18_STATE;
     TOFINO_POWER_VDD18_STATE->name = "VDD18 State";


### PR DESCRIPTION
This moves the state, step, and error types for the Tofino sequencer code out of RTL and into the RDL definition. There are no functional changes here, just shuffling types around. This will support allowing the Hubris sidecar-seq code to leverage the same types as the FPGA. Currently we duplicate the type definitions, once in the BSV and again in Rust.

Fixes #521 